### PR TITLE
Fixed the error in the description of the allowElements and the dropElements

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -515,8 +515,8 @@ is used as the configuration dictionary.
 :: The <dfn>allow comments option</dfn> determines whether HTML comments are
    allowed.
 
-Note: `allowElements` creates a sanitizer that defaults to dropping elements,
-  while `blockElements` and `dropElements` defaults to keeping unknown
+Note: `allowElements` creates a sanitizer that defaults to keeping elements,
+  while `blockElements` and `dropElements` defaults to dropping unknown
   elements. Using both types is possible, but is probably of little practical
   use. The same applies to `allowAttributes` and `dropAttributes`.
 


### PR DESCRIPTION
There are two errors in the provided description in the note section here https://wicg.github.io/sanitizer-api/#attribute-drop-list
this is a fix for those errors.