### PR TITLE
Update Mutated XSS chapter to reference the current API.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -858,7 +858,7 @@ new document. Therefore Sanitizer API is not directly affected by mutated XSS.
 
 If a developer were to retrieve a sanitized node tree as a string, e.g. via
 `.innerHTML`, and to then parse it again then mutated XSS may occur.
-We recommend against this practice. If processing or passing of HTML as a
+We discourage this practice. If processing or passing of HTML as a
 string should be necessary after all, then any string should be considered
 untrusted and should be sanitized (again) when inserting it into the DOM. In
 other words, a sanitized and then serialized HTML tree can no

--- a/index.bs
+++ b/index.bs
@@ -862,7 +862,7 @@ We recommend against this practice. If processing or passing of HTML as a
 string should be necessary after all, then any string should be considered
 untrusted and should be sanitized (again) when inserting it into the DOM. In
 other words, a sanitized and then serialized HTML tree can no
-longer considered as sanitized.
+longer be considered as sanitized.
 
 A more complete treatement of mXSS can be found in [[MXSS]].
 

--- a/index.bs
+++ b/index.bs
@@ -851,20 +851,18 @@ into a different parent element. An example for carrying out such an attack
 is by relying on the change of parsing behavior for foreign content or
 misnested tags.
 
-The Sanitizer API offers help against Mutated XSS, but relies on some amount of
-cooperation by the developers. The `sanitize()` function does not handle strings
-and is therefore unaffected. The `setHTML` function combines sanitization
-with DOM modification and can implicitly apply the correct context. The
-`sanitizeFor()` function combines parsing and sanitization, and relies on the
-developer to supply the correct context for the eventual application of its
-result.
+The Sanitizer API offers only functions that turn a string into a node tree.
+The context is supplied implicitly by all sanitizer functions:
+`Element.setHTML()` uses the current element; `Document.parseHTML()` creates a
+new document. Therefore Sanitizer API is not directly affected by mutated XSS.
 
-If the data to be sanitized is available as a node tree, we encourage authors
-to use the `sanitize()` function of the API which returns a
-DocumentFragment and avoids risks that come with serialization and additional
-parsing. Directly operating on a fragment after sanitization also comes with a
-performance benefit, as the cost of additional serialization and parsing is
-avoided.
+If a developer were to retrieve a sanitized node tree as a string, e.g. via
+`.innerHTML`, and to then parse it again then mutated XSS may occur.
+We recommend against this practice. If processing or passing of HTML as a
+string should be necessary after all, then any string should be considered
+untrusted and should be sanitized (again) when inserting it into the DOM. In
+other words, a sanitized and then serialized HTML tree can no
+longer considered as sanitized.
 
 A more complete treatement of mXSS can be found in [[MXSS]].
 


### PR DESCRIPTION
Remove refences to `.sanitize` and `.sanitizeFor`.
Update the text to reference the current API.

Fixes #213.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/219.html" title="Last updated on Apr 17, 2024, 9:33 AM UTC (a556353)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/219/abac6ed...otherdaniel:a556353.html" title="Last updated on Apr 17, 2024, 9:33 AM UTC (a556353)">Diff</a>