### PR TITLE
Fix WPT reference: sanitizer-unknown

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -943,6 +943,9 @@ To determine the <dfn>sanitize action for an |element|</dfn>, given a
   1. If |element| does not [=element matches an element name|match=] any name
      in |allow list|: Return `block`.
   1. Return `keep`.
+<wpt>
+sanitizer-unknown.https.html
+</wpt>
 </div>
 
 <div algorithm="element matches an element name">


### PR DESCRIPTION
Add a reference to WPT test sanitizer-unknown in the algorithm where its used.
Bikeshed insists any WPT test is referenced.