### PR TITLE
Formalize drop lists (& friends)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -95,13 +95,14 @@ Examples {#examples}
 --------------------
 
 ```js
-let s = new Sanitizer({
-  allowElements: ['a', 'b', ...],
-  allowAttributes: ['c', 'd', 'e', ...],
-  ...
-});
-s.sanitizeToString("&lt;img src=x onerror=alert(1)//&gt;"); // returns `<img src="x">`
-s.sanitize("&lt;img src=x onerror=alert(1)//&gt;"); // returns a `DocumentFragment`
+let userControlledInput = "&lt;img src=x onerror=alert(1)//&gt;";
+
+// Create a DocumentFragment from unsanitized input:
+let s = new Sanitizer();
+let sanitizedFragment = s.sanitize(userControlledInput);
+
+// Replace an element's content from unsanitized input:
+element.replaceChildren(s.sanitize(userControlledInput));
 ```
 
 Framework {#framework}

--- a/index.bs
+++ b/index.bs
@@ -129,12 +129,6 @@ Framework {#framework}
     constructor(optional SanitizerConfig config = {});
     DOMString sanitizeToString(DOMString input);
     DocumentFragment sanitize(DOMString input);
-
-    readonly attribute SanitizerConfig creationOptions;
-
-    // And maybe?
-    static DOMString sanitizeToString(DOMString input, optional SanitizerConfig config);
-    static DocumentFragment sanitizeToFragment(DOMString input, optional SanitizerConfig config);
   };
 </pre>
 


### PR DESCRIPTION
Specify behaviour of drop, block, and allow lists. This means to formalize the discussion at #33.

Features are:

1, Built-ins are handled first, and thus cannot be overriden.
2, Except dropping an element with all children is handled before built-in element blocking, which should allow us to emulate DOMPurify's KEEP_CONTENT.
(Assuming that the built-ins e.g. block <script> (but not its content), a user could then add <script> into the drop list, meaning that <script> and all children would be dropped.)
3. I've tried to translate this into spec-like algorithms language. First time, so... please look closely.

This would also obsolete #15.