### PR TITLE
Justify the built-ins.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -449,7 +449,7 @@ The <dfn>element kind</dfn> of an |element| is one of `regular`, `unknown`, or `
 <div algorithm="attribute kind">
 Similarly, the <dfn>attribute kind</dfn> of an |attribute| is one of `regular`
 or `unknown`. Let <var ignore>attribute kind</var> be:
-  - `unknown`, if the [[HTML]] specifcation does not assign any meaning to
+  - `unknown`, if the [[HTML]] specification does not assign any meaning to
      |attribute|'s name.
   - `regular`, otherwise.
 </div>
@@ -609,7 +609,7 @@ These constants define core behaviour of the Sanitizer algorithm.
 Note: The normative values of these constants are found below. The derivation
     of these are explained here, with an implementation in the [[DEFAULTS]]
     script. It is expected that these values will change before this
-    specifcation is finalized. Also, we expect these
+    specification is finalized. Also, we expect these
     to be updated to include additional HTML elements as they are
     introduced in user agents.
 

--- a/index.bs
+++ b/index.bs
@@ -600,6 +600,8 @@ describes, as is Internet Explorer's {{window.toStaticHTML()}}.
 
 # Appendix A: Built-in Constants # {#constants}
 
+<em>This appendix is normative, except where explicitly noted otherwise.</em>
+
 These constants define core behaviour of the Sanitizer algorithm.
 
 ## Built-ins Justification ## {#builtins-justification}
@@ -663,8 +665,6 @@ Specifically:
 
 ## The Baseline Element Allow List ## {#baseline-elements}
 
-<em>This subsection is normative.</em>
-
 The built-in <dfn>baseline element allow list</dfn> has the following value:
 
 <pre class=include-code>
@@ -674,8 +674,6 @@ highlight: js
 
 ## The Baseline Attribute Allow List ## {#baseline-attributes}
 
-<em>This subsection is normative.</em>
-
 The <dfn>baseline attribute allow list</dfn> has the following value:
 
 <pre class=include-code>
@@ -684,8 +682,6 @@ highlight: js
 </pre>
 
 ## The Default Configuration Object ## {#default-configuration-object}
-
-<em>This subsection is normative.</em>
 
 The built-in <dfn>default configuration</dfn> has the following value:
 

--- a/index.bs
+++ b/index.bs
@@ -600,16 +600,70 @@ describes, as is Internet Explorer's {{window.toStaticHTML()}}.
 
 # Appendix A: Built-in Constants # {#constants}
 
-<em>This appendix is normative.</em>
-
 These constants define core behaviour of the Sanitizer algorithm.
 
-Note: The normative values of these constants are found below. They have
-    been derived with the [[DEFAULTS]] script. It is expected that these
-    values will be updated to include additional HTML elements as they are
+## Built-ins Justification ## {#builtins-justification}
+
+<em>This subsection is super duper non-normative.</em>
+
+Note: The normative values of these constants are found below. The derivation
+    of these are explained here, with an implementation in the [[DEFAULTS]]
+    script. It is expected that these values will change before this
+    specifcation is finalized. Also, we expect these
+    to be updated to include additional HTML elements as they are
     introduced in user agents.
 
+For the purpose of this Sanitizer API, [[HTML]] constructs fall into one of
+four classes, where the first defines the baseline, and the first, second,
+plus the third define the default:
+
+1. Elements and attributes that (directly) execute script.
+   In other words, elements and attributes that are unconditionally script-ish.
+2. Legacy and "difficult" elements and attributes.
+  Examples are the `<plaintext>` `<xmp>` and elements, which have special
+  parsing rules attached to them. These are not dangerous _per se_, but they
+  have contributed to existing vulnerability.
+3. Elements and attributes that we feel rarely make sense in user-supplied
+  content.
+4. All the rest.
+
+Specifically:
+
+1. Script-ish constructs:
+  - The {{HTMLScriptElement}}, which proudly executes script as its sole purpose.
+  - All [event handler attributes]((https://html.spec.whatwg.org/#event-handler-attributes),
+    since these also execute script.
+  - {{HTMLIFrameElement}}, which loads arbitrary HTML content and therefor also script.
+  - The legacy {{HTMLObjectElement}} and {{HTMLEmbedElement}}, which load
+    non-HTML active content. Also, `<object>`'s side-kick {{HTMLParamElement}}.
+  - The [no-longer conforming](https://html.spec.whatwg.org/#non-conforming-features)
+    `<frame>`, `<frameset>`, and `<applet>` tags, which are
+    outdated versions companions of several elements listed above.
+  - The `<noframes>`, `<noembed>`, and `<nolayer>` elements.
+    These, by themselves, are arguably not script-ish, but they are companions
+    to elements listed above, and make no sense on their own.
+  - Also, the {{HTMLBaseElement}}, as this effectively modifies interpretation
+    of other URLs.
+
+2. Legacy and "difficult" elements.
+  - Special parsing behaviour. This is not dangerous in its own right, but has
+    contributed to mXSS-style attacks. This includes:
+      - `<plaintext>` (Which parses in [=PLAINTEXT state=].)
+      - The non-conforming [`<xmp>`](https://html.spec.whatwg.org/#xmp) element.
+  - Legacy elements:
+      - `<image>` ([which is parsed as `<img>`](https://html.spec.whatwg.org/#parsing-main-inbody)).
+      - `<basefont>`
+
+3. Constructs unlikely to be beneficial in user-supplied content:
+  - The {{HTMLTemplateElement}}, which introduces a new template to be used
+    by JavaScript, and its {{HTMLSlotElement}} accomplice.
+  - The frame-like [HTMLPortalElement](https://wicg.github.io/portals/).
+  - {{HTMLDataElement}},
+  - The (deprecated) [allowpaymentrequest](https://www.w3.org/TR/payment-request/) attribute.
+
 ## The Baseline Element Allow List ## {#baseline-elements}
+
+<em>This subsection is normative.</em>
 
 The built-in <dfn>baseline element allow list</dfn> has the following value:
 
@@ -620,6 +674,8 @@ highlight: js
 
 ## The Baseline Attribute Allow List ## {#baseline-attributes}
 
+<em>This subsection is normative.</em>
+
 The <dfn>baseline attribute allow list</dfn> has the following value:
 
 <pre class=include-code>
@@ -628,6 +684,8 @@ highlight: js
 </pre>
 
 ## The Default Configuration Object ## {#default-configuration-object}
+
+<em>This subsection is normative.</em>
 
 The built-in <dfn>default configuration</dfn> has the following value:
 

--- a/index.bs
+++ b/index.bs
@@ -639,7 +639,7 @@ Specifically:
   - The [no-longer conforming](https://html.spec.whatwg.org/#non-conforming-features)
     `<frame>`, `<frameset>`, and `<applet>` tags, which are
     outdated versions companions of several elements listed above.
-  - The `<noframes>`, `<noembed>`, and `<nolayer>` elements.
+  - The `<noscript>`, `<noframes>`, `<noembed>`, and `<nolayer>` elements.
     These, by themselves, are arguably not script-ish, but they are companions
     to elements listed above, and make no sense on their own.
   - Also, the {{HTMLBaseElement}}, as this effectively modifies interpretation


### PR DESCRIPTION
This picks up comments from several sources, including our "spec mentor", the [TAG](https://github.com/w3ctag/design-reviews/issues/619#issuecomment-809700791), and issue #69. It provides an explanation where our defaults are coming from, and links those to the HTML spec, so that a reader can go back and forth to understand the issue.

Linking is, honestly, best effort since some elements/attributes don't have good link targets. Particularly the legacy / non-conforming ones don't seem to have a "nice" linkable definition in HTML.