### PR TITLE
Specify allow/blockAttributes.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -255,11 +255,6 @@ Examples for attributes and attribute match lists:
   new Sanitizer({blockAttributes: {"id": ["*"]}}).sanitizeToString(sample);
 ```
 
-Note: `allowElements` creates a sanitizer that defaults to dropping elements,
-  while `blockElements` and `dropElements` defaults to keeping unknown
-  elements. Using both types is possible, but is probably of little practical
-  use. The same applies to `allowAttributes` and `dropAttributes`.
-
 ## Algorithms {#algorithms}
 
 To <dfn lt="sanitize document fragment">sanitize a document fragment</dfn> named |fragment| using |sanitizer| run these steps:

--- a/index.bs
+++ b/index.bs
@@ -329,15 +329,17 @@ named |fragment| from a Sanitizer |input|, run these steps:
 4. [=Append=] the node |clone| to the parent |f|.
 5. Return |f|.
 
+
 Issue(WICG/sanitizer-api#42): It's unclear whether we can assume a generic
   context for {{parseFromString}}, or if we need to re-work the API to take
   the insertion context of the created fragment into account.
 
+
 To <dfn>sanitize</dfn> a given |input|, run these steps:
 
-1, run [=create a document fragment=] algorithm on the |input|.
-2, run the [=sanitize document fragment=] algorithm on the resulting fragment,
-3, and return its result.
+1. run [=create a document fragment=] algorithm on the |input|.
+2. run the [=sanitize document fragment=] algorithm on the resulting fragment,
+3. and return its result.
 
 To <dfn>sanitizeToString</dfn> a given |input|, run these steps:
 

--- a/index.bs
+++ b/index.bs
@@ -168,8 +168,8 @@ dictionary which describes modifications to the sanitze operation.
     sequence&lt;DOMString> allowElements;
     sequence&lt;DOMString> blockElements;
     sequence&lt;DOMString> dropElements;
-    sequence&lt;DOMString> allowAttributes;
-    sequence&lt;DOMString> dropAttributes;
+    AttributeMatchList allowAttributes;
+    AttributeMatchList dropAttributes;
     boolean allowCustomElements;
   };
 </pre>
@@ -185,9 +185,11 @@ dictionary which describes modifications to the sanitze operation.
 :: The <dfn>element drop list</dfn> is a sequence of strings with elements
    that the sanitizer should remove from the input, including its children.
 : allowAttributes
-:: TODO: <dfn>attribute allow list</dfn>
+:: The <dfn>attribute allow list</dfn> is an [=attribute match list=], which
+   determines whether an attribute (on a given element) should be allowed.
 : dropAttributes
-:: TODO: <dfn>attribute drop list</dfn>
+:: The <dfn>attribute drop list</dfn>  is an [=attribute match list=], which
+   determines whether an attribute (on a given element) should be dropped.
 : allowCustomElements
 :: <dfn>allow custom elements option</dfn> determines whether
    [=custom elements=] are to be considered. The default is to drop them.
@@ -221,6 +223,43 @@ Examples:
   new Sanitizer().sanitizeToString("abc <script>alert(1)</script> def");
 ```
 
+### Attribute Match Lists {#attr-match-list}
+
+An <dfn>attribute match list</dfn> is a map of attribute names to element names,
+where the special name "*" stands for all elements. A given |attribute|
+belonging to an |element| matches an [=attribute match list=], if the
+attribute's local name is a key in the match list, and element's local name
+or `"*"` are found in the attribute's value list.
+
+<pre class="idl">
+  typedef record&lt;DOMString, sequence&lt;DOMString>> AttributeMatchList;
+</pre>
+
+Examples for attributes and attribute match lists:
+```js
+  const sample = "<span id='span1' class='theclass' style='font-weight: bold'>hello</span>";
+
+  // Allow only <span style>: "<span style='font-weight: bold'>...</span>"
+  new Sanitizer({allowAttributes: {"style": ["span"]}}).sanitizeToString(sample);
+
+  // Allow style, but not on span: "<span>...</span>"
+  new Sanitizer({allowAttributes: {"style": ["div"]}}).sanitizeToString(sample);
+
+  // Allow style on any elements: "<span style='font-weight: bold'>...</span>"
+  new Sanitizer({allowAttributes: {"style": ["*"]}}).sanitizeToString(sample);
+
+  // Block <span id>: "<span class='theclass' style='font-weight: bold'>...</span>";
+  new Sanitizer({blockAttributes: {"id": ["span"]}}).sanitizeToString(sample);
+
+  // Block id, everywhere: "<span class='theclass' style='font-weight: bold'>...</span>";
+  new Sanitizer({blockAttributes: {"id": ["*"]}}).sanitizeToString(sample);
+```
+
+Note: `allowElements` creates a sanitizer that defaults to dropping elements,
+  while `blockElements` and `dropElements` defaults to keeping unknown
+  elements. Using both types is possible, but is probably of little practical
+  use. The same applies to `allowAttributes` and `dropAttributes`.
+
 ## Algorithms {#algorithms}
 
 To <dfn lt="sanitize document fragment">sanitize a document fragment</dfn> named |fragment| using |sanitizer| run these steps:
@@ -237,8 +276,7 @@ To <dfn lt="sanitize document fragment">sanitize a document fragment</dfn> named
 To <dfn>sanitize a node</dfn> named |node| run these steps:
 
 1. if |node| is an element node, call [=sanitize an element=] and return its result.
-2. if |node| is an attribute node, call [=sanitize an attribute=] and return its result.
-3. return 'keep'
+2. return 'keep'
 
 To <dfn>sanitize an element</dfn> named |element|, run these steps:
 
@@ -251,21 +289,32 @@ To <dfn>sanitize an element</dfn> named |element|, run these steps:
 6. if |name| is contained in the built-in [=default element block list=] return 'block'.
 7. if |name| is in |config|'s [=element block list=] return 'block'.
 8. if |config| has a non-empty [=element allow list=] and |name| is not in |config|'s [=element allow list=] return 'block'
-9. return 'keep'
+9. [=list/iterate|for each=] |attr| in |element|'s [=Element/attribute list=]:
+  1. call [=sanitize an attribute=] with |attr|'s name and |element|'s local name.
+  2. if the result is different from 'keep', remove |attr| from |element|.
+10. return 'keep'
 
 Issue: This presently ignores all namespace info, making it impossible to
     support different actions for like-named elements from different
     namespaces.
 
-To <dfn>sanitize an attribute</dfn> named |attr|, run these steps:
+To <dfn>sanitize an attribute</dfn> named |attr| belonging to |element|, run these steps:
 
 1. let |config| be the |sanitizer|'s [=configuration=] dictionary.
-2. let |element| be |attr|'s parent element.
-3. let |name| be |element|'s tag name, followed by ''.'', followed by |attr|'s name.
-4. if |name| is contained in the built-in [=default attribute drop list=] return 'drop'.
-5. if |name| is in |config|'s [=attribute drop list=] return 'drop'.
-6. if |config| has a non-empty [=attribute allow list=] and |name| is not in |config|'s [=attribute allow list=] return 'drop'
-7. return 'keep'
+2. if |attr| and |element| [=attribute-match=] the built-in [=default attribute drop list=] return 'drop'.
+3. if |attr| and |element| [=attribute-match=] the |config|'s [=attribute drop list=] return 'drop'.
+4. if |config| has a non-empty [=attribute allow list=] and |attr| and |element| do not [=attribute-match=] the |config|'s [=attribute allow list=] return 'drop'.
+5. return 'keep'.
+
+To determine whether an |attribute| and |element| <dfn>attribute-match</dfn> an [=attribute match list=] |list|, run these steps:
+
+1. let |attr-name| be |attribute|'s local name.
+2. let |elem-name| be |element|'s local name.
+3. if |list| does not contain a key |attr-name|, return false.
+4. let |matches| be the value of |list|[|attr-name|].
+3. if |matches| contains the string |elem-name|, return true.
+4. if |matches| contains the string "*", return true.
+5. return false.
 
 To <dfn>create a document fragment</dfn>
 named |fragment| from a Sanitizer |input|, run these steps:
@@ -285,17 +334,15 @@ named |fragment| from a Sanitizer |input|, run these steps:
 4. [=Append=] the node |clone| to the parent |f|.
 5. Return |f|.
 
-
 Issue(WICG/sanitizer-api#42): It's unclear whether we can assume a generic
   context for {{parseFromString}}, or if we need to re-work the API to take
   the insertion context of the created fragment into account.
 
-
 To <dfn>sanitize</dfn> a given |input|, run these steps:
 
-1. run [=create a document fragment=] algorithm on the |input|.
-2. run the [=sanitize document fragment=] algorithm on the resulting fragment,
-3. and return its result.
+1, run [=create a document fragment=] algorithm on the |input|.
+2, run the [=sanitize document fragment=] algorithm on the resulting fragment,
+3, and return its result.
 
 To <dfn>sanitizeToString</dfn> a given |input|, run these steps:
 


### PR DESCRIPTION
This specifies handling of allow/blockAttributes, following discussion in #18.

I don't think we explcitily agreed on how to handle attributes in the SanitizerConfig. The goal here is to resolve #18, and specifically to
- allow(block specific element/attribute combinations. (E.g. <script src=.>, but not \<img src=.>)
- allow emulation of existing sanitizers (e.g. DOMPurify specifies attribtues independent of the element).
