### PR TITLE
Revert "Change config to be an attribute getter."

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -134,8 +134,8 @@ handle additional, application-specific use cases.
     DocumentFragment sanitize(SanitizerInput input);
     DOMString sanitizeToString(SanitizerInput input);
 
-    SanitizerConfig config();
-    static SanitizerConfig defaultConfig();
+    SanitizerConfig getConfiguration();
+    static SanitizerConfig getDefaultConfiguration();
   };
 </pre>
 
@@ -149,12 +149,12 @@ handle additional, application-specific use cases.
 * The <dfn method for=Sanitizer><code>sanitizeToString(<var>input</var>)</code></dfn>
     method steps are to return the result of running [=sanitizeToString=]
     algorithm on |input|.
-* The <dfn method for=Sanitizer><code>config()</code></dfn> method steps are
+* The <dfn method for=Sanitizer><code>getConfiguration()</code></dfn> method steps are
     to return the result of running the [=query the sanitizer config=]
     algorithm. It essentially returns a copy of the Sanitizer's
     [=configuration object=], with some degree of normalization.
 * The value of the static
-    <dfn method for=Sanitizer><code>defaultConfig()</code></dfn> method steps
+    <dfn method for=Sanitizer><code>getDefaultConfiguration()</code></dfn> method steps
     are to return the value of the [=default configuration=] object.
 
 Example:
@@ -283,29 +283,29 @@ A sanitizer's configuration can be queried using the
 Examples:
 ```js
   // Does the default config allow script elements?
-  Sanitizer.defaultConfig().allowElements.includes("script")  // false
+  Sanitizer.getDefaultConfiguration().allowElements.includes("script")  // false
 
   // We found a Sanitizer instance. Does it have an allow-list configured?
   const a_sanitizer = ...;
-  !!a_sanitizer.config().allowElements // true, if an allowElements list is configured
+  !!a_sanitizer.getConfiguration().allowElements // true, if an allowElements list is configured
 
   // If it does have an allow elements list, does it include the <div> element?
-  a_sanitizer.config().allowElements.includes("div")  // true, if "div" is in allowElements.
+  a_sanitizer.getConfiguration().allowElements.includes("div")  // true, if "div" is in allowElements.
 
-  // Note that the config attribute might do some normaliztion. E.g., it won't
+  // Note that the getConfiguration method might do some normalization. E.g., it won't
   // contain key/value pairs that are not declare in the IDL.
-  Object.keys(new Sanitizer({madeUpDictionaryKey: "Hello"}).config())  // []
+  Object.keys(new Sanitizer({madeUpDictionaryKey: "Hello"}).getConfiguration())  // []
 
   // As a Sanitizer's config describes its operation, a new sanitizer with
   // another instance's configuration should behave identically.
   // (For illustration purposes only. It would make more sense to just use a directly.)
   const a = /* ... a Sanitizer we found somewhere ... */;
-  const b = new Sanitizer(a.config());  // b should behave the same as a.
+  const b = new Sanitizer(a.getConfiguration());  // b should behave the same as a.
 
-  // defaultConfig() and new Sanitizer().config should be the same.
+  // getDefaultConfiguration() and new Sanitizer().getConfiguration should be the same.
   // (For illustration purposes only. There are better ways of implementing
   // object equality in JavaScript.)
-  JSON.stringify(Sanitizer.defaultConfig()) == JSON.stringify(new Sanitizer().config());  // true
+  JSON.stringify(Sanitizer.getDefaultConfiguration()) == JSON.stringify(new Sanitizer().getConfiguration());  // true
 ```
 
 ### Attribute Match Lists ### {#attr-match-list}

--- a/index.bs
+++ b/index.bs
@@ -129,19 +129,19 @@ handle additional, application-specific use cases.
     Exposed=(Window),
     SecureContext
   ] interface Sanitizer {
-    constructor(optional SanitizerConfig aConfig = {});
+    constructor(optional SanitizerConfig config = {});
 
     DocumentFragment sanitize(SanitizerInput input);
     DOMString sanitizeToString(SanitizerInput input);
 
-    readonly attribute SanitizerConfig config;
-    static readonly attribute SanitizerConfig defaultConfig;
+    SanitizerConfig config();
+    static SanitizerConfig defaultConfig();
   };
 </pre>
 
-* The <dfn constructor for=Sanitizer lt="Sanitizer()">
-    <code>new Sanitizer(<var>aConfig</var>)</code></dfn> constructor steps
-    are to create a new Sanitizer instance, and to retain a copy of |aConfig|
+* The <dfn constructor for=Sanitizer lt="Sanitizer(config)">
+    <code>new Sanitizer(<var>config</var>)</code></dfn> constructor steps
+    are to create a new Sanitizer instance, and to retain a copy of |config|
     as its [=configuration object=].
 * The <dfn method for=Sanitizer><code>sanitize(<var>input</var>)</code></dfn>
     method steps are to return the result of running the [=sanitize=]
@@ -149,13 +149,13 @@ handle additional, application-specific use cases.
 * The <dfn method for=Sanitizer><code>sanitizeToString(<var>input</var>)</code></dfn>
     method steps are to return the result of running [=sanitizeToString=]
     algorithm on |input|.
-* The <dfn attribute for=Sanitizer><code>config</code></dfn> attribute getter
-    steps steps are to return the result of running the [=query the sanitizer
-    config=] algorithm. It essentially returns a copy of the Sanitizer's
+* The <dfn method for=Sanitizer><code>config()</code></dfn> method steps are
+    to return the result of running the [=query the sanitizer config=]
+    algorithm. It essentially returns a copy of the Sanitizer's
     [=configuration object=], with some degree of normalization.
-* The <dfn attribute for=Sanitizer><code>defaultConfig</code></dfn> attribute
-    getter steps are to return the value of the [=default configuration=]
-    object.
+* The value of the static
+    <dfn method for=Sanitizer><code>defaultConfig()</code></dfn> method steps
+    are to return the value of the [=default configuration=] object.
 
 Example:
 ```js
@@ -278,36 +278,34 @@ Examples:
 ```
 
 A sanitizer's configuration can be queried using the
-{{Sanitizer}}'s {{config}} read-only attribute. The default configuration
-can be quried using the {{Sanitizer}}'s {{defaultConfig}} static read-only
-attribute.
+[=query the sanitizer config=] method.
 
 Examples:
 ```js
   // Does the default config allow script elements?
-  Sanitizer.defaultConfig.allowElements.includes("script")  // false
+  Sanitizer.defaultConfig().allowElements.includes("script")  // false
 
   // We found a Sanitizer instance. Does it have an allow-list configured?
   const a_sanitizer = ...;
-  !!a_sanitizer.config.allowElements // true, if an allowElements list is configured
+  !!a_sanitizer.config().allowElements // true, if an allowElements list is configured
 
   // If it does have an allow elements list, does it include the <div> element?
-  a_sanitizer.config.allowElements.includes("div")  // true, if "div" is in allowElements.
+  a_sanitizer.config().allowElements.includes("div")  // true, if "div" is in allowElements.
 
   // Note that the config attribute might do some normaliztion. E.g., it won't
   // contain key/value pairs that are not declare in the IDL.
-  Object.keys(new Sanitizer({madeUpDictionaryKey: "Hello"}).config)  // []
+  Object.keys(new Sanitizer({madeUpDictionaryKey: "Hello"}).config())  // []
 
   // As a Sanitizer's config describes its operation, a new sanitizer with
   // another instance's configuration should behave identically.
   // (For illustration purposes only. It would make more sense to just use a directly.)
   const a = /* ... a Sanitizer we found somewhere ... */;
-  const b = new Sanitizer(a.config);  // b should behave the same as a.
+  const b = new Sanitizer(a.config());  // b should behave the same as a.
 
-  // defaultConfig and new Sanitizer().config should be the same.
+  // defaultConfig() and new Sanitizer().config should be the same.
   // (For illustration purposes only. There are better ways of implementing
   // object equality in JavaScript.)
-  JSON.stringify(Sanitizer.defaultConfig) == JSON.stringify(new Sanitizer().config);  // true
+  JSON.stringify(Sanitizer.defaultConfig()) == JSON.stringify(new Sanitizer().config());  // true
 ```
 
 ### Attribute Match Lists ### {#attr-match-list}


### PR DESCRIPTION
This reverts commit f3f52ce95d9516f525c071a7f9f56c21205840be.

See discussion at https://github.com/WICG/sanitizer-api/issues/107.