### PR TITLE
Use class=extract instead of __TO_BE_MERGED suffix.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -102,22 +102,18 @@ configuration. The methods come in two by two flavours:
 ## Sanitizer API ## {#sanitizer-api}
 
 The {{Element}} interface defines two methods, {{Element/setHTML()}} and
-{{Element/setHTMLUnsafe__TO_BE_MERGED()}}. Both of these take a {{DOMString}} with HTML
+{{Element/setHTMLUnsafe()}}. Both of these take a {{DOMString}} with HTML
 markup, and an optional configuration.
 
-<pre class=idl>
+<pre class="idl extract">
 partial interface Element {
-  [CEReactions] undefined setHTMLUnsafe__TO_BE_MERGED(HTMLString html, optional SanitizerConfig config = {});
+  [CEReactions] undefined setHTMLUnsafe(HTMLString html, optional SanitizerConfig config = {});
   [CEReactions] undefined setHTML(DOMString html, optional SanitizerConfig config = {});
 };
 </pre>
 
-Note: The `setHTMLUnsafe` method is meant to be merged with [[HTML]]'s
-setHTMLUnsafe. To prevent tooling errors about overloaded methods
-we'll rename them here by appending `__TO_BE_MERGED` to those names.
-
-<div algorithm="DOM-Element-setHTMLUnsafe__TO_BE_MERGED" export>
-{{Element}}'s <dfn for="DOM/Element">setHTMLUnsafe__TO_BE_MERGED</dfn>(|html|, |options|) method steps are:
+<div algorithm="DOM-Element-setHTMLUnsafe" export>
+{{Element}}'s <dfn for="DOM/Element">setHTMLUnsafe</dfn>(|html|, |options|) method steps are:
 
 1. Let |target| be |this|'s [=template contents=] if [=this=] is {{HTMLTemplateElement|template}} element; otherwise |this|.
 1. [=Set and filter HTML=] given |target|, [=this=], |html|, |options|, and false.
@@ -133,17 +129,17 @@ we'll rename them here by appending `__TO_BE_MERGED` to those names.
 
 </div>
 
-<pre class=idl>
+<pre class="idl extract">
 partial interface ShadowRoot {
-  [CEReactions] undefined setHTMLUnsafe__TO_BE_MERGED(HTMLString html, optional SanitizerConfig config = {});
+  [CEReactions] undefined setHTMLUnsafe(HTMLString html, optional SanitizerConfig config = {});
   [CEReactions] undefined setHTML(DOMString html, optional SanitizerConfig config = {});
 };
 </pre>
 
 These methods are mirrored on the {{ShadowRoot}}:
 
-<div algorithm="ShadowRoot-setHTMLUnsafe__TO_BE_MERGED" export>
-{{ShadowRoot}}'s <dfn for="DOM/ShadowRoot">setHTMLUnsafe__TO_BE_MERGED</dfn>(|html|, |options|) method steps are:
+<div algorithm="ShadowRoot-setHTMLUnsafe" export>
+{{ShadowRoot}}'s <dfn for="DOM/ShadowRoot">setHTMLUnsafe</dfn>(|html|, |options|) method steps are:
 
 1. [=Set and filter HTML=] using [=this=],
    [=this=]'s [=shadow host=] (as context element),
@@ -161,15 +157,15 @@ These methods are mirrored on the {{ShadowRoot}}:
 
 The {{Document}} interface gains two new methods which parse an entire {{Document}}:
 
-<pre class=idl>
+<pre class="idl extract">
 partial interface Document {
-  static Document parseHTMLUnsafe__TO_BE_MERGED(HTMLString html, optional SanitizerConfig config = {});
+  static Document parseHTMLUnsafe(HTMLString html, optional SanitizerConfig config = {});
   static Document parseHTML(DOMString html, optional SanitizerConfig config = {});
 };
 </pre>
 
-<div algorithm="parseHTMLUnsafe__TO_BE_MERGED" export>
-The <dfn for="DOM/Document">parseHTMLUnsafe__TO_BE_MERGED</dfn>(|html|, |options|) method steps are:
+<div algorithm="parseHTMLUnsafe" export>
+The <dfn for="DOM/Document">parseHTMLUnsafe</dfn>(|html|, |options|) method steps are:
 
 1. Let |document| be a new {{Document}}, whose [=Document/content type=] is "text/html".
 


### PR DESCRIPTION
In #210, we added a suffix to methods defined in HTML in order to avoid tooling errors. Per #216, this still causes inconvenience. So here we solve this by using `class=extract`, to prevent these partial interfaces from being extracted at all.

See: https://speced.github.io/bikeshed/#no-idl
Fixes #216.