### PR TITLE
Cleanup: Remove un-specced features.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -128,12 +128,6 @@ Framework {#framework}
     constructor(optional SanitizerConfig config = {});
     DOMString sanitizeToString(DOMString input);
     DocumentFragment sanitize(DOMString input);
-
-    readonly attribute SanitizerConfig creationOptions;
-
-    // And maybe?
-    static DOMString sanitizeToString(DOMString input, optional SanitizerConfig config);
-    static DocumentFragment sanitizeToFragment(DOMString input, optional SanitizerConfig config);
   };
 </pre>
 


### PR DESCRIPTION
This removes a that are potentially useful, but so far were neither speced out nor discussed properly. These should be trivial to add back if we want to support them after all.

Additionally, removing the static methods fixes a bikeshed error about duplicate defintiions of "sanitizerToString". 