### PR TITLE
Update reference to Element.innerHTML.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -21,7 +21,7 @@ WPT Display: inline
 WPT Path Prefix: /sanitizer-api/
 </pre>
 <pre class="anchors">
-text: innerHTML; type: attribute; for: Element; url: https://dom.spec.whatwg.org/#widl-Element-innerHTML
+text: innerHTML; type: attribute; for: Element; url: https://html.spec.whatwg.org/#dom-element-innerhtml
 text: window.toStaticHTML(); type: method; url: https://msdn.microsoft.com/en-us/library/cc848922(v=vs.85).aspx
 text: createDocumentFragment; type: method; url: https://dom.spec.whatwg.org/#dom-document-createdocumentfragment
 text: template contents; type: dfn; url: https://html.spec.whatwg.org/#template-contents


### PR DESCRIPTION
Element.innerHTML is defined in HTML, not DOM.

Fixes #232.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/235.html" title="Last updated on Jun 25, 2024, 10:13 AM UTC (01593ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/235/c8e529d...otherdaniel:01593ff.html" title="Last updated on Jun 25, 2024, 10:13 AM UTC (01593ff)">Diff</a>