### PR TITLE
explicit conversion of element names to lowercase

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -225,6 +225,9 @@ is used as the configuration object.
   };
 </pre>
 
+Note: Element names are expected to be ascii lowercase and those that don't
+  conform will be lowercased.
+
 : allowElements
 :: The <dfn>element allow list</dfn> is a sequence of strings with
     elements that the sanitizer should retain in the input.


### PR DESCRIPTION
this came up during implementation/review and I think it would be useful to make explicit. Happy to incorporate it somewhere else or in a different form.

This is the best place I could find, but maybe you'll find a better section of the document :-)