### PR TITLE
Update "javascript:" handling; esp. SVG animation and MathML href.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -485,6 +485,29 @@ template contents). It consistes of these steps:
 
 </div>
 
+<div class=note>
+<span class=marker>Note:</span> Current browsers support `javascript:` URLs
+only when navigating. Since navigation itself is not an XSS threat we handle
+navigation to `javascript:` URLs, but not navigations in general.
+
+Declarative navigation falls into a handful of categories:
+
+  1. Anchor elements. (`<a>` in HTML and SVG namespaces)
+  1. Form elements that trigger navigation as part of the form action.
+  1. [[MathML]] allows [any element to act as an anchor](
+     https://www.w3.org/TR/MathML3/mathml.html#chapter2_fund.globatt).
+  1. [[SVG11]] animation.
+
+The first two are covered by the [=built-in navigating URL attributes list=].
+
+The MathML case is covered by a seperate rule, because there is no formalism
+in this spec to cover a "per-namespace global" rule.
+
+The SVG animation case is covered by the
+[=built-in animating URL attributes list=]. But since the interpretation of SVG animation elements depends on the animation target, and since during sanitization we cannot know what the final target will be, the [=sanitize=] algorithm blocks any animation of `href` attributes.
+
+</div>
+
 <div algorithm>
 To determine whether an |attribute| <dfn>contains a javascript: URL</dfn>:
 1. Let |url| be the result of running the [=basic URL parser=]

--- a/index.bs
+++ b/index.bs
@@ -779,6 +779,21 @@ navigations are "unsafe", are as follows:
     { "`name`" &rightarrow; "`formaction`", "`namespace`" &rightarrow; `null` }
   ],
   <br>
+  [
+    { "`name`" &rightarrow; "`a`", "`namespace`" &rightarrow; [=SVG namespace=] },
+    { "`name`" &rightarrow; "`href`", "`namespace`" &rightarrow; `null` }
+  ],
+  <br>
+  [
+    { "`name`" &rightarrow; "`a`", "`namespace`" &rightarrow; [=SVG namespace=] },
+    { "`name`" &rightarrow; "`href`", "`namespace`" &rightarrow; [=XLink namespace=] }
+  ],
+  <br>
+  [
+    { "`name`" &rightarrow; "`base`", "`namespace`" &rightarrow; [=HTML namespace=] },
+    { "`name`" &rightarrow; "`href`", "`namespace`" &rightarrow; `null` }
+  ],
+  <br>
 ]&raquo;
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -468,9 +468,15 @@ template contents). It consistes of these steps:
          - "data-" is a [=code unit prefix=] of [=Attr/local name=] and
             [=Attr/namespace=] is `null` and
             |configuration|["{{SanitizerConfig/dataAttributes}}"] is true
-      1. If |handleJavascriptNavigationUrls| and &laquo;[|elementName|, |attrName|]&raquo; matches an entry in the
-         [=built-in navigating URL attributes list=], and if |attribute|
-         [=contains a javascript: URL=], then remove |attribute| from |child|.
+      1. If |handleJavascriptNavigationUrls|:
+         1. If &laquo;[|elementName|, |attrName|]&raquo; matches an entry in
+            the [=built-in navigating URL attributes list=], and if |attribute|
+            [=contains a javascript: URL=], then remove |attribute| from |child|.
+         1. If the [=built-in animating URL attributes list=]
+            [=SanitizerConfig/contains=]
+            &laquo;[|elementName|, |attrName|]&raquo; and |attr|'s
+            [=get an attribute value|value=] [=string/is=] "`href`" or
+            "`xlink:href`", then [=/remove an attribute|remove=] |attr|.
 
 </div>
 
@@ -717,11 +723,12 @@ regard to order:
 
 ## Defaults ## {#sanitization-defaults}
 
-There are three builtins:
+There are four builtins:
 
 * The [=built-in safe default configuration=],
 * the [=built-in safe baseline configuration=], and
-* the [=built-in navigating URL attributes list=].
+* the [=built-in navigating URL attributes list=], and
+* the [=built-in animating URL attributes list=].
 
 The <dfn>built-in safe default configuration</dfn> is as follows:
 ```
@@ -797,6 +804,33 @@ navigations are "unsafe", are as follows:
 ]&raquo;
 </div>
 
+The <dfn>built-in animating URL attributes list</dfn>, which can be used in
+[[SVG11]] to declaratively modify navigation elements to use "`javascript:`"
+URLs, is as follows:
+
+&laquo;[
+  <br>
+  [
+    { "`name`" &rightarrow; "`animate`", "`namespace`" &rightarrow; [=SVG namespace=] },
+    { "`name`" &rightarrow; "`attributeName`", "`namespace`" &rightarrow; `null`] }
+  ],
+  <br>
+  [
+    { "`name`" &rightarrow; "`animateMotion`", "`namespace`" &rightarrow; [=SVG namespace=] },
+    { "`name`" &rightarrow; "`attributeName`", "`namespace`" &rightarrow; `null` }
+  ],
+  <br>
+  [
+    { "`name`" &rightarrow; "`animateTransform`", "`namespace`" &rightarrow; [=SVG namespace=] },
+    { "`name`" &rightarrow; "`attributeName`", "`namespace`" &rightarrow; `null` }
+  ],
+  <br>
+  [
+    { "`name`" &rightarrow; "`set`", "`namespace`" &rightarrow; [=SVG namespace=] },
+    { "`name`" &rightarrow; "`attributeName`", "`namespace`" &rightarrow; `null` }
+  ],
+  <br>
+]&raquo;
 
 # Security Considerations # {#security-considerations}
 

--- a/index.bs
+++ b/index.bs
@@ -472,6 +472,11 @@ template contents). It consistes of these steps:
          1. If &laquo;[|elementName|, |attrName|]&raquo; matches an entry in
             the [=built-in navigating URL attributes list=], and if |attribute|
             [=contains a javascript: URL=], then remove |attribute| from |child|.
+         1. If |child|'s [=Element/namespace=] [=string/is=] the
+            [=MathML Namespace=] and |attr|'s [=Attr/local name=] [=string/is=]
+            "`href`" and  |attr|'s [=Attr/namespace=] is `null` or the
+            [=XLink namespace=] and |attr| [=contains a javascript: URL=],
+            then [=/remove an attribute|remove=] |attr|.
          1. If the [=built-in animating URL attributes list=]
             [=SanitizerConfig/contains=]
             &laquo;[|elementName|, |attrName|]&raquo; and |attr|'s

--- a/index.bs
+++ b/index.bs
@@ -431,16 +431,15 @@ template contents). It consistes of these steps:
            parser for which this assertion should hold. If in the future
            this algorithm will be used in different contexts, this assumption
            needs to be re-examined.
-  1. If |child| [=implements=] {{Text}}:
-    1. [=continue=].
-  1. else if |child| [=implements=] {{Comment}}:
-    1. If |configuration|["{{SanitizerConfig/comments}}"] is not true:
-      1. [=/remove=] |child|.
-  1. else:
+  1. If |child| [=implements=] {{Text}}, then [=continue=].
+  1. If |child| [=implements=] {{Comment}}:
+    1. If |configuration|["{{SanitizerConfig/comments}}"] is not true,
+       then [=/remove=] |child|.
+  1. Otherwise:
     1. Let |elementName| be a {{SanitizerElementNamespace}} with |child|'s
        [=Element/local name=] and [=Element/namespace=].
-    1. If |configuration|["{{SanitizerConfig/removeElements}}"] [=SanitizerConfig/contains=] |elementName|, or if |configuration|["{{SanitizerConfig/elements}}"] is not [=list/empty=] and does not [=SanitizerConfig/contain=] |elementName|:
-       1. [=/remove=] |child|.
+    1. If |configuration|["{{SanitizerConfig/removeElements}}"] [=SanitizerConfig/contains=] |elementName|, or if |configuration|["{{SanitizerConfig/elements}}"] is not [=list/empty=] and does not [=SanitizerConfig/contain=] |elementName|,
+       then [=/remove=] |child|.
     1. If |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"] [=SanitizerConfig/contains=] |elementName|:
       1. Call [=sanitize core=] on |child| with |configuration| and
           |handleJavascriptNavigationUrls|.
@@ -449,18 +448,17 @@ template contents). It consistes of these steps:
        "`namespace`" &rightarrow; [=HTML namespace=] ]&raquo;
       1. Then call [=sanitize core=] on |child|'s [=template contents=] with
           |configuration| and |handleJavascriptNavigationUrls|.
-    1. If |child| is a [=shadow host=]:
-      1. Then call [=sanitize core=] on |child|'s [=Element/shadow root=] with
-          |configuration| and |handleJavascriptNavigationUrls|.
+    1. If |child| is a [=shadow host=],
+       then call [=sanitize core=] on |child|'s [=Element/shadow root=] with
+       |configuration| and |handleJavascriptNavigationUrls|.
     1. [=list/iterate|For each=] |attribute| in |child|'s [=Element/attribute list=]:
       1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
          [=Attr/local name=] and [=Attr/namespace=].
       1. If |configuration|["{{SanitizerConfig/removeAttributes}}"]
-           [=SanitizerConfig/contains=] |attrName|:
-         1. Remove |attribute| from |child|.
+         [=SanitizerConfig/contains=] |attrName|,
+         then Remove |attribute| from |child|.
       1. If |configuration|["{{SanitizerConfig/elements}}"]["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-           [=SanitizerConfig/contains=] |attrName|:
-         1. Remove |attribute| from |child|.
+           [=SanitizerConfig/contains=] |attrName|, then remove |attribute| from |child|.
 
       1. If all of the following are false, then remove |attribute| from |child|.
          - |configuration|["{{SanitizerConfig/attributes}}"] [=list/exists=] and
@@ -472,8 +470,7 @@ template contents). It consistes of these steps:
             |configuration|["{{SanitizerConfig/dataAttributes}}"] is true
       1. If |handleJavascriptNavigationUrls| and &laquo;[|elementName|, |attrName|]&raquo; matches an entry in the
          [=built-in navigating URL attributes list=], and if |attribute|
-         [=contains a javascript: URL=]:
-         1. Then remove |attribute| from |child|.
+         [=contains a javascript: URL=], then remove |attribute| from |child|.
 
 </div>
 


### PR DESCRIPTION
- Add SVG <a href> & <a xlink:href> to list of javascript:-attributes.
- Add a list for SVG animations.
- Minor edits when using those lists.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/212.html" title="Last updated on Jan 10, 2025, 2:32 PM UTC (7134494)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/212/3604c34...otherdaniel:7134494.html" title="Last updated on Jan 10, 2025, 2:32 PM UTC (7134494)">Diff</a>