### PR TITLE
Specify behaviour of custom elements.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -170,6 +170,7 @@ dictionary which describes modifications to the sanitze operation.
     sequence&lt;DOMString> dropElements;
     sequence&lt;DOMString> allowAttributes;
     sequence&lt;DOMString> dropAttributes;
+    boolean allowCustomElements;
   };
 </pre>
 
@@ -187,6 +188,12 @@ dictionary which describes modifications to the sanitze operation.
 :: TODO: <dfn>attribute allow list</dfn>
 : dropAttributes
 :: TODO: <dfn>attribute drop list</dfn>
+: allowCustomElements
+:: <dfn>allow custom elements option</dfn> determines whether
+   [=custom elements=] are to be considered. The default is to drop them.
+   If this option is true, custom elements will still be checked against all
+   other built-in or configured configured checks. Note that whether an
+   element is recognized or not depends on the current document.
 
 Note: `allowElements` creates a sanitizer that defaults to dropping elements,
   while `blockElements` and `dropElements` defaults to keeping unknown
@@ -230,9 +237,19 @@ To <dfn lt="sanitize document fragment">sanitize a document fragment</dfn> named
 
 To <dfn>sanitize a node</dfn> named |node| run these steps:
 
-1. if |node| is an element node, call [=sanitize an element=] and return its result.
+1. if |node| is an element node, call [=sanitize an element node=] and return its result.
 2. if |node| is an attribute node, call [=sanitize an attribute=] and return its result.
 3. return 'keep'
+
+To <dfn>sanitize an element node</dfn> |node|, run these steps:
+
+1. Call [=look up a custom element definition=] with the current document,
+   the |element|'s namespace, the |element|'s local name, and the |element|'s
+   `is` attribute (if present).
+2. If the previous step returns anything other than `null`, and if the
+   |sanitizer|'s [=configuration=]'s [=allow custom elements option=] is unset
+   or set to anything other than `true`, return 'drop'.
+3. Call [=sanitize an element=], using |node| as the |element|, and return its result.
 
 To <dfn>sanitize an element</dfn> named |element|, run these steps:
 
@@ -244,6 +261,10 @@ To <dfn>sanitize an element</dfn> named |element|, run these steps:
 6. if |name| is in |config|'s [=element block list=] return 'block'.
 7. if |config| has a non-empty [=element allow list=] and |name| is not in |config|'s [=element allow list=] return 'block'
 8. return 'keep'
+
+Issue: This presently ignores all namespace info, making it impossible to
+    support different actions for like-named elements from different
+    namespaces.
 
 To <dfn>sanitize an attribute</dfn> named |attr|, run these steps:
 

--- a/index.bs
+++ b/index.bs
@@ -192,8 +192,7 @@ dictionary which describes modifications to the sanitze operation.
 :: <dfn>allow custom elements option</dfn> determines whether
    [=custom elements=] are to be considered. The default is to drop them.
    If this option is true, custom elements will still be checked against all
-   other built-in or configured configured checks. Note that whether an
-   element is recognized or not depends on the current document.
+   other built-in or configured configured checks.
 
 Note: `allowElements` creates a sanitizer that defaults to dropping elements,
   while `blockElements` and `dropElements` defaults to keeping unknown
@@ -237,30 +236,22 @@ To <dfn lt="sanitize document fragment">sanitize a document fragment</dfn> named
 
 To <dfn>sanitize a node</dfn> named |node| run these steps:
 
-1. if |node| is an element node, call [=sanitize an element node=] and return its result.
+1. if |node| is an element node, call [=sanitize an element=] and return its result.
 2. if |node| is an attribute node, call [=sanitize an attribute=] and return its result.
 3. return 'keep'
-
-To <dfn>sanitize an element node</dfn> |node|, run these steps:
-
-1. Call [=look up a custom element definition=] with the current document,
-   the |element|'s namespace, the |element|'s local name, and the |element|'s
-   `is` attribute (if present).
-2. If the previous step returns anything other than `null`, and if the
-   |sanitizer|'s [=configuration=]'s [=allow custom elements option=] is unset
-   or set to anything other than `true`, return 'drop'.
-3. Call [=sanitize an element=], using |node| as the |element|, and return its result.
 
 To <dfn>sanitize an element</dfn> named |element|, run these steps:
 
 1. let |config| be the |sanitizer|'s [=configuration=] dictionary.
 2. let |name| be |element|'s tag name.
-3. if |name| is contained in the built-in [=default element drop list=] return 'drop'.
-4. if |name| is in |config|'s [=element drop list=] return 'drop'.
-5. if |name| is contained in the built-in [=default element block list=] return 'block'.
-6. if |name| is in |config|'s [=element block list=] return 'block'.
-7. if |config| has a non-empty [=element allow list=] and |name| is not in |config|'s [=element allow list=] return 'block'
-8. return 'keep'
+3. if |name| is a [=valid custom element name=] and if |config|'s
+   [=allow custom elements option=] is unset or set to anything other than `true`, return 'drop'.
+4. if |name| is contained in the built-in [=default element drop list=] return 'drop'.
+5. if |name| is in |config|'s [=element drop list=] return 'drop'.
+6. if |name| is contained in the built-in [=default element block list=] return 'block'.
+7. if |name| is in |config|'s [=element block list=] return 'block'.
+8. if |config| has a non-empty [=element allow list=] and |name| is not in |config|'s [=element allow list=] return 'block'
+9. return 'keep'
 
 Issue: This presently ignores all namespace info, making it impossible to
     support different actions for like-named elements from different


### PR DESCRIPTION
Formalize behaviour of custom elements by introducing an "allow custom elements" option.

This PR follows discussion in #17.