### PR TITLE
Expand & Move test references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -542,9 +542,6 @@ Note: `allowElements` creates a sanitizer that defaults to dropping elements,
   // Scripts will be blocked: "abc alert(1) def"
   new Sanitizer().sanitize("abc <script>alert(1)</script> def");
 ```
-<wpt>
-  sanitizer-sanitize.https.tentative.html
-</wpt>
 </div>
 
 In addition to allow and block lists for elements and attributes, there are
@@ -588,9 +585,6 @@ A sanitizer's configuration can be queried using the
   // object equality in JavaScript.)
   JSON.stringify(Sanitizer.getDefaultConfiguration()) == JSON.stringify(new Sanitizer().getConfiguration());  // true
 ```
-<wpt>
-  sanitizer-config.https.tentative.html
-</wpt>
 </div>
 
 ### Attribute Match Lists ### {#attr-match-list}
@@ -638,6 +632,9 @@ run these steps:
      algorithm on |input|.
   1. Run the [=sanitize a document fragment=] algorithm on |fragment|.
   1. Return |fragment|.
+<wpt>
+  sanitizer-sanitize.https.tentative.html
+</wpt>
 </div>
 
 <div algorithm="sanitizeFor">
@@ -656,6 +653,9 @@ To <dfn lt="sanitizeFor">sanitize for</dfn> an |element| name of type
   1. Run the steps of the [=sanitize a document fragment=] algorithm on |fragment|.
   1. [=Replace all=] with |fragment| as the `node` and |node| as the `parent`.
   1. Return |node|.
+<wpt>
+  sanitizer-sanitizeFor.https.tentative.html
+</wpt>
 </div>
 
 <div algorithm="sanitizeAndSet">
@@ -671,6 +671,9 @@ To <dfn lt="sanitizeAndSet">sanitize and set</dfn> a |value| using a
   1. Run the steos if the [=sanitize a document fragment=] algorithm
      on |fragment|, using |sanitizer| as the current {{Sanitizer}} instance.
   1. [=Replace all=] with |fragment| as the `node` and |this| as the `parent`.
+<wpt>
+  element-set-sanitized.https.tentative.html
+</wpt>
 </div>
 
 <div algorithm="create a document fragment">
@@ -698,6 +701,10 @@ run these steps:
   4. For any non-empty member of |config| whose key is declared in
      SanitizerOptions, copy the value to |result|.
   5. Return |result|.
+<wpt>
+  sanitizer-config.https.tentative.html
+  sanitizer-query-config.https.tentative.html
+</wpt>
 </div>
 
 ## Sanitization Algorithms ## {#sanitizer-algorithms}

--- a/index.bs
+++ b/index.bs
@@ -672,7 +672,7 @@ To <dfn lt="sanitizeAndSet">sanitize and set</dfn> a |value| using a
      on |fragment|, using |sanitizer| as the current {{Sanitizer}} instance.
   1. [=Replace all=] with |fragment| as the `node` and |this| as the `parent`.
 <wpt>
-  element-set-sanitized.https.tentative.html
+  element-set-sanitized-html.https.tentative.html
 </wpt>
 </div>
 
@@ -688,7 +688,7 @@ run these steps:
   5. Return |result|.
 <wpt>
   sanitizer-config.https.tentative.html
-  sanitizer-query-config.https.tentative.html
+  sanitizer-query-config.https.tenative.html
 </wpt>
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -676,21 +676,6 @@ To <dfn lt="sanitizeAndSet">sanitize and set</dfn> a |value| using a
 </wpt>
 </div>
 
-<div algorithm="create a document fragment">
-To <dfn>create a document fragment</dfn> named |fragment| from an
-|input| of type `Document or DocumentFragment`, run these steps:
-  1. Switch based on |input|'s type:
-    1. If |input| is of type {{DocumentFragment}}, then:
-      1. Let |node| refer to |input|.
-    1. If |input| is of type {{Document}}, then:
-      1. Let |node| refer to |input|'s `documentElement`.
-  1. Let |clone| be the result of running [=clone a node=] on |node| with the
-     `clone children flag` set to `true`.
-  1. Let `fragment` be the result of {{createDocumentFragment}}.
-  1. [=Append=] the node |clone| to the parent |fragment|.
-  1. Return |fragment|.
-</div>
-
 <div algorithm="query the sanitizer config">
 To <dfn>query the sanitizer config</dfn> of a given sanitizer instance,
 run these steps:
@@ -705,6 +690,24 @@ run these steps:
   sanitizer-config.https.tentative.html
   sanitizer-query-config.https.tentative.html
 </wpt>
+</div>
+
+## Helper Definitions ## {#helper-algorithms}
+
+<div algorithm="create a document fragment">
+To <dfn>create a document fragment</dfn> named |fragment| from an
+|input| of type `Document or DocumentFragment`, run these steps:
+
+  1. Switch based on |input|'s type:
+    1. If |input| is of type {{DocumentFragment}}, then:
+      1. Let |node| refer to |input|.
+    1. If |input| is of type {{Document}}, then:
+      1. Let |node| refer to |input|'s `documentElement`.
+  1. Let |clone| be the result of running [=clone a node=] on |node| with the
+     `clone children flag` set to `true`.
+  1. Let `fragment` be the result of {{createDocumentFragment}}.
+  1. [=Append=] the node |clone| to the parent |fragment|.
+  1. Return |fragment|.
 </div>
 
 ## Sanitization Algorithms ## {#sanitizer-algorithms}


### PR DESCRIPTION
- Move WPT test references to the algorithm section (rather than framework)
- Expand the references.
- Move non-API helper functions out of the API section, so that it's easy to see whether all API functions have test coverage or not.