### PR TITLE
Introduce a query-able Sanitizer (or config) object.

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -110,15 +110,6 @@ The currently proposed API differs in a number of aspects:
   use-config-as-written way.
 - The configuration dictionary differs substantially in syntax.
 
-## Open questions:
-
-- Defaults: If no filter is supplied, do the safe methods have any filtering
-  other than the baseline? (For further discussion, see #188.)
-- Should the filter config be a separate object, or should it be a plain
-  dictionary? (As-is, it should probably be a dictionary. An object would
-  require either compelling performance numbers, or a compelling operation that
-  would only work with a pre-processed dictionary.)
-
 ## Examples
 
 The new APIs, in their most basic form:
@@ -232,6 +223,43 @@ const config_with_namespaces = new Sanitizer({
 > The `config_with_namespaces` example contains multiple entries for the same
 > element or attribute, to illustrate the syntax. Note that this isn't actually
 > allowed.
+
+### Configuration Options: Sanitizer object or dictionary.
+
+The Sanitizer object can be constructed from a dictionary. The same dictionary
+can also be used directly in the method options.
+
+```
+const config_dict = {
+  elements: [ "div", "p", "em", "b", "span" ],
+  attributes: [ "class", "style" ]
+};
+
+// These two should be the same:
+const some_html_string = "...";
+div.setHTML(some_html_string, {sanitizer: config_dict});
+div.setHTML(some_html_string, {sanitizer: new Sanitizer(config_dict)});
+```
+
+Note that implementations are expected to perform normalization work on the
+configuration, which can be easily re-used and amortized over many calls when
+used with the Sanitizer object that holds the configuration. To encourage this
+usage we explicitly instantiate objects in this explainer, outside of this
+particular sub-section.
+
+```
+// These should have the same results, but likely different performance:
+const huge_array_of_strings = [ "...", ... ];
+
+for (const str of huge_array_of_strings) {
+  div.setHTML(str, {sanitizer: config_dict});
+}
+
+const sanitizer = new Sanitizer(config_dict);
+for (const str of huge_array_of_strings) {
+  div.setHTML(str, {sanitizer: sanitizer});
+}
+```
 
 ### Configuration Options: Allowing or removing elements or attributes
 

--- a/explainer.md
+++ b/explainer.md
@@ -198,7 +198,7 @@ applications' needs. Both "safe" and "unsafe" versions can take a configuration.
 The "safe" version will ignore configuration items that break its security
 guarantees:
 ```js
-const an_unsafe_config = { 'elements': [ { name: 'script' } ] };
+const an_unsafe_config = new Sanitizer({ 'elements': [ { name: 'script' } ] });
 element.setHTML("<script>", { sanitizer: an_unsafe_config });  // <div></div>
 element.setHTMLUnsafe("<script>", { sanitizer: an_unsafe_config });  // You now have a script. Congrats.
 ```
@@ -209,7 +209,7 @@ only the name, in the HTML/null namespace (for elements/attributes,
 respectively).
 
 ``` js
-const config_with_namespaces = {
+const config_with_namespaces = new Sanitizer({
   elements: [
     'a',  // The HTML anchor element.
     { name: 'a' },  // Also the HTML anchor element.
@@ -225,7 +225,7 @@ const config_with_namespaces = {
         // It won't match any HTML-defined href attributes. Probably the config
         // author made an error.
   ]
-};
+});
 ```
 
 > [!NOTE]
@@ -243,17 +243,17 @@ This effectively specifies the sanitizer output relative to the built-in list.
 This can be useful if you wish to mostly retain the built-in defaults.
 
 ```js
-const config_allow_some_formatting = {
+const config_allow_some_formatting = new Sanitizer({
   elements: [ "div", "p", "em", "b", "img" ],  // Allows only 5 elements.
   attributes: [ "class" ]  // Allows only class attributes.
       // Output with "safe" and "unsafe" methods are the same for this config.
-};
-const config_disallow_style_definitions = {
+});
+const config_disallow_style_definitions = new Sanitizer({
   removeElements: [ "style" ],  // Allows the defaults, but without <style>.
   removeAttributes: [ "class", "style" ]  // No style or class attribute either.
       // And not XSS-y stuff, either, if used with a "safe" method.
       // Output with "safe" and "unsafe" methods might be quite different.
-};
+});
 ```
 
 You may also wish to remove elements, but retain their children. This is
@@ -261,9 +261,9 @@ chiefly useful to remove unwanted formatting from user input, while
 preserving its textual content.
 
 ```js
-const config_that_removes_elements_but_preserves_their_children = {
+const config_that_removes_elements_but_preserves_their_children = new Sanitizer({
  replaceWithChildrenElements: ["span", "em", "u", "s", "i", "b"]
-};
+});
 
 element.setHTML(
   "Fancy <b>text</b> with <span style='color:blue'>pizzazz</span>.",
@@ -279,10 +279,10 @@ level. Combining `elements` with `replaceWithChildrenElements` lets you keep
 some formatting, but all the text content:
 
 ```js
-const config_replace_spans = {
+const config_replace_spans = new Sanitizer({
   elements: ["b", "i"],
   replaceWithChildrenElements: ["span"]
-};
+});
 
 // <div>Fancy text with <b>pizzazz</b>.</div>
 element.setHTML(
@@ -304,22 +304,22 @@ If one wanted to allow `class` everywhere, but `src` only on `<img>`, the
 following would do:
 
 ```js
-const config_with_element_specific_attributes = {
+const config_with_element_specific_attributes = new Sanitizer({
   elements: [
     "div", "p","em", "b",
     { name: "img", attributes: [ "src" ] }
   ],
   attributes: ["class"],
-};
+});
 ```
 
 If you want to remove `src` attributes from `<input>` elements but retain them
 elsewhere, you can use:
 
 ```js
-const remove_src_attribute_from_input = {
+const remove_src_attribute_from_input = new Sanitizer({
   elements: [{ name: "input", removeAttributes: ["src"]}],
-}
+});
 ```
 
 Note that the `removeAttributes` key is on an allowed element, since removing
@@ -332,7 +332,7 @@ Handling of HTML comment nodes can be controlled by an option. Setting
 `comments` to `true` allows them:
 
 ```js
-const config_comments: { comments: true };
+const config_comments: new Sanitizer({ comments: true });
 element.setHTML("XXX<!-- Hello world! -->XXX", {sanitizer: config_comments});
 // <div>XXX<!-- Hello world! -->XXX</div>
 ```
@@ -367,33 +367,33 @@ the configuration. A well-formed configuration has the following properties:
 
 ```js
 // Mixing allow and block lists throws.
-const config_that_mixes_allow_and_block_lists = {
+const config_that_mixes_allow_and_block_lists = new Sanitizer({
     elements: ["i", "u"],
     removeElements: ["u", "s"],
-};
+});
 element.setHTML("bla", {sanitizer: config_that_mixes_allow_and_block_lists}); // throws
 
 // Mixing allow and replace with children lists works.
-const config_that_retains_simple_styling_but_most_text = {
+const config_that_retains_simple_styling_but_most_text = new Sanitizer({
   elements: ["p", "b", "i"],
   replaceWithChildrenElements: ["div", "span", "em", "u", "s", "li"],
-};
+});
 const styled_text = "<p>Some <span style='color: blue'>colourful</span> <u>styled</u> <b>text</b>";
 
 // <div><p>Some colourful styled <b>text</b></p></div>
 element.setHTML(styled_text, {sanitizer: config_that_retains_simple_styling_but_most_text});
 
 // Duplicate entries throw.
-const config_with_dupes = {
+const config_with_dupes = new Sanitizer({
   elements: [ "div", { name: "div", namespace: "http://www.w3.org/1999/xhtml" } ]
-};
+});
 element.setHTML("bla", {sanitizer: config_with_dupes});  // throws.
 
-const config_with_dupes2 = {
+const config_with_dupes2 = new Sanitizer({
   elements: [
     { name: "div", attributes: ["class"] },
     { name: "div", attributes: ["style"] }
-  ] };
+  ] });
 element.setHTML("bla", config_with_dupes2);  // throws.
 ```
 
@@ -401,12 +401,91 @@ Listing an attribute in the "global" allow-list and in an element specific one
 is allowed. In this case, the specific action takes precedence.
 
 ```js
-const config_with_local_and_global_attributes = {
+const config_with_local_and_global_attributes = new Sanitizer({
   elements: [ "span", { name: "b", removeAttributes: [ "class" ] } ],
   attributes: ["class"]
-};
+});
 
 // <div><span class="a">abc</span> <b>def</b></div>
 element.setHTML("<span class='a'>abc</span> <b class='b'>def</b>",
                 {sanitizer: config_with_local_and_global_attributes});
 ```
+
+### Querying the Configuration
+
+If you would like to better understand what a given configuration will do, you
+can query a `Sanitizer` (and possibly build a new config out of an existing one):
+
+```js
+const a_simple_config = new Sanitizer({ elements: [ "div", "p", "span", "script" ] });
+
+a_simple_config.get();
+// The result will be quite long. It'll look something like this:
+{
+  elements: [
+    { "name": "div", "namespace": "http://www.w3.org/1999/xhtml" },
+    { "name": "p", "namespace": "http://www.w3.org/1999/xhtml" },
+    { "name": "span", "namespace": "http://www.w3.org/1999/xhtml" }
+  ],
+  attributes: [
+    { "name": "href", "namespace": "" },
+    { "name": "class, "namespace": "" },
+    { "name": "id", "namespace": "" },
+    // ... many more
+  ]
+};
+```
+
+Note that:
+
+1. The returned config entries all have the "long" form with explicit name
+   and namespace.
+1. The `"script"` element has disappeared. Because, when used in a "safe"
+   version of the API, it wouldn't be allowed.
+1. Note that we suddenly have an `"attributes"` key that
+   represent the defaults.
+
+But what would the unsafe versions do with this config? Just ask:
+
+```js
+a_simple_config.getUnsafe();
+// The result:
+{
+  elements: [
+    { "name": "div", "namespace": "http://www.w3.org/1999/xhtml" },
+    { "name": "p", "namespace": "http://www.w3.org/1999/xhtml" },
+    { "name": "span", "namespace": "http://www.w3.org/1999/xhtml" }
+    { "name": "script", "namespace": "http://www.w3.org/1999/xhtml" }
+  ],
+  attributes: [
+    // ... many more. Should be the same list as above.
+  ]
+};
+```
+
+The configuration that is returned corresponds to what the specification calls
+a canonical configuration: Names are resolved into their explicit name &amp;
+namespace form. But some keys are also processed further. For example:
+
+```js
+new Sanitizer({
+  removeElements: [ "span" ],
+  removeAttributes: ["id", "class"]
+}).get();
+
+// The result will be quite long. It'll look something like this:
+{
+  elements: [
+    { "name": "div", "namespace": "http://www.w3.org/1999/xhtml" },
+    { "name": "p", "namespace": "http://www.w3.org/1999/xhtml" },
+    // ... many more. But no span.
+  ],
+  attributes: [
+    { "name": "href", "namespace": "" },
+    // ... many more. But no id or class.
+  ]
+};
+```
+
+Note that here, the remove-lists are converted to their allow-list equivalents,
+based on the built-in defaults.

--- a/index.bs
+++ b/index.bs
@@ -221,6 +221,7 @@ page to query and predict what effect a given configuration will have, or
 to build a new configuration based on an existing one.
 
 <pre class=idl>
+[Exposed=Window,Worker]
 interface Sanitizer {
   constructor(optional SanitizerConfig config = {});
   SanitizerConfig get();

--- a/index.bs
+++ b/index.bs
@@ -25,6 +25,7 @@ text: innerHTML; type: attribute; for: Element; url: https://dom.spec.whatwg.org
 text: window.toStaticHTML(); type: method; url: https://msdn.microsoft.com/en-us/library/cc848922(v=vs.85).aspx
 text: createDocumentFragment; type: method; url: https://dom.spec.whatwg.org/#dom-document-createdocumentfragment
 text: template contents; type: dfn; url: https://html.spec.whatwg.org/#template-contents
+text: internal slot; type:dfn; url: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots
 </pre>
 <pre class="biblio">
 {
@@ -107,8 +108,8 @@ markup, and an optional configuration.
 
 <pre class="idl extract">
 partial interface Element {
-  [CEReactions] undefined setHTMLUnsafe(HTMLString html, optional SanitizerConfig config = {});
-  [CEReactions] undefined setHTML(DOMString html, optional SanitizerConfig config = {});
+  [CEReactions] undefined setHTMLUnsafe(HTMLString html, optional SetHTMLOptions options = {});
+  [CEReactions] undefined setHTML(DOMString html, optional SetHTMLOptions options = {});
 };
 </pre>
 
@@ -131,8 +132,8 @@ partial interface Element {
 
 <pre class="idl extract">
 partial interface ShadowRoot {
-  [CEReactions] undefined setHTMLUnsafe(HTMLString html, optional SanitizerConfig config = {});
-  [CEReactions] undefined setHTML(DOMString html, optional SanitizerConfig config = {});
+  [CEReactions] undefined setHTMLUnsafe(HTMLString html, optional SetHTMLOptions options = {});
+  [CEReactions] undefined setHTML(DOMString html, optional SetHTMLOptions options = {});
 };
 </pre>
 
@@ -159,8 +160,8 @@ The {{Document}} interface gains two new methods which parse an entire {{Documen
 
 <pre class="idl extract">
 partial interface Document {
-  static Document parseHTMLUnsafe(HTMLString html, optional SanitizerConfig config = {});
-  static Document parseHTML(DOMString html, optional SanitizerConfig config = {});
+  static Document parseHTMLUnsafe(HTMLString html, optional SetHTMLOptions options = {});
+  static Document parseHTML(DOMString html, optional SetHTMLOptions options = {});
 };
 </pre>
 
@@ -172,8 +173,8 @@ The <dfn for="DOM/Document">parseHTMLUnsafe</dfn>(|html|, |options|) method step
    Note: Since |document| does not have a browsing context, scripting is disabled.
 1. Set |document|'s [=allow declarative shadow roots=] to true.
 1. [=Parse HTML=] from a string given |document| and |html|.
-1. Let |config| be the result of calling [=canonicalize a configuration=] on
-   |options|["`sanitizer`"] and false.
+1. Let |config| be the result of calling [=get a sanitizer config from options=]
+   with |options| and false.
 1. If |config| is not [=list/empty=],
    then call [=sanitize=] on |document|'s [=tree/root|root node=] with |config|.
 1. Return |document|.
@@ -189,10 +190,65 @@ The <dfn for="DOM/Document">parseHTML</dfn>(|html|, |options|) method steps are:
    Note: Since |document| does not have a browsing context, scripting is disabled.
 1. Set |document|'s [=allow declarative shadow roots=] to true.
 1. [=Parse HTML=] from a string given |document| and |html|.
-1. Let |config| be the result of calling [=canonicalize a configuration=] on
-   |options|["`sanitizer`"] and true.
+1. Let |config| be the result of calling [=get a sanitizer config from options=]
+   with |options| and true.
 1. Call [=sanitize=] on |document|'s [=tree/root|root node=] with |config|.
 1. Return |document|.
+
+</div>
+
+## SetHTML options and the configuration object. ## {#configobject}
+
+The family of {{Element/setHTML()}}-like methods always take an options
+dictionary. Right now, only one member of this dictionary is defined:
+
+<pre class=idl>
+dictionary SetHTMLOptions {
+  Sanitizer? sanitizer;
+};
+</pre>
+
+The {{Sanitizer}} configuration object encapsulates a filter configuration.
+The same config can be used with both safe or unsafe methods. The intent is
+that one (or a few) configurations will be built-up early on in a page's
+lifetime, and can then be used whenever needed. This allows implementations
+to pre-process configurations.
+
+The configuration object is also query-able and can return
+[=SanitizerConfig/canonical=] configuration dictionaries,
+in both safe and unsafe variants. This allows a
+page to query and predict what effect a given configuration will have, or
+to build a new configuration based on an existing one.
+
+<pre class=idl>
+interface Sanitizer {
+  constructor(optional SanitizerConfig config = {});
+  SanitizerConfig get();
+  SanitizerConfig getUnsafe();
+};
+</pre>
+
+<div algorithm>
+The <dfn for="Sanitizer" export>constructor</dfn>(|config|)
+method steps are:
+
+1. Store |config| in [=this=]'s [=internal slot=].
+
+</div>
+
+<div algorithm>
+The <dfn for="Sanitizer" export>get</dfn>() method steps are:
+
+1. Return the result of [=canonicalize a configuration=] with the value of
+   [=this=]'s [=internal slot=] and true.
+
+</div>
+
+<div algorithm>
+The <dfn for="Sanitizer" export>getUnsafe</dfn>() method steps are:
+
+1. Return the result of [=canonicalize a configuration=] with the value of
+   [=this=]'s [=internal slot=] and false.
 
 </div>
 
@@ -232,6 +288,7 @@ dictionary SanitizerConfig {
 };
 </pre>
 
+
 # Algorithms # {#algorithms}
 
 <div algorithm>
@@ -242,14 +299,27 @@ To <dfn>set and filter HTML</dfn>, given an {{Element}} or {{DocumentFragment}}
 1. If |safe| and |contextElement|'s [=Element/local name=] is "`script`" and
    |contextElement|'s [=Element/namespace=] is the [=HTML namespace=] or the
    [=SVG namespace=], then return.
-1. Let |config| be the result of calling [=canonicalize a configuration=] on
-   |options|["`sanitizer`"] and |safe|.
+1. Let |config| be the result of calling [=get a sanitizer config from options=]
+   with |options| and |safe|.
 1. Let |newChildren| be the result of the HTML [=fragment parsing algorithm=]
    given |contextElement|, |html|, and true.
 1. Let |fragment| be a new {{DocumentFragment}} whose [=node document=] is |contextElement|'s [=node document=].
 1. [=list/iterate|For each=] |node| in |newChildren|, [=list/append=] |node| to |fragment|.
 1. If |config| is not [=list/empty=], then run [=sanitize=] on |fragment| using |config|.
 1. [=Replace all=] with |fragment| within |target|.
+
+</div>
+
+<div algorithm>
+To <dfn for="SanitizerConfig">get a sanitizer config from options</dfn> for
+an options dictionary |options| and a boolean |safe|, do:
+
+1. Assert: |options| is a [=dictionary=].
+1. If |options|["`sanitizer`"] doesn't [=map/exists=]
+   or if |options|["`sanitizer`"] [=map/exists=] but is not a
+   {{Sanitizer}} instance, then return undefined.
+1. Return the result of calling [=canonicalize a configuration=] on
+   |options|["`sanitizer`"]'s [=internal slot=] and |safe|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -204,7 +204,7 @@ dictionary. Right now, only one member of this dictionary is defined:
 
 <pre class=idl>
 dictionary SetHTMLOptions {
-  Sanitizer? sanitizer;
+  (Sanitizer or SanitizerConfig) sanitizer = {};
 };
 </pre>
 
@@ -316,11 +316,14 @@ To <dfn for="SanitizerConfig">get a sanitizer config from options</dfn> for
 an options dictionary |options| and a boolean |safe|, do:
 
 1. Assert: |options| is a [=dictionary=].
-1. If |options|["`sanitizer`"] doesn't [=map/exists=]
-   or if |options|["`sanitizer`"] [=map/exists=] but is not a
-   {{Sanitizer}} instance, then return undefined.
+1. If |options|["`sanitizer`"] doesn't [=map/exists=], then return undefined.
+1. Assert: |options|["`sanitizer`"] is either a {{Sanitizer}} instance
+   or a [=dictionary=].
+1. If |options|["`sanitizer`"] is a {{Sanitizer}} instance:
+   1. Then let |config| be the value of |options|["`sanitizer`"]'s [=internal slot=].
+   1. Otherwise let |config| be the value of |options|["`sanitizer`"].
 1. Return the result of calling [=canonicalize a configuration=] on
-   |options|["`sanitizer`"]'s [=internal slot=] and |safe|.
+   |config| and |safe|.
 
 </div>
 


### PR DESCRIPTION
This makes a configuration query-able, and should make it easy (or easier) to derive a new configuration from an existing one. In terms of spec & implementation, this leans heavily on the existing canonicalization.

----

This needs further discussion. We had discussed re-introducing a configuration object in order to expose the canonical configuration(s), but not how exactly that should look like. This proposes specific spec & explainer wording to focus the discussion.