### PR TITLE
Clarification on how other node types work.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -425,8 +425,6 @@ To <dfn>sanitize a node</dfn> named |node| run these steps:
      [=parent=] is null: Return `keep`.
   1. If |node| is a {{Text}} [=node=]: Return `keep`.
   1. Return `drop`
-
-Issue: What about comment nodes, CDATA, etc. ?
 </div>
 
 

--- a/index.bs
+++ b/index.bs
@@ -421,7 +421,10 @@ To <dfn>sanitize a node</dfn> named |node| run these steps:
        [=effective element configuration=] algorithm on |sanitizer| and
        |element|.
     1. Return |action|.
-  1. Return 'keep'
+  1. If |node| is a {{Document}} or {{DocumentFragment}} node and if |node|'s
+     [=parent=] is null: Return `keep`.
+  1. If |node| is a {{Text}} [=node=]: Return `keep`.
+  1. Return `drop`
 
 Issue: What about comment nodes, CDATA, etc. ?
 </div>


### PR DESCRIPTION
The previous definition kept anything (unless dropped). That's unbecoming for a sanitizer, and this changes the algorithm to drop all nodes unless they're being kept. Text node's are kept by default, and Dcoument/DocumentFragments, but only if they're the root.