### PR TITLE
Fix `Exposed` statement in dfn of `Sanitizer` interface

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -221,7 +221,7 @@ page to query and predict what effect a given configuration will have, or
 to build a new configuration based on an existing one.
 
 <pre class=idl>
-[Exposed=Window,Worker]
+[Exposed=(Window,Worker)]
 interface Sanitizer {
   constructor(optional SanitizerConfig config = {});
   SanitizerConfig get();


### PR DESCRIPTION
Identifiers of an extended attribute need to be enclosed in parentheses in Web IDL: https://webidl.spec.whatwg.org/#dfn-extended-attribute