### PR TITLE
Update Unsafe methods to use HTMLString IDL type from Trusted Types

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -107,7 +107,7 @@ markup, and an optional configuration.
 
 <pre class=idl>
 partial interface Element {
-  [CEReactions] undefined setHTMLUnsafe__TO_BE_MERGED(DOMString html, optional SanitizerConfig config = {});
+  [CEReactions] undefined setHTMLUnsafe__TO_BE_MERGED(HTMLString html, optional SanitizerConfig config = {});
   [CEReactions] undefined setHTML(DOMString html, optional SanitizerConfig config = {});
 };
 </pre>
@@ -135,7 +135,7 @@ we'll rename them here by appending `__TO_BE_MERGED` to those names.
 
 <pre class=idl>
 partial interface ShadowRoot {
-  [CEReactions] undefined setHTMLUnsafe__TO_BE_MERGED(DOMString html, optional SanitizerConfig config = {});
+  [CEReactions] undefined setHTMLUnsafe__TO_BE_MERGED(HTMLString html, optional SanitizerConfig config = {});
   [CEReactions] undefined setHTML(DOMString html, optional SanitizerConfig config = {});
 };
 </pre>
@@ -163,7 +163,7 @@ The {{Document}} interface gains two new methods which parse an entire {{Documen
 
 <pre class=idl>
 partial interface Document {
-  static Document parseHTMLUnsafe__TO_BE_MERGED(DOMString html, optional SanitizerConfig config = {});
+  static Document parseHTMLUnsafe__TO_BE_MERGED(HTMLString html, optional SanitizerConfig config = {});
   static Document parseHTML(DOMString html, optional SanitizerConfig config = {});
 };
 </pre>


### PR DESCRIPTION
Minor edit just to make it clearer when upstreaming to HTML that you should keep the HTMLString type.