### PR TITLE
Add some integration to Trusted Types

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -100,7 +100,6 @@ let s = new Sanitizer({
   allowAttributes: ['c', 'd', 'e', ...],
   ...
 });
-
 s.sanitize("&lt;img src=x onerror=alert(1)//&gt;"); // returns a 'DocumentFragment'
 s.sanitizeToString("&lt;img src=x onerror=alert(1)//&gt;"); // returns '<img src="x">'
 s.sanitizeToTrustedHTML("&lt;img src=x onerror=alert(1)//&gt;"); // returns 'TrustedHTML'

--- a/index.bs
+++ b/index.bs
@@ -100,9 +100,9 @@ let s = new Sanitizer({
   attributes: ['c', 'd', 'e', ...],
   ...
 });
+s.sanitize("&lt;img src=x onerror=alert(1)//&gt;"); // returns a 'DocumentFragment'
 s.sanitizeToString("&lt;img src=x onerror=alert(1)//&gt;"); // returns '<img src="x">'
 s.sanitizeToTrustedHTML("&lt;img src=x onerror=alert(1)//&gt;"); // returns 'TrustedHTML'
-s.sanitize("&lt;img src=x onerror=alert(1)//&gt;"); // returns a 'DocumentFragment'
 ```
 
 Framework {#framework}

--- a/index.bs
+++ b/index.bs
@@ -121,6 +121,7 @@ Framework {#framework}
   interface Sanitizer {
     constructor(SanitizerConfig? config);
     DocumentFragment sanitize(HTMLString input);
+    DOMString sanitizeToString(DOMString input);
     HTMLString sanitizeToHTML(DOMString input);
 
     // And maybe?

--- a/index.bs
+++ b/index.bs
@@ -100,8 +100,8 @@ let s = new Sanitizer({
   attributes: ['c', 'd', 'e', ...],
   ...
 });
-s.toString("&lt;img src=x onerror=alert(1)//&gt;"); // returns `<img src="x">`
-s.toFragment("&lt;img src=x onerror=alert(1)//&gt;"); // returns a `DocumentFragment`
+s.sanitizeToHTML("&lt;img src=x onerror=alert(1)//&gt;"); // returns '<img src="x">'
+s.sanitize("&lt;img src=x onerror=alert(1)//&gt;"); // returns a 'DocumentFragment'
 ```
 
 Framework {#framework}
@@ -120,8 +120,8 @@ Framework {#framework}
   [Exposed=(Window)]
   interface Sanitizer {
     constructor(SanitizerConfig? config);
-    DOMString toString(DOMString input);
-    DocumentFragment toFragment(DOMString input);
+    [CEReactions] DocumentFragment sanitize(HTMLString input);
+    HTMLString sanitizeToHTML(DOMString input);
 
     // And maybe?
     static DOMString sanitizeToString(DOMString input, optional SanitizerConfig config);

--- a/index.bs
+++ b/index.bs
@@ -120,7 +120,7 @@ Framework {#framework}
   [Exposed=(Window)]
   interface Sanitizer {
     constructor(SanitizerConfig? config);
-    [CEReactions] DocumentFragment sanitize(HTMLString input);
+    DocumentFragment sanitize(HTMLString input);
     HTMLString sanitizeToHTML(DOMString input);
 
     // And maybe?

--- a/index.bs
+++ b/index.bs
@@ -116,13 +116,15 @@ Framework {#framework}
     // ...
     // More things from https://github.com/cure53/DOMPurify/blob/master/src/purify.js#L224
   };
+  typedef [StringContext=TrustedHTML] DOMString HTMLString;
+  typedef (DOMString or HTMLString or DocumentFragment or Document) SanitizerInput;
 
   [Exposed=(Window)]
   interface Sanitizer {
     constructor(SanitizerConfig? config);
-    DocumentFragment sanitize(HTMLString input);
-    DOMString sanitizeToString(DOMString input);
-    HTMLString sanitizeToHTML(DOMString input);
+    DocumentFragment sanitize(optional SanitizerInput input);
+    DOMString sanitizeToString(optional SanitizerInput input);
+    HTMLString sanitizeToHTML(optional SanitizerInput input);
 
     // And maybe?
     static DOMString sanitizeToString(DOMString input, optional SanitizerConfig config);

--- a/index.bs
+++ b/index.bs
@@ -100,7 +100,8 @@ let s = new Sanitizer({
   attributes: ['c', 'd', 'e', ...],
   ...
 });
-s.sanitizeToHTML("&lt;img src=x onerror=alert(1)//&gt;"); // returns '<img src="x">'
+s.sanitizeToString("&lt;img src=x onerror=alert(1)//&gt;"); // returns '<img src="x">'
+s.sanitizeToTrustedHTML("&lt;img src=x onerror=alert(1)//&gt;"); // returns 'TrustedHTML'
 s.sanitize("&lt;img src=x onerror=alert(1)//&gt;"); // returns a 'DocumentFragment'
 ```
 
@@ -117,14 +118,14 @@ Framework {#framework}
     // More things from https://github.com/cure53/DOMPurify/blob/master/src/purify.js#L224
   };
   typedef [StringContext=TrustedHTML] DOMString HTMLString;
-  typedef (DOMString or HTMLString or DocumentFragment or Document) SanitizerInput;
+  typedef (HTMLString or DocumentFragment or Document) SanitizerInput;
 
   [Exposed=(Window)]
   interface Sanitizer {
     constructor(SanitizerConfig? config);
     DocumentFragment sanitize(optional SanitizerInput input);
     DOMString sanitizeToString(optional SanitizerInput input);
-    HTMLString sanitizeToHTML(optional SanitizerInput input);
+    TrustedHTML sanitizeToTrustedHTML(optional SanitizerInput input);
 
     // And maybe?
     static DOMString sanitizeToString(DOMString input, optional SanitizerConfig config);


### PR DESCRIPTION
This PR tries to integrate Sanitizer API with Trusted Types.
I'm not sure this is the right way in terms of WebIDL, but what I'm proposing here is:

1. New _sanitizeToTrustedHTML_ method☺ _sanitizeToTrustedHTML_ will return _TrustedHTML_, and ideally this method will be exposed only if _SanitizerConfig_ is same or stricter than default config.
2. Require _TrustedHTML_ as an argument to _sanitize_ if the _SanitizerConfig_ is weaker than default config.
