### PR TITLE
nit: Remove bikeshed warning about single-use variable.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -292,7 +292,7 @@ handle additional, application-specific use cases.
 
 * The <dfn constructor for=Sanitizer lt="Sanitizer(config)">
     <code>new Sanitizer(<var>config</var>)</code></dfn> constructor steps
-    are to run the [=create a sanitizer=] algorithm steps with |config| and |this| as
+    are to run the [=create a sanitizer=] algorithm steps with |config| and <var ignore>this</var> as
     parameter.
 * The <dfn method for=Sanitizer><code>sanitize(<var>input</var>)</code></dfn>
     method steps are to return the result of running the [=sanitize=]


### PR DESCRIPTION
Bikeshed issues a warning if a variable has not been defined, and we do not define |this|.

> WARNING: The following \<var>s were only used once in the document:
>   'this'
> If these are not typos, please add an ignore='' attribute to the \<var>.
