### PR TITLE
Remove <noscript> from default & baseline.

### DIFF
--- a/resources/baseline-element-allow-list.json
+++ b/resources/baseline-element-allow-list.json
@@ -76,7 +76,6 @@
   "meter",
   "nav",
   "nobr",
-  "noscript",
   "ol",
   "optgroup",
   "option",

--- a/resources/default-configuration.json
+++ b/resources/default-configuration.json
@@ -74,7 +74,6 @@
     "meter",
     "nav",
     "nobr",
-    "noscript",
     "ol",
     "optgroup",
     "option",

--- a/resources/defaults-derivation.html
+++ b/resources/defaults-derivation.html
@@ -112,7 +112,7 @@ function toTextContent(element_id, value) {
 const baseline_element_allow_list =
     new Helper(known_elements).without([
         "applet", "base", "embed", "iframe", "noembed", "noframes", "nolayer",
-        "object", "frame", "frameset", "param", "script",
+        "noscript", "object", "frame", "frameset", "param", "script",
     ]).val;
 
 const baseline_attribute_allow_list =


### PR DESCRIPTION
The (non-normative) built-ins paragraph lists `<noscript>` as not allowable, but this wasn't actually reflected in the (normative) built-in constants in the spec. I think that was unintended, and this fixes it. (See also: #86)