### PR TITLE
Modify-able config.

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -378,11 +378,11 @@ The following methods are offered on the Sanitizer object:
   - `options` is an optional dictionary argument.
     Supported keys are: `"attributes":` and `"removeAttributes":.`
 - `removeElement(x)`
-- `replaceWithChildren(x)`
+- `replaceElementWithChildren(x)`
 - `allowAttribute(x)`
 - `removeAttribute(x)`
-- `comments(bool)`
-- `dataAttributes(bool)`
+- `setComments(bool)`
+- `setDataAttributes(bool)`
 
 These correspond 1:1 to the keys in the configuration dictionary.
 

--- a/explainer.md
+++ b/explainer.md
@@ -381,6 +381,8 @@ The following methods are offered on the Sanitizer object:
 - `replaceWithChildren(x)`
 - `allowAttribute(x)`
 - `removeAttribute(x)`
+- `comments(bool)`
+- `dataAttributes(bool)`
 
 These correspond 1:1 to the keys in the configuration dictionary.
 
@@ -400,6 +402,23 @@ s.get();  // { elements: ["div", "p", "span"], removeElements: ["b"] }
           // Really, all these entries will be dictionaries with name and
           // namespace entries.
 ```
+
+If one wishes to modify the element-dependent attributes, then `allow` is
+the way to do this, with a dictionary as argument. This allows `"attributes"`
+and `"removeAttributes"` keys, like the configuration dictionary. These
+element-dependent attributes are set, meaning they overwrite any previously
+set values, rather than some sort of merger operation.
+
+```js
+const s = new Sanitizer();
+s.element({name: "div", attributes: ["id", "class"]});
+s.element({name: "div", attributes: ["style"]});
+// s now allows <div style="bla">, but will drop the id= from <div id="bla">
+```
+
+Since the configuration is mutable, passing around a pre-configured Sanitizer
+can be used to let other callers modify its configuration. The "safe" methods
+(`setHTML` and `parseHTML`) will still guarantee XSS safety.
 
 ### Configuration Errors
 

--- a/explainer.md
+++ b/explainer.md
@@ -374,9 +374,10 @@ functionality of the Sanitizer.
 
 The following methods are offered on the Sanitizer object:
 
-- `allow(x, options)`
-  - `options` is an optional dictionary argument.
-    Supported keys are: `"attributes":` and `"removeAttributes":.`
+- `allowElement(x)`
+  - `x` can be a dictionary (similar to all other methods), but it also
+    supports additional keys to allow (`"attributes"`) or to remove attributes
+    ("removeAttributes"`) for this particular element type.
 - `removeElement(x)`
 - `replaceElementWithChildren(x)`
 - `allowAttribute(x)`
@@ -396,7 +397,7 @@ namespace, just as with the configuration dictionary.
 
 ```js
 const s = new Sanitizer({ elements: ["div", "p", "b"] });
-s.element("span");
+s.allowElement("span");
 s.removeElement("b");
 s.get();  // { elements: ["div", "p", "span"], removeElements: ["b"] }
           // Really, all these entries will be dictionaries with name and
@@ -411,8 +412,8 @@ set values, rather than some sort of merger operation.
 
 ```js
 const s = new Sanitizer();
-s.element({name: "div", attributes: ["id", "class"]});
-s.element({name: "div", attributes: ["style"]});
+s.allowElement({name: "div", attributes: ["id", "class"]});
+s.allowElement({name: "div", attributes: ["style"]});
 // s now allows <div style="bla">, but will drop the id= from <div id="bla">
 ```
 

--- a/explainer.md
+++ b/explainer.md
@@ -363,6 +363,44 @@ element.setHTML("XXX<!-- Hello world! -->XXX", {sanitizer: config_comments});
 // <div>XXX<!-- Hello world! -->XXX</div>
 ```
 
+### Modifying Existing Configurations
+
+The `Sanitizer` object offers multiple methods to easily modify or tailor
+an existing configuration. The query methods (`get()` and `getUnsafe()`) can
+be used to retrieve a dictionary representation of a Sanitizer,
+for introspection, or for use with the Sanitizer constructor to create a new
+Sanitizer. Additionally, there are methods that directly manipulate the filter
+functionality of the Sanitizer.
+
+The following methods are offered on the Sanitizer object:
+
+- `allow(x, options)`
+  - `options` is an optional dictionary argument.
+    Supported keys are: `"attributes":` and `"removeAttributes":.`
+- `removeElement(x)`
+- `replaceWithChildren(x)`
+- `allowAttribute(x)`
+- `removeAttribute(x)`
+
+These correspond 1:1 to the keys in the configuration dictionary.
+
+Adding an element or attribute to any of the allow- or deny-lists will also
+remove that element or attribute from the other lists for its type. E.g.,
+calling `allow(x)` will also remove `x` from the removeElements and
+replaceWithChildrenElements lists.
+
+Any name can be given as either a string, or a dictionary with name or
+namespace, just as with the configuration dictionary.
+
+```js
+const s = new Sanitizer({ elements: ["div", "p", "b"] });
+s.element("span");
+s.removeElement("b");
+s.get();  // { elements: ["div", "p", "span"], removeElements: ["b"] }
+          // Really, all these entries will be dictionaries with name and
+          // namespace entries.
+```
+
 ### Configuration Errors
 
 The configuration allows expressing redundant or even contradictory options.

--- a/index.bs
+++ b/index.bs
@@ -25,7 +25,6 @@ spec:html; type:dfn; text: template contents
 </pre>
 <pre class="anchors">
 text: window.toStaticHTML(); type: method; url: https://msdn.microsoft.com/en-us/library/cc848922(v=vs.85).aspx
-text: internal slot; type:dfn; url: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots
 text: parse HTML from a string; type: dfn; url: https://html.spec.whatwg.org/#parse-html-from-a-string
 </pre>
 <pre class="biblio">
@@ -228,8 +227,8 @@ dictionary SetHTMLOptions {
 </pre>
 
 The {{Sanitizer}} configuration object encapsulates a filter configuration.
-The same config can be used with both safe or unsafe methods, where the safe
-methods perform an implicit {{removeUnsafe}} operation. The intent is
+The same configuration can be used with both safe or unsafe methods, where
+the safe methods perform an implicit {{removeUnsafe}} operation. The intent is
 that one (or a few) configurations will be built-up early on in a page's
 lifetime, and can then be used whenever needed. This allows implementations
 to pre-process configurations.
@@ -240,7 +239,7 @@ It can also be modified directly.
 <pre class=idl>
 [Exposed=(Window,Worker)]
 interface Sanitizer {
-  constructor(optional SanitizerConfig config = {});
+  constructor(optional SanitizerConfig configuration = {});
 
   // Query configuration:
   SanitizerConfig get();
@@ -259,127 +258,61 @@ interface Sanitizer {
 };
 </pre>
 
+A {{Sanitizer}} has an associated <dfn for="Sanitizer">configuration</dfn>, a {{SanitizerConfig}}.
+
 ISSUE(238): Final naming TBD.
 
-ISSUE(240): "other markup" TBD.
-
-ISSUE: Should these be setter methods -- particularly the setXXX(boolean) --
-    or setters or properties or somesuch?
-
-ISSUE: Should the modifier methods return a reference to [=this=], so that you
-    can 'chain' methods?
+ISSUE(242): Should the modifier methods return a reference to [=this=], so
+    that you can 'chain' methods?
     (e.g. `sanitizer.allowElement("a").allowElement("span")`).
 
 <div algorithm>
-The <dfn for="Sanitizer" export>constructor</dfn>(|config|)
+The <dfn for="Sanitizer" export>constructor</dfn>(|configuration|)
 method steps are:
 
-1. Let |valid| be the return value of [=set a config|Set=] |config| on [=this=].
-1. If not |valid|, throw a {{TypeError}1. If not |valid|, throw a {{TypeError}}}
+1. Let |valid| be the return value of [=set a config|setting=] |configuration| on [=this=].
+1. If |valid| is false, then throw a {{TypeError}}.
 
 </div>
 
 <div algorithm>
-The <dfn for="Sanitizer" export>get</dfn>() method steps are:
-
-1. Return the value of [=this=]'s [=internal slot=].
-
+The <dfn for="Sanitizer" export>get</dfn>() method steps are to return the value of [=this=]'s [=Sanitizer/configuration=].
 </div>
 
 <div algorithm>
-The <dfn for="Sanitizer" export>allowElement</dfn>(|element|) method steps are:
-
-1. Let |name| be the result of [=canonicalize a sanitizer name=] |element| with [=HTML namespace=] as the default namespace.
-1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}}.
-1. [=list/Append=] |name| to [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}}.
-1. [=list/iterate|For each=] |attr| in
-    |element|[{{SanitizerElementNamespaceWithAttributes/attributes}}],
-    [=SanitizerConfig/add=] |attr| to [=this=]'s [=internal slot=]'s
-    {{SanitizerConfig/elements}}[|name|][{{SanitizerElementNamespaceWithAttributes/attributes}}].
-1. [=list/iterate|For each=] |attr| in
-    |element|[{{SanitizerElementNamespaceWithAttributes/removeAttributes}}],
-    [=SanitizerConfig/add=] |attr| to [=this=]'s [=internal slot=]'s
-    {{SanitizerConfig/elements}}[|name|][{{SanitizerElementNamespaceWithAttributes/removeAttributes}}].
-1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeElements}}.
-1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s
-   {{SanitizerConfig/replaceWithChildrenElements}}.
-
-NOTE: Handling of [=allowElement=] is a little more complicated than the other
-    methods, because the element allow list can have per-element allow- and
-    remove-attribute lists. We first remove the given element from the list
-    before then adding it, which has the effect of re-setting (rather than
-    merging or elsehow modifying) the per-element list to whatever is passed
-    in. In other words, the per-element allow- and remove-lists can only be
-    set as a whole.
-
-</div>
-
-
+The <dfn for="Sanitizer" export>allowElement</dfn>(|element|) method steps are to [=allow an element=] with |element| and [=this=]'s [=Sanitizer/configuration=].
 </div>
 
 <div algorithm>
-The <dfn for="Sanitizer" export>removeElement</dfn>(|element|) method steps are:
+The <dfn for="Sanitizer" export>removeElement</dfn>(|element|) method steps are
+to [=remove an element=] with |element| and [=this=]'s [=Sanitizer/configuration=].
+</div>
 
-1. Let |name| be the result of [=canonicalize a sanitizer name=] |element| with [=HTML namespace=] as the default namespace.
-1. [=SanitizerConfig/Add=] |name| to [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeElements}}.
-1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}} list.
-1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s
-   {{SanitizerConfig/replaceWithChildrenElements}}.
+<div algorithm>
+The <dfn for="Sanitizer" export>replaceWithChildrenElement</dfn>(|element|) method steps are to [=replace an element=] with |element| and [=this=]'s [=Sanitizer/configuration=].
+</div>
 
+<div algorithm>
+The <dfn for="Sanitizer" export>allowAttribute</dfn>(|attribute|) method steps are to [=allow an attribute=] with |attribute| and [=this=]'s [=Sanitizer/configuration=].
 </div>
 
 
 <div algorithm>
-The <dfn for="Sanitizer" export>replaceWithChildrenElement</dfn>(|element|) method steps are:
-
-1. Let |name| be the result of [=canonicalize a sanitizer name=] |element| with [=HTML namespace=] as the default namespace.
-1. [=SanitizerConfig/Add=] |name| to [=this=]'s [=internal slot=]'s
-   {{SanitizerConfig/replaceWithChildrenElements}}.
-1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeElements}}.
-1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}} list.
-
+The <dfn for="Sanitizer" export>removeAttribute</dfn>(|attribute|) method steps are to [=Sanitizer/remove an attribute=] with |attribute| and [=this=]'s [=Sanitizer/configuration=].
 </div>
 
 <div algorithm>
-The <dfn for="Sanitizer" export>allowAttribute</dfn>(|attribute|) method steps are:
-
-1. Let |name| be the result of [=canonicalize a sanitizer name=] |attribute| with the `null` as the default namespace.
-1. [=SanitizerConfig/Add=] |name| to [=this=]'s [=internal slot=]'s
-   {{SanitizerConfig/attributes}}.
-1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeAttributes}}.
-
+The <dfn for="Sanitizer" export>setComment</dfn>(|allow|) method steps to [=allow comments=] with |allow| and [=this=]'s [=Sanitizer/configuration=].
 </div>
 
 <div algorithm>
-The <dfn for="Sanitizer" export>removeAttribute</dfn>(|attribute|) method steps are:
-
-1. Let |name| be the result of [=canonicalize a sanitizer name=] |attribute| with the `null` as the default namespace.
-1. [=SanitizerConfig/Add=] |name| to [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeAttributes}}.
-1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s
-   {{SanitizerConfig/attributes}}.
-
+The <dfn for="Sanitizer" export>setDataAttributes</dfn>(|allow|) method steps are to [=allow data attributes=] with |allow| and [=this=]'s [=Sanitizer/configuration=].
 </div>
 
 <div algorithm>
-The <dfn for="Sanitizer" export>setComment</dfn>(|allow|) method steps are:
-
-1. Set [=this=]'s [=internal slot=]'s {{SanitizerConfig/comments}} to |allow|.
-
-</div>
-
-<div algorithm>
-The <dfn for="Sanitizer" export>setDataAttributes</dfn>(|allow|) method steps are:
-
-1. Set [=this=]'s [=internal slot=]'s {{SanitizerConfig/dataAttributes}} to |allow|.
-
-</div>
-
-<div algorithm>
-The <dfn for="Sanitizer" export>removeUnsafe</dfn>() method steps are:
-
-1. Update [=this=]'s [=internal slot=] with the result of calling [=remove unsafe=]
-    on [=this=]'s [=internal slot=].
-
+The <dfn for="Sanitizer" export>removeUnsafe</dfn>() method steps are to
+update [=this=]'s [=Sanitizer/configuration=] with the result of calling [=remove unsafe=]
+on [=this=]'s [=Sanitizer/configuration=].
 </div>
 
 ## The Configuration Dictionary ## {#config}
@@ -417,8 +350,6 @@ dictionary SanitizerConfig {
   boolean dataAttributes;
 };
 </pre>
-
-ISSUE: Sould members be required, or have declared defaults?
 
 # Algorithms # {#algorithms}
 
@@ -461,18 +392,18 @@ an options dictionary |options|, do:
 
 <div algorithm>
 For the main <dfn>sanitize</dfn> operation, using a {{ParentNode}} |node|, a
-{{Sanitizer}} |sanitizer| and a [=boolean=] |safe|, run these steps:
+{{Sanitizer}} |sanitizer|, and a [=boolean=] |safe|, run these steps:
 
-1. Let |config| be the value of |sanitizer|'s [=internal slot=].
-1. If |safe|, let |config| be the result of calling [=remove unsafe=] on |config|.
-1. Call [=sanitize core=] on |node|, |config|, and |safe| (as value for
+1. Let |configuration| be the value of |sanitizer|'s [=Sanitizer/configuration=].
+1. If |safe| is true, then set |configuration| to the result of calling [=remove unsafe=] on |configuration|.
+1. Call [=sanitize core=] on |node|, |configuration|, and |safe| (as value for
     handling javascript navigation urls).
 
 </div>
 
 <div algorithm>
 The <dfn>sanitize core</dfn> operation,
-using a {{ParentNode}} |node|, a {{SanitizerConfig}} |config|, and a
+using a {{ParentNode}} |node|, a {{SanitizerConfig}} |configuration|, and a
 [=boolean=] |handle javascript navigation urls|, iterates over the DOM tree
 beginning with |node|, and may recurse to handle some special cases (e.g.
 template contents). It consistes of these steps:
@@ -488,50 +419,129 @@ template contents). It consistes of these steps:
   1. If |child| [=implements=] {{Text}}:
     1. [=continue=].
   1. else if |child| [=implements=] {{Comment}}:
-    1. If |config|'s {{SanitizerConfig/comments}} is not true:
+    1. If |configuration|["{{SanitizerConfig/comments}}"] is not true:
       1. [=/remove=] |child|.
   1. else:
     1. Let |elementName| be a {{SanitizerElementNamespace}} with |child|'s
        [=Element/local name=] and [=Element/namespace=].
-    1. If |config|["{{SanitizerConfig/removeElements}}"] [=SanitizerConfig/contains=] |elementName|, or if |config|["{{SanitizerConfig/elements}}"] is not [=list/empty=] and does not [=SanitizerConfig/contain=] |elementName|:
+    1. If |configuration|["{{SanitizerConfig/removeElements}}"] [=SanitizerConfig/contains=] |elementName|, or if |configuration|["{{SanitizerConfig/elements}}"] is not [=list/empty=] and does not [=SanitizerConfig/contain=] |elementName|:
        1. [=/remove=] |child|.
-    1. If |config|["{{SanitizerConfig/replaceWithChildrenElements}}"] [=SanitizerConfig/contains=] |elementName|:
-      1. Call [=sanitize core=] on |child| with |config| and
+    1. If |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"] [=SanitizerConfig/contains=] |elementName|:
+      1. Call [=sanitize core=] on |child| with |configuration| and
           |handle javascript navigation urls|.
       1. Call [=replace all=] with |child|'s [=tree/children=] within |child|.
     1. If |elementName| [=equals=] &laquo;[ "`name`" &rightarrow; "`template`",
        "`namespace`" &rightarrow; [=HTML namespace=] ]&raquo;
       1. Then call [=sanitize core=] on |child|'s [=template contents=] with
-          |config| and |handle javascript navigation urls|.
+          |configuration| and |handle javascript navigation urls|.
     1. If |child| is a [=shadow host=]:
       1. Then call [=sanitize core=] on |child|'s [=Element/shadow root=] with
-          |config| and |handle javascript navigation urls|.
-    1. [=list/iterate|For each=] |attr| in |child|'s [=Element/attribute list=]:
-      1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attr|'s
+          |configuration| and |handle javascript navigation urls|.
+    1. [=list/iterate|For each=] |attribute| in |child|'s [=Element/attribute list=]:
+      1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
          [=Attr/local name=] and [=Attr/namespace=].
-      1. If |config|["{{SanitizerConfig/removeAttributes}}"]
+      1. If |configuration|["{{SanitizerConfig/removeAttributes}}"]
            [=SanitizerConfig/contains=] |attrName|:
-         1. Remove |attr| from |child|.
-      1. If |config|["{{SanitizerConfig/elements}}"]["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
+         1. Remove |attribute| from |child|.
+      1. If |configuration|["{{SanitizerConfig/elements}}"]["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
            [=SanitizerConfig/contains=] |attrName|:
-         1. Remove |attr| from |child|.
+         1. Remove |attribute| from |child|.
 
-      1. If all of the following are false, then remove |attr| from |child|.
-         - |config|["{{SanitizerConfig/attributes}}"] [=list/exists=] and 
+      1. If all of the following are false, then remove |attribute| from |child|.
+         - |configuration|["{{SanitizerConfig/attributes}}"] [=list/exists=] and
            [=SanitizerConfig/contains=] |attrName|
-         - |config|["{{SanitizerConfig/elements}}"]["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
+         - |configuration|["{{SanitizerConfig/elements}}"]["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
            [=SanitizerConfig/contains=] |attrName|
          - "data-" is a [=code unit prefix=] of [=Attr/local name=] and
             [=Attr/namespace=] is `null` and
-            |config|["{{SanitizerConfig/dataAttributes}}"] is true
+            |configuration|["{{SanitizerConfig/dataAttributes}}"] is true
       1. If |handle javascript navigation urls| and &laquo;[|elementName|, |attrName|]&raquo; matches an entry in the
-         [=navigating URL attributes list=], and if |attr|'s [=protocol=] is
+         [=navigating URL attributes list=], and if |attribute|'s [=protocol=] is
          "`javascript:`":
-         1. Then remove |attr| from |child|.
+         1. Then remove |attribute| from |child|.
 
 </div>
 
 ## Configuration Processing ## {#configuration-processing}
+
+<div algorithm>
+To <dfn for="SanitizerConfig">allow an element</dfn> |element| with a {{SanitizerConfig}} |configuration|, do:
+
+1. Let |name| be the result of [=canonicalize a sanitizer name=] |element| with [=HTML namespace=] as the default namespace.
+1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/elements}}"].
+1. [=list/Append=] |name| to |configuration|["{{SanitizerConfig/elements}}"].
+1. [=list/iterate|For each=] |attribute| in
+    |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"],
+    [=SanitizerConfig/add=] |attribute| to
+    |configuration|["{{SanitizerConfig/elements}}"][|name|]["{{SanitizerElementNamespaceWithAttributes/attributes}}"].
+1. [=list/iterate|For each=] |attribute| in
+    |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"],
+    [=SanitizerConfig/add=] |attribute| to
+    |configuration|["{{SanitizerConfig/elements}}"][|name|]["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"].
+1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/removeElements}}"].
+1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"].
+
+NOTE: Handling of [=allowElement=] is a little more complicated than the other
+    methods, because the element allow list can have per-element allow- and
+    remove-attribute lists. We first remove the given element from the list
+    before then adding it, which has the effect of re-setting (rather than
+    merging or elsehow modifying) the per-element list to whatever is passed
+    in. In other words, the per-element allow- and remove-lists can only be
+    set as a whole.
+
+</div>
+
+<div algorithm>
+To <dfn for="Sanitizer">remove an element</dfn> |element| from a {{SanitizerConfig}} |configuration|, do:
+
+1. Let |name| be the result of [=canonicalize a sanitizer name=] |element| with [=HTML namespace=] as the default namespace.
+1. [=SanitizerConfig/Add=] |name| to |configuration|["{{SanitizerConfig/removeElements}}"].
+1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/elements}}"] list.
+1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"].
+
+</div>
+
+<div algorithm>
+To <dfn for="Sanitizer">replace an element</dfn> |element| from a {{SanitizerConfig}} |configuration|, do:
+
+1. Let |name| be the result of [=canonicalize a sanitizer name=] |element| with [=HTML namespace=] as the default namespace.
+1. [=SanitizerConfig/Add=] |name| to |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"].
+1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/removeElements}}"].
+1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/elements}}"] list.
+
+</div>
+
+<div algorithm>
+To <dfn for="Sanitizer">allow an attribute</dfn> |attribute| on a {{SanitizerConfig}} |configuration|, do:
+
+1. Let |name| be the result of [=canonicalize a sanitizer name=] |attribute| with the `null` as the default namespace.
+1. [=SanitizerConfig/Add=] |name| to |configuration|["{{SanitizerConfig/attributes}}"].
+1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/removeAttributes}}"].
+
+</div>
+
+<div algorithm>
+To <dfn for="Sanitizer">remove an attribute</dfn> |attribute| from a {{SanitizerConfig}} |configuration|, do:
+
+1. Let |name| be the result of [=canonicalize a sanitizer name=] |attribute| with the `null` as the default namespace.
+1. [=SanitizerConfig/Add=] |name| to |configuration|["{{SanitizerConfig/removeAttributes}}"].
+1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/attributes}}"].
+
+</div>
+
+<div algorithm>
+To <dfn for="Sanitizer">allow comments</dfn> with |allow| on a {{SanitizerConfig}} |configuration|, do:
+
+1. Set |configuration|["{{SanitizerConfig/comments}}"] to |allow|.
+
+</div>
+
+<div algorithm>
+To <dfn for="Sanitizer">allow data attributes</dfn> with |allow| on a {{SanitizerConfig}} |configuration|, do:
+
+1. Set |configuration|["{{SanitizerConfig/dataAttributes}}"] to |allow|.
+
+</div>
 
 <div algorithm>
 
@@ -541,56 +551,56 @@ Note: While this algorithm is called [=remove unsafe=], we use
     execute JavaScript when inserted into the document. In other words, this
     method will remove oportunities for XSS.
 
-To <dfn for="SanitizerConfig">remove unsafe</dfn> from a |config|, do this:
+To <dfn for="SanitizerConfig">remove unsafe</dfn> from a |configuration|, do this:
 
 1. [=Assert=]: The [=built-in safe baseline config=] has
    {{SanitizerConfig/removeElements}} and {{SanitizerConfig/removeAttributes}}
    keys set, but not {{SanitizerConfig/elements}},
    {{SanitizerConfig/replaceWithChildrenElements}}, or
    {{SanitizerConfig/attributes}}.
-1. Let |result| be a copy of |config|.
-1. [=list/For each=] |elem| in
+1. Let |result| be a copy of |configuration|.
+1. [=list/For each=] |element| in
    [=built-in safe baseline config=][{{SanitizerConfig/removeElements}}]:
-    1. Call |result|.{{Sanitizer/removeElement()|removeElement}}(|elem|)
-1. [=list/For each=] |attr| in
+    1. Call [=remove an element=] with |element| and |result|.
+1. [=list/For each=] |attribute| in
    [=built-in safe baseline config=][{{SanitizerConfig/removeAttributes}}]:
-    1. Call |result|.{{Sanitizer/removeAttribute()|removeAttribute}}(|attr|)
+    1. Call [=Sanitizer/remove an attribute=] with |attribute| and |result|.
 1. Return |result|.
 
 </div>
 
 <div algorithm>
-To <dfn for="Sanitizer">set a config</dfn> |config| on a {{Sanitizer}} |sanitizer|, do this:
+To <dfn for="Sanitizer">set a config</dfn> |configuration| on a {{Sanitizer}} |sanitizer|, do this:
 
-1. [=Assert=]: |config| is a [=dictionary=].
-1. [=list/iterate|For each=] |item| of |config|[{{SanitizerConfig/elements}}] do:
-  1. Call |sanitizer|.{{Sanitizer/allowElement()|allowElement}}(|item|).
-1. [=list/iterate|For each=] |item| of |config|[{{SanitizerConfig/removeElements}}] do:
-  1. Call |sanitizer|.{{Sanitizer/removeElement()|removeElement}}(|item|).
-1. [=list/iterate|For each=] |item| of |config|[{{SanitizerConfig/replaceWithChildrenElements}}] do:
-  1. Call |sanitizer|.{{Sanitizer/replaceWithChildrenElement()|replaceWithChildrenElement}}(|item|).
-1. [=list/iterate|For each=] |item| of |config|[{{SanitizerConfig/attributes}}] do:
-  1. Call |sanitizer|.{{Sanitizer/allowAttribute()|allowAttribute}}(|item|).
-1. [=list/iterate|For each=] |item| of |config|[{{SanitizerConfig/removeAttributes}}] do:
-  1. Call |sanitizer|.{{Sanitizer/removeAttribute()|removeAttribute}}(|item|).
-1. Call |sanitizer|.{{Sanitizer/setComment()|setComment}}(|config|[{{SanitizerConfig/comments}}]).
-1. Call |sanitizer|.{{Sanitizer/setDataAttributes()|setDataAttributes}}(|config|[{{SanitizerConfig/dataAttributes}}]).
+1. [=Assert=]: |configuration| is a [=dictionary=].
+1. [=list/iterate|For each=] |element| of |configuration|["{{SanitizerConfig/elements}}"] do:
+  1. Call [=allow an element=] with |element| and |sanitizer|.
+1. [=list/iterate|For each=] |element| of |configuration|["{{SanitizerConfig/removeElements}}"] do:
+  1. Call [=remove an element=] with |element| and |sanitizer|.
+1. [=list/iterate|For each=] |element| of |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"] do:
+  1. Call [=replace an element=] with |element| and |sanitizer|.
+1. [=list/iterate|For each=] |attribute| of |configuration|["{{SanitizerConfig/attributes}}"] do:
+  1. Call [=allow an attribute=] with |attribute| and |sanitizer|.
+1. [=list/iterate|For each=] |attribute| of |configuration|["{{SanitizerConfig/removeAttributes}}"] do:
+  1. Call [=Sanitizer/remove an attribute=] with |attribute| and |sanitizer|.
+1. Call [=allow comments=] with |configuration|["{{SanitizerConfig/comments}}"] and |sanitizer|.
+1. Call [=allow data attributes=] with |configuration|["{{SanitizerConfig/dataAttributes}}"] and |sanitizer|.
 1. Return whether all of the following are true:
-    - [=list/size=] of |config|[{{SanitizerConfig/elements}}] equals
-      [=list/size=] of [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}}.
-    - [=list/size=] of |config|[{{SanitizerConfig/removeElements}}] equals
-      [=list/size=] of [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeElements}}.
-    - [=list/size=] of |config|[{{SanitizerConfig/replaceWithChildrenElements}}] equals
-      [=list/size=] of [=this=]'s [=internal slot=]'s {{SanitizerConfig/replaceWithChildrenElements}}.
-    - [=list/size=] of |config|[{{SanitizerConfig/attributes}}] equals
-      [=list/size=] of [=this=]'s [=internal slot=]'s {{SanitizerConfig/attributes}}.
-    - [=list/size=] of |config|[{{SanitizerConfig/removeAttributes}}] equals
-      [=list/size=] of [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeAttributes}}.
-    - Either |config|[{{SanitizerConfig/elements}}] or
-      |config|[{{SanitizerConfig/removeElements}}] [=map/exist=],
+    - [=list/size=] of |configuration|["{{SanitizerConfig/elements}}"] equals
+      [=list/size=] of [=this=]'s [=Sanitizer/configuration=]["{{SanitizerConfig/elements}}"].
+    - [=list/size=] of |configuration|["{{SanitizerConfig/removeElements}}"] equals
+      [=list/size=] of [=this=]'s [=Sanitizer/configuration=]["{{SanitizerConfig/removeElements}}"].
+    - [=list/size=] of |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"] equals
+      [=list/size=] of [=this=]'s [=Sanitizer/configuration=]["{{SanitizerConfig/replaceWithChildrenElements}}"].
+    - [=list/size=] of |configuration|["{{SanitizerConfig/attributes}}"] equals
+      [=list/size=] of [=this=]'s [=Sanitizer/configuration=]["{{SanitizerConfig/attributes}}"].
+    - [=list/size=] of |configuration|["{{SanitizerConfig/removeAttributes}}"] equals
+      [=list/size=] of [=this=]'s [=Sanitizer/configuration=]["{{SanitizerConfig/removeAttributes}}"].
+    - Either |configuration|["{{SanitizerConfig/elements}}"] or
+      |configuration|["{{SanitizerConfig/removeElements}}"] [=map/exist=],
       or neither, but not both.
-    - Either |config|[{{SanitizerConfig/attributes}}] or
-      |config|[{{SanitizerConfig/removeAttributes}}] [=map/exist=],
+    - Either |configuration|["{{SanitizerConfig/attributes}}"] or
+      |configuration|["{{SanitizerConfig/removeAttributes}}"] [=map/exist=],
       or neither, but not both.
 
 Note: Previous versions of this spec had elaborate definitions of how to
@@ -645,7 +655,13 @@ A Sanitizer name |list| <dfn for="SanitizerConfig">contains</dfn> an |item|
 if there exists an |entry| of |list| that is an [=ordered map=], and where
 |item|["name"] [=equals=] |entry|["name"] and
 |item|["namespace"] [=equals=] |entry|["namespace"].
+</div>
 
+<div algorithm>
+To <dfn for="SanitizerConfig">remove</dfn> an |item| from a |list| that is an
+[=ordered map=], [=list/remove=] all |entry| from |list|
+where |item|["name"] [=equals=] |entry|["name"] and
+|item|["namespace"] [=equals=] |entry|["namespace"].
 </div>
 
 <div algorithm>
@@ -653,7 +669,6 @@ Equality for [=ordered sets=] is equality of its members, but without
 regard to order:
 [=Ordered sets=] |A| and |B| are <dfn for=set>equal</dfn> if both |A| is a
 [=superset=] of |B| and |B| is a [=superset=] of |A|.
-
 </div>
 
 ## Defaults ## {#sanitization-defaults}
@@ -667,7 +682,7 @@ There are four builtins:
 
 The <dfn>built-in safe default config</dfn> is the same as the [=built-in safe baseline config=].
 
-ISSUE: Determine if this actually holds.
+ISSUE(233): Determine if this actually holds.
 
 
 The <dfn>built-in unsafe default config</dfn> is meant to allow anything.

--- a/index.bs
+++ b/index.bs
@@ -247,10 +247,10 @@ interface Sanitizer {
   // Modify a Sanitizer's lists and fields:
   undefined allowElement(SanitizerElementWithAttributes element);
   undefined removeElement(SanitizerElement element);
-  undefined replaceWithChildrenElement(SanitizerElement element);
+  undefined replaceElementWithChildren(SanitizerElement element);
   undefined allowAttribute(SanitizerAttribute attribute);
   undefined removeAttribute(SanitizerAttribute attribute);
-  undefined setComment(boolean allow);
+  undefined setComments(boolean allow);
   undefined setDataAttributes(boolean allow);
 
   // Remove markup that executes script. May modify multiple lists:
@@ -259,12 +259,6 @@ interface Sanitizer {
 </pre>
 
 A {{Sanitizer}} has an associated <dfn for="Sanitizer">configuration</dfn>, a {{SanitizerConfig}}.
-
-ISSUE(238): Final naming TBD.
-
-ISSUE(242): Should the modifier methods return a reference to [=this=], so
-    that you can 'chain' methods?
-    (e.g. `sanitizer.allowElement("a").allowElement("span")`).
 
 <div algorithm>
 The <dfn for="Sanitizer" export>constructor</dfn>(|configuration|)
@@ -289,7 +283,7 @@ to [=remove an element=] with |element| and [=this=]'s [=Sanitizer/configuration
 </div>
 
 <div algorithm>
-The <dfn for="Sanitizer" export>replaceWithChildrenElement</dfn>(|element|) method steps are to [=replace an element=] with |element| and [=this=]'s [=Sanitizer/configuration=].
+The <dfn for="Sanitizer" export>replaceElementWithChildren</dfn>(|element|) method steps are to [=replace an element=] with |element| and [=this=]'s [=Sanitizer/configuration=].
 </div>
 
 <div algorithm>
@@ -302,7 +296,7 @@ The <dfn for="Sanitizer" export>removeAttribute</dfn>(|attribute|) method steps 
 </div>
 
 <div algorithm>
-The <dfn for="Sanitizer" export>setComment</dfn>(|allow|) method steps to [=allow comments=] with |allow| and [=this=]'s [=Sanitizer/configuration=].
+The <dfn for="Sanitizer" export>setComments</dfn>(|allow|) method steps to [=allow comments=] with |allow| and [=this=]'s [=Sanitizer/configuration=].
 </div>
 
 <div algorithm>
@@ -467,19 +461,11 @@ template contents). It consistes of these steps:
 <div algorithm>
 To <dfn for="SanitizerConfig">allow an element</dfn> |element| with a {{SanitizerConfig}} |configuration|, do:
 
-1. Let |name| be the result of [=canonicalize a sanitizer name=] |element| with [=HTML namespace=] as the default namespace.
-1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/elements}}"].
-1. [=list/Append=] |name| to |configuration|["{{SanitizerConfig/elements}}"].
-1. [=list/iterate|For each=] |attribute| in
-    |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"],
-    [=SanitizerConfig/add=] |attribute| to
-    |configuration|["{{SanitizerConfig/elements}}"][|name|]["{{SanitizerElementNamespaceWithAttributes/attributes}}"].
-1. [=list/iterate|For each=] |attribute| in
-    |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"],
-    [=SanitizerConfig/add=] |attribute| to
-    |configuration|["{{SanitizerConfig/elements}}"][|name|]["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"].
-1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/removeElements}}"].
-1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"].
+1. Set |element| to the result of [=canonicalize a sanitizer element with attributes=] with |element|.
+1. [=SanitizerConfig/Remove=] |element| from |configuration|["{{SanitizerConfig/elements}}"].
+1. [=list/Append=] |element| to |configuration|["{{SanitizerConfig/elements}}"].
+1. [=SanitizerConfig/Remove=] |element| from |configuration|["{{SanitizerConfig/removeElements}}"].
+1. [=SanitizerConfig/Remove=] |element| from |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"].
 
 NOTE: Handling of [=allowElement=] is a little more complicated than the other
     methods, because the element allow list can have per-element allow- and
@@ -489,43 +475,47 @@ NOTE: Handling of [=allowElement=] is a little more complicated than the other
     in. In other words, the per-element allow- and remove-lists can only be
     set as a whole.
 
+NOTE: [=SanitizerConfig/Remove=] matches on name and namespace, so adding an
+    element with attributes would still remove the matching element from the
+    {{SanitizerConfig/removeElements}} and {{SanitizerConfig/replaceWithChildrenElements}} lists.
+
 </div>
 
 <div algorithm>
 To <dfn for="Sanitizer">remove an element</dfn> |element| from a {{SanitizerConfig}} |configuration|, do:
 
-1. Let |name| be the result of [=canonicalize a sanitizer name=] |element| with [=HTML namespace=] as the default namespace.
-1. [=SanitizerConfig/Add=] |name| to |configuration|["{{SanitizerConfig/removeElements}}"].
-1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/elements}}"] list.
-1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"].
+1. Set |element| to the result of [=canonicalize a sanitizer element=] with |element|.
+1. [=SanitizerConfig/Add=] |element| to |configuration|["{{SanitizerConfig/removeElements}}"].
+1. [=SanitizerConfig/Remove=] |element| from |configuration|["{{SanitizerConfig/elements}}"] list.
+1. [=SanitizerConfig/Remove=] |element| from |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"].
 
 </div>
 
 <div algorithm>
 To <dfn for="Sanitizer">replace an element</dfn> |element| from a {{SanitizerConfig}} |configuration|, do:
 
-1. Let |name| be the result of [=canonicalize a sanitizer name=] |element| with [=HTML namespace=] as the default namespace.
-1. [=SanitizerConfig/Add=] |name| to |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"].
-1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/removeElements}}"].
-1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/elements}}"] list.
+1. Set |element| to the result of [=canonicalize a sanitizer element=] with |element|.
+1. [=SanitizerConfig/Add=] |element| to |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"].
+1. [=SanitizerConfig/Remove=] |element| from |configuration|["{{SanitizerConfig/removeElements}}"].
+1. [=SanitizerConfig/Remove=] |element| from |configuration|["{{SanitizerConfig/elements}}"] list.
 
 </div>
 
 <div algorithm>
 To <dfn for="Sanitizer">allow an attribute</dfn> |attribute| on a {{SanitizerConfig}} |configuration|, do:
 
-1. Let |name| be the result of [=canonicalize a sanitizer name=] |attribute| with the `null` as the default namespace.
-1. [=SanitizerConfig/Add=] |name| to |configuration|["{{SanitizerConfig/attributes}}"].
-1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/removeAttributes}}"].
+1. Set |attribute| to the result of [=canonicalize a sanitizer attribute=] with |attribute|.
+1. [=SanitizerConfig/Add=] |attribute| to |configuration|["{{SanitizerConfig/attributes}}"].
+1. [=SanitizerConfig/Remove=] |attribute| from |configuration|["{{SanitizerConfig/removeAttributes}}"].
 
 </div>
 
 <div algorithm>
 To <dfn for="Sanitizer">remove an attribute</dfn> |attribute| from a {{SanitizerConfig}} |configuration|, do:
 
-1. Let |name| be the result of [=canonicalize a sanitizer name=] |attribute| with the `null` as the default namespace.
-1. [=SanitizerConfig/Add=] |name| to |configuration|["{{SanitizerConfig/removeAttributes}}"].
-1. [=SanitizerConfig/Remove=] |name| from |configuration|["{{SanitizerConfig/attributes}}"].
+1. Set |attribute| to the result of [=canonicalize a sanitizer attribute=] with |attribute|.
+1. [=SanitizerConfig/Add=] |attribute| to |configuration|["{{SanitizerConfig/removeAttributes}}"].
+1. [=SanitizerConfig/Remove=] |attribute| from |configuration|["{{SanitizerConfig/attributes}}"].
 
 </div>
 
@@ -621,6 +611,34 @@ Issue: This is still missing error checks for the per-element attribute lists
 </div>
 
 <div algorithm>
+In order to <dfn>canonicalize a sanitizer element with attributes</dfn> a {{SanitizerElementWithAttributes}} |element|, do this:
+
+1. Let |result| be the result of [=canonicalize a sanitizer element=] with |element|.
+1. If |element| is a [=dictionary=]:
+   1. [=list/iterate|For each=] |attribute| in
+      |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]:
+      1. [=SanitizerConfig/Add=] the result of [=canonicalize a sanitizer attribute=] with |attribute| to |result|["{{SanitizerElementNamespaceWithAttributes/attributes}}"].
+   1. [=list/iterate|For each=] |attribute| in
+      |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]:
+      1. [=SanitizerConfig/Add=] the result of [=canonicalize a sanitizer attribute=] with |attribute| to |result|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"].
+1. Return |result|.
+
+</div>
+
+
+<div algorithm>
+In order to <dfn>canonicalize a sanitizer element</dfn> a
+{{SanitizerElement}} |element|,
+return the result of [=canonicalize a sanitizer name=] with |element| and the [=HTML namespace=] as the default namespace.
+</div>
+
+<div algorithm>
+In order to <dfn>canonicalize a sanitizer attribute</dfn> a
+{{SanitizerAttribute}} |attribute|, 
+return the result of [=canonicalize a sanitizer name=] with |attribute| and `null` as the default namespace.
+</div>
+
+<div algorithm>
 In order to <dfn>canonicalize a sanitizer name</dfn> |name|, with a default
 namespace |defaultNamespace|, run the following steps:
 
@@ -631,15 +649,6 @@ namespace |defaultNamespace|, run the following steps:
   "`name`" &rightarrow; |name|["name"], <br>
   "`namespace`" &rightarrow; ( |name|["namespace"] if it [=map/exists=], otherwise |defaultNamespace| ) <br>
   ]&raquo;.
-
-</div>
-
-<div algorithm>
-To <dfn for="SanitizerConfig">add</dfn> a |name| to a |list|, where |name| is
-[=canonicalize a sanitizer name|canonicalized=] and |list| is an [=ordered map=]:
-
-1. If |list| [=SanitizerConfig/contains=] |name|, then return.
-1. [=list/Append=] |name| to |list|.
 
 </div>
 
@@ -662,6 +671,15 @@ To <dfn for="SanitizerConfig">remove</dfn> an |item| from a |list| that is an
 [=ordered map=], [=list/remove=] all |entry| from |list|
 where |item|["name"] [=equals=] |entry|["name"] and
 |item|["namespace"] [=equals=] |entry|["namespace"].
+</div>
+
+<div algorithm>
+To <dfn for="SanitizerConfig">add</dfn> a |name| to a |list|, where |name| is
+[=canonicalize a sanitizer name|canonicalized=] and |list| is an [=ordered map=]:
+
+1. If |list| [=SanitizerConfig/contains=] |name|, then return.
+1. [=list/Append=] |name| to |list|.
+
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -195,7 +195,7 @@ The <dfn for="Document" export>parseHTMLUnsafe</dfn>(|html|, |options|) method s
 1. [=Parse HTML from a string=] given |document| and |compliantHTML|.
 1. Let |sanitizer| be the result of calling [=get a sanitizer instance from options=]
    with |options|.
-1. Call [=sanitize=] on |document|'s [=tree/root|root node=] with |sanitizer|.
+1. Call [=sanitize=] on |document|'s [=tree/root|root node=] with |sanitizer| and false.
 1. Return |document|.
 
 </div>
@@ -211,7 +211,7 @@ The <dfn for="Document" export>parseHTML</dfn>(|html|, |options|) method steps a
 1. [=Parse HTML from a string=] given |document| and |html|.
 1. Let |sanitizer| be the result of calling [=get a sanitizer instance from options=]
    with |options|.
-1. Call [=sanitize=] on |document|'s [=tree/root|root node=] with |sanitizer|.
+1. Call [=sanitize=] on |document|'s [=tree/root|root node=] with |sanitizer| and true.
 1. Return |document|.
 
 </div>
@@ -228,37 +228,44 @@ dictionary SetHTMLOptions {
 </pre>
 
 The {{Sanitizer}} configuration object encapsulates a filter configuration.
-The same config can be used with both safe or unsafe methods. The intent is
+The same config can be used with both safe or unsafe methods, where the safe
+methods perform an implicit {{removeUnsafe}} operation. The intent is
 that one (or a few) configurations will be built-up early on in a page's
 lifetime, and can then be used whenever needed. This allows implementations
 to pre-process configurations.
 
-The configuration object is also query-able and can return
-configuration dictionaries,
-in both safe and unsafe variants. This allows a
-page to query and predict what effect a given configuration will have, or
-to build a new configuration based on an existing one.
+The configuration object can be queried to return a configuration dictionary.
+It can also be modified directly.
 
 <pre class=idl>
 [Exposed=(Window,Worker)]
 interface Sanitizer {
   constructor(optional SanitizerConfig config = {});
 
-  // Query configurations:
+  // Query configuration:
   SanitizerConfig get();
-  SanitizerConfig getUnsafe();
 
-  // Modifying a Sanitizer:
-  undefined element(SanitizerElementNamespaceWithAttributes element);
+  // Modify a Sanitizer's lists and fields:
+  undefined allowElement(SanitizerElementNamespaceWithAttributes element);
   undefined removeElement(SanitizerElement element);
-  undefined replaceWithChildren(SanitizerElement element);
+  undefined replaceWithChildrenElement(SanitizerElement element);
   undefined allowAttribute(SanitizerAttribute attribute);
   undefined removeAttribute(SanitizerAttribute attribute);
   undefined setComment(boolean allow);
   undefined setDataAttributes(boolean allow);
   undefined setOtherMarkup(boolean allow);
+
+  // Remove markup that executes script. May modify multiple lists:
+  undefined removeUnsafe();
 };
 </pre>
+
+ISSUE(238): Final naming TBD.
+
+ISSUE(240): "other markup" TBD.
+
+ISSUE: Should these be setter methods -- particularly the setXXX(boolean) --
+    or setters or properties or somesuch?
 
 <div algorithm>
 The <dfn for="Sanitizer" export>constructor</dfn>(|config|)
@@ -274,50 +281,42 @@ Issue: This abandons all error handling, because setting a config will
 <div algorithm>
 The <dfn for="Sanitizer" export>get</dfn>() method steps are:
 
-1. Return the result of calling [=safeify=] on the result of
-   [=Sanitizer/getUnsafe=].
-
-</div>
-
-<div algorithm>
-The <dfn for="Sanitizer" export>getUnsafe</dfn>() method steps are:
-
 1. Return the value of [=this=]'s [=internal slot=].
 
 </div>
 
 <div algorithm>
-The <dfn for="Sanitizer" export>element</dfn>(|element|) method steps are:
+The <dfn for="Sanitizer" export>allowElement</dfn>(|element|) method steps are:
 
 1. Let |name| be the result of [=canonicalize a sanitizer name=] |element| with [=HTML namespace=] as the default namespace.
-1. [=list/Append=] |name| to [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}} list.
+1. [=SanitizerConfig/Add=] |name| to [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}}.
+1. [=Merge attribute lists=] of |element| to [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}}.
 1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeElements}}.
-1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s 
+1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s
    {{SanitizerConfig/replaceWithChildrenElements}}.
 
-ISSUE: This does not handle per-element attribute allow/remove lists.
 </div>
 
 <div algorithm>
 The <dfn for="Sanitizer" export>removeElement</dfn>(|element|) method steps are:
 
 1. Let |name| be the result of [=canonicalize a sanitizer name=] |element| with [=HTML namespace=] as the default namespace.
-1. [=list/Append=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeElements}}.
-1. [=list/Remove=] |name| to [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}} list.
-1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s 
+1. [=SanitizerConfig/Add=] |name| to [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeElements}}.
+1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}} list.
+1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s
    {{SanitizerConfig/replaceWithChildrenElements}}.
 
 </div>
 
 
 <div algorithm>
-The <dfn for="Sanitizer" export>replaceWithChildren</dfn>(|element|) method steps are:
+The <dfn for="Sanitizer" export>replaceWithChildrenElement</dfn>(|element|) method steps are:
 
 1. Let |name| be the result of [=canonicalize a sanitizer name=] |element| with [=HTML namespace=] as the default namespace.
-1. [=list/Append=] |name| from [=this=]'s [=internal slot=]'s 
+1. [=SanitizerConfig/Add=] |name| to [=this=]'s [=internal slot=]'s
    {{SanitizerConfig/replaceWithChildrenElements}}.
 1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeElements}}.
-1. [=list/Remove=] |name| to [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}} list.
+1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}} list.
 
 </div>
 
@@ -325,19 +324,18 @@ The <dfn for="Sanitizer" export>replaceWithChildren</dfn>(|element|) method step
 The <dfn for="Sanitizer" export>allowAttribute</dfn>(|attribute|) method steps are:
 
 1. Let |name| be the result of [=canonicalize a sanitizer name=] |attribute| with the `null` as the default namespace.
-1. [=list/Append=] |name| from [=this=]'s [=internal slot=]'s 
+1. [=SanitizerConfig/Add=] |name| to [=this=]'s [=internal slot=]'s
    {{SanitizerConfig/attributes}}.
 1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeAttributes}}.
 
-</div>
 </div>
 
 <div algorithm>
 The <dfn for="Sanitizer" export>removeAttribute</dfn>(|attribute|) method steps are:
 
 1. Let |name| be the result of [=canonicalize a sanitizer name=] |attribute| with the `null` as the default namespace.
-1. [=list/Append=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeAttributes}}.
-1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s 
+1. [=SanitizerConfig/Add=] |name| to [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeAttributes}}.
+1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s
    {{SanitizerConfig/attributes}}.
 
 </div>
@@ -360,6 +358,14 @@ The <dfn for="Sanitizer" export>setDataAttributes</dfn>(|allow|) method steps ar
 The <dfn for="Sanitizer" export>setOtherMarkup</dfn>(|allow|) method steps are:
 
 1. Set [=this=]'s [=internal slot=]'s {{SanitizerConfig/otherMarkup}} to |allow|.
+
+</div>
+
+<div algorithm>
+The <dfn for="Sanitizer" export>removeUnsafe</dfn>() method steps are:
+
+1. Update [=this=]'s [=internal slot=] with the result of calling [=remove unsafe=]
+    on [=this=]'s [=internal slot=].
 
 </div>
 
@@ -426,14 +432,14 @@ To <dfn>set and filter HTML</dfn>, given an {{Element}} or {{DocumentFragment}}
 To <dfn for="SanitizerConfig">get a sanitizer instance from options</dfn> for
 an options dictionary |options|, do:
 
-1. Assert: |options| is a [=dictionary=].
+1. [=Assert=]: |options| is a [=dictionary=].
 1. If |options|["`sanitizer`"] doesn't [=map/exist=],
    then return new {{Sanitizer}}().
-1. Assert: |options|["`sanitizer`"] is either a {{Sanitizer}} instance
+1. [=Assert=]: |options|["`sanitizer`"] is either a {{Sanitizer}} instance
    or a [=dictionary=].
 1. If |options|["`sanitizer`"] is a {{Sanitizer}} instance:
    Then return  |options|["`sanitizer`"].
-1. Assert: |options|["`sanitizer`"] is a [=dictionary=].
+1. [=Assert=]: |options|["`sanitizer`"] is a [=dictionary=].
 1. Return new {{Sanitizer}}(|options|["`sanitizer`"]).
 
 </div>
@@ -445,7 +451,7 @@ For the main <dfn>sanitize</dfn> operation, using a {{ParentNode}} |node|, a
 {{Sanitizer}} |sanitizer| and a [=boolean=] |safe|, run these steps:
 
 1. Let |config| be the value of |sanitizer|'s [=internal slot=].
-1. If |safe|, let |config| be the result of calling [=safeify=] on |config|.
+1. If |safe|, let |config| be the result of calling [=remove unsafe=] on |config|.
 1. Call [=sanitize core=] on |node|, |config|, and |safe| (as value for
     handling javascript navigation urls).
 
@@ -455,7 +461,7 @@ For the main <dfn>sanitize</dfn> operation, using a {{ParentNode}} |node|, a
 The <dfn>sanitize core</dfn> operation,
 using a {{ParentNode}} |node|, a {{SanitizerConfig}} |config|, and a
 [=boolean=] |handle javascript navigation urls|, iterates over the DOM tree
-beginning with |node|, and may recurse to handle some special cases (e.g. 
+beginning with |node|, and may recurse to handle some special cases (e.g.
 template contents). It consistes of these steps:
 
 1. Let |current| be |node|.
@@ -506,7 +512,7 @@ template contents). It consistes of these steps:
             [=Attr/namespace=] is `null` and
             |config|["{{SanitizerConfig/dataAttributes}}"] is true
          - |config|["{{SanitizerConfig/otherMarkup}}"]
-      1. If |handle javascript navigation urls|and &laquo;[|elementName|, |attrName|]&raquo; matches an entry in the
+      1. If |handle javascript navigation urls| and &laquo;[|elementName|, |attrName|]&raquo; matches an entry in the
          [=navigating URL attributes list=], and if |attr|'s [=protocol=] is
          "`javascript:`":
          1. Then remove |attr| from |child|.
@@ -516,7 +522,14 @@ template contents). It consistes of these steps:
 ## Configuration Processing ## {#configuration-processing}
 
 <div algorithm>
-To <dfn for="SanitizerConfig">safeify</dfn> a |config|, do this:
+
+Note: While this algorithm is called [=remove unsafe=], we use
+    <a href="#security-considerations">the term "unsafe" strictly in the sense
+    of this spec</a>, to denote content that will
+    execute JavaScript when inserted into the document. In other words, this
+    method will remove oportunities for XSS.
+
+To <dfn for="SanitizerConfig">remove unsafe</dfn> from a |config|, do this:
 
 1. [=Assert=]: The [=built-in safe baseline config=] has
    {{SanitizerConfig/removeElements}} and {{SanitizerConfig/removeAttributes}}
@@ -526,10 +539,10 @@ To <dfn for="SanitizerConfig">safeify</dfn> a |config|, do this:
 1. Let |result| be a copy of |config|.
 1. [=list/For each=] |elem| in
    [=built-in safe baseline config=][{{SanitizerConfig/removeElements}}]:
-    1. Call |result|.removeElement(|elem|)
+    1. Call |result|.{{Sanitizer/removeElement()|removeElement}}(|elem|)
 1. [=list/For each=] |attr| in
    [=built-in safe baseline config=][{{SanitizerConfig/removeAttributes}}]:
-    1. Call |result|.removeAttributes(|attr|)
+    1. Call |result|.{{Sanitizer/removeAttribute()|removeAttribute}}(|attr|)
 1. Return |result|.
 
 </div>
@@ -539,18 +552,18 @@ To <dfn for="Sanitizer">set a config</dfn> |config| on a {{Sanitizer}} |sanitize
 
 1. [=Assert=]: |config| is a [=dictionary=].
 1. [=list/iterate|For each=] |item| of |config|[{{SanitizerConfig/elements}}] do:
-  1. Call |sanitizer|.element(|item|).
+  1. Call |sanitizer|.{{Sanitizer/allowElement()|allowElement}}(|item|).
 1. [=list/iterate|For each=] |item| of |config|[{{SanitizerConfig/removeElements}}] do:
-  1. Call |sanitizer|.removeElement(|item|).
+  1. Call |sanitizer|.{{Sanitizer/removeElement()|removeElement}}(|item|).
 1. [=list/iterate|For each=] |item| of |config|[{{SanitizerConfig/replaceWithChildrenElements}}] do:
-  1. Call |sanitizer|.replaceWithChildren(|item|).
+  1. Call |sanitizer|.{{Sanitizer/replaceWithChildrenElement()|replaceWithChildrenElement}}(|item|).
 1. [=list/iterate|For each=] |item| of |config|[{{SanitizerConfig/attributes}}] do:
-  1. Call |sanitizer|.attribute(|item|).
+  1. Call |sanitizer|.{{Sanitizer/allowAttribute()|allowAttribute}}(|item|).
 1. [=list/iterate|For each=] |item| of |config|[{{SanitizerConfig/removeAttributes}}] do:
-  1. Call |sanitizer|.removeAttributes(|item|).
-1. Call |sanitizer|.comments(|config|[{{SanitizerConfig/comments}}]).
-1. Call |sanitizer|.dataAttributes(|config|[{{SanitizerConfig/dataAttributes}}]).
-1. Call |sanitizer|.otherMarkup(|config|[{{SanitizerConfig/otherMarkup}}]).
+  1. Call |sanitizer|.{{Sanitizer/removeAttribute()|removeAttribute}}(|item|).
+1. Call |sanitizer|.{{Sanitizer/setComment()|setComment}}(|config|[{{SanitizerConfig/comments}}]).
+1. Call |sanitizer|.{{Sanitizer/setDataAttributes()|setDataAttributes}}(|config|[{{SanitizerConfig/dataAttributes}}]).
+1. Call |sanitizer|.{{Sanitizer/setOtherMarkup()|setOtherMarkup}}(|config|[{{SanitizerConfig/otherMarkup}}]).
 
 Note: Previous versions of this spec had elaborate definitions of how to
   canonicalize a config. This has now effectively been moved into the method
@@ -572,30 +585,44 @@ namespace |defaultNamespace|, run the following steps:
 
 </div>
 
-## Supporting Algorithms ## {#alg-support}
-
 <div algorithm>
-For the [=canonicalize a sanitizer name|canonicalized=]
-{{SanitizerElementNamespace|element}} and {{SanitizerAttributeNamespace|attribute name}} lists
-used in this spec, list membership is based on matching both "`name`" and "`namespace`"
-entries:
-A Sanitizer name |list| <dfn for="SanitizerConfig">contains</dfn> an |item|
-if there exists an |entry| of |list| that is an [=ordered map=], and where
-|item|["name"] [=equals=] |entry|["name"] and
-|item|["namespace"] [=equals=] |entry|["namespace"].
+To <dfn for="SanitizerConfig">add</dfn> a |name| to a |list|, where |name| is
+[=canonicalize a sanitizer name|canonicalized=] and |list| is an [=ordered map=]:
+
+1. If |list| [=SanitizerConfig/contains=] |name|, then return.
+1. [=list/Append=] |name| to |list|.
 
 </div>
 
 <div algorithm>
-Set difference (or set subtraction) is a clone of a set A, but with all members
-removed that occur in a set B:
-To compute the <dfn for="set">difference</dfn> of two [=ordered sets=] |A| and |B|:
+To <dfn for="SanitizerConfig">merge attribute lists</dfn> of an |element| to a
+|list|, run these steps:
 
-1. Let |set| be a new [=ordered set=].
-1. [=list/iterate|For each=] |item| of |A|:
-   1. If |B| does not [=set/contain=] |item|, then [=set/append=] |item|
-      to |set|.
-1. Return |set|.
+1. [=Assert=]: |element| is an {{SanitizerElementNamespaceWithAttributes}}.
+1. [=Assert=]: |list| [=SanitizerConfig/contains=] |element|.
+1. [=list/iterate|For each=] |attr| in
+    |element|[{{SanitizerElementNamespaceWithAttributes/attributes}}],
+    [=SanitizerConfig/add=] |attr| to
+    |list|[|element|][{{SanitizerElementNamespaceWithAttributes/attributes}}].
+1. [=list/iterate|For each=] |attr| in
+    |element|[{{SanitizerElementNamespaceWithAttributes/removeAttributes}}],
+    [=SanitizerConfig/add=] |attr| to
+    |list|[|element|][{{SanitizerElementNamespaceWithAttributes/removeAttributes}}].
+
+</div>
+
+## Supporting Algorithms ## {#alg-support}
+
+For the [=canonicalize a sanitizer name|canonicalized=]
+{{SanitizerElementNamespace|element}} and {{SanitizerAttributeNamespace|attribute name}} lists
+used in this spec, list membership is based on matching both "`name`" and "`namespace`"
+entries:
+
+<div algorithm>
+A Sanitizer name |list| <dfn for="SanitizerConfig">contains</dfn> an |item|
+if there exists an |entry| of |list| that is an [=ordered map=], and where
+|item|["name"] [=equals=] |entry|["name"] and
+|item|["namespace"] [=equals=] |entry|["namespace"].
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -101,9 +101,10 @@ The Sanitizer API offers functionality to parse a string containing HTML into
 a DOM tree, and to filter the resulting tree according to a user-supplied
 configuration. The methods come in two by two flavours:
 
-* Safe and unsafe: The "safe" methods will not generate any markup that executes
-  script. That is, they should be safe from XSS. The "unsafe" methods will parse
-  and filter whatever they're supposed to.
+* <dfn>Safe and unsafe</dfn>: The "safe" methods will not generate any markup that
+  executes script. That is, they should be safe from XSS. The "unsafe" methods
+  will parse and filter whatever they're supposed to.
+  See also: [[#security-considerations]].
 * Context: Methods are defined on {{Element}} and {{ShadowRoot}} and will
   replace these {{Node}}'s children, and are largely analogous to {{Element/innerHTML}}.
   There are also static methods on the {{Document}}, which parse an entire
@@ -227,8 +228,10 @@ dictionary SetHTMLOptions {
 </pre>
 
 The {{Sanitizer}} configuration object encapsulates a filter configuration.
-The same configuration can be used with both safe or unsafe methods, where
-the safe methods perform an implicit {{removeUnsafe}} operation. The intent is
+The same configuration can be used with both <a lt="safe and unsafe">"safe"
+or "unsafe"</a> methods, where the "safe" methods perform an implicit
+{{removeUnsafe}} operation on the passed in configuration and have a default
+configuration when none is passed. The intent is
 that one (or a few) configurations will be built-up early on in a page's
 lifetime, and can then be used whenever needed. This allows implementations
 to pre-process configurations.
@@ -258,6 +261,9 @@ interface Sanitizer {
 };
 </pre>
 
+Note: {{Sanitizer}} will likely get an additional method:
+    <br>`[NewObject] static Sanitizer getDefault();`
+
 A {{Sanitizer}} has an associated <dfn for="Sanitizer">configuration</dfn>, a {{SanitizerConfig}}.
 
 <div algorithm>
@@ -283,7 +289,7 @@ to [=remove an element=] with |element| and [=this=]'s [=Sanitizer/configuration
 </div>
 
 <div algorithm>
-The <dfn for="Sanitizer" export>replaceElementWithChildren</dfn>(|element|) method steps are to [=replace an element=] with |element| and [=this=]'s [=Sanitizer/configuration=].
+The <dfn for="Sanitizer" export>replaceElementWithChildren</dfn>(|element|) method steps are to [=replace an element with its children=] with |element| and [=this=]'s [=Sanitizer/configuration=].
 </div>
 
 <div algorithm>
@@ -296,11 +302,11 @@ The <dfn for="Sanitizer" export>removeAttribute</dfn>(|attribute|) method steps 
 </div>
 
 <div algorithm>
-The <dfn for="Sanitizer" export>setComments</dfn>(|allow|) method steps to [=allow comments=] with |allow| and [=this=]'s [=Sanitizer/configuration=].
+The <dfn for="Sanitizer" export>setComments</dfn>(|allow|) method steps to [=set comments=] with |allow| and [=this=]'s [=Sanitizer/configuration=].
 </div>
 
 <div algorithm>
-The <dfn for="Sanitizer" export>setDataAttributes</dfn>(|allow|) method steps are to [=allow data attributes=] with |allow| and [=this=]'s [=Sanitizer/configuration=].
+The <dfn for="Sanitizer" export>setDataAttributes</dfn>(|allow|) method steps are to [=set data attributes=] with |allow| and [=this=]'s [=Sanitizer/configuration=].
 </div>
 
 <div algorithm>
@@ -371,14 +377,20 @@ To <dfn for="SanitizerConfig">get a sanitizer instance from options</dfn> for
 an options dictionary |options|, do:
 
 1. [=Assert=]: |options| is a [=dictionary=].
-1. If |options|["`sanitizer`"] doesn't [=map/exist=],
-   then return new {{Sanitizer}}().
+1. If |options|["`sanitizer`"] doesn't [=map/exist=], then:
+   1. Let |result| be a new {{Sanitizer}} instance.
+   1. Call [=set a config=] with an empty [=dictionary=] on |result|.
+   1. [=Assert=]: The return value is true.
+   1. Return |result|.
 1. [=Assert=]: |options|["`sanitizer`"] is either a {{Sanitizer}} instance
    or a [=dictionary=].
 1. If |options|["`sanitizer`"] is a {{Sanitizer}} instance:
    Then return  |options|["`sanitizer`"].
 1. [=Assert=]: |options|["`sanitizer`"] is a [=dictionary=].
-1. Return new {{Sanitizer}}(|options|["`sanitizer`"]).
+1. Let |result| be a new {{Sanitizer}} instance.
+1. Call [=set a config=] with |options|["`sanitizer`"].
+1. If [=set a config=] returned false, [=throw=] a {{TypeError}}.
+1. Otherwise, return |result|.
 
 </div>
 
@@ -390,15 +402,14 @@ For the main <dfn>sanitize</dfn> operation, using a {{ParentNode}} |node|, a
 
 1. Let |configuration| be the value of |sanitizer|'s [=Sanitizer/configuration=].
 1. If |safe| is true, then set |configuration| to the result of calling [=remove unsafe=] on |configuration|.
-1. Call [=sanitize core=] on |node|, |configuration|, and |safe| (as value for
-    handling javascript navigation urls).
+1. Call [=sanitize core=] on |node|, |configuration|, and with [=handleJavascriptNavigationUrls=] set to |safe|.
 
 </div>
 
-<div algorithm>
+<div algorithm="sanitize core">
 The <dfn>sanitize core</dfn> operation,
 using a {{ParentNode}} |node|, a {{SanitizerConfig}} |configuration|, and a
-[=boolean=] |handle javascript navigation urls|, iterates over the DOM tree
+[=boolean=] <var><dfn type=argument>handleJavascriptNavigationUrls</dfn></var>, iterates over the DOM tree
 beginning with |node|, and may recurse to handle some special cases (e.g.
 template contents). It consistes of these steps:
 
@@ -422,15 +433,15 @@ template contents). It consistes of these steps:
        1. [=/remove=] |child|.
     1. If |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"] [=SanitizerConfig/contains=] |elementName|:
       1. Call [=sanitize core=] on |child| with |configuration| and
-          |handle javascript navigation urls|.
+          |handleJavascriptNavigationUrls|.
       1. Call [=replace all=] with |child|'s [=tree/children=] within |child|.
     1. If |elementName| [=equals=] &laquo;[ "`name`" &rightarrow; "`template`",
        "`namespace`" &rightarrow; [=HTML namespace=] ]&raquo;
       1. Then call [=sanitize core=] on |child|'s [=template contents=] with
-          |configuration| and |handle javascript navigation urls|.
+          |configuration| and |handleJavascriptNavigationUrls|.
     1. If |child| is a [=shadow host=]:
       1. Then call [=sanitize core=] on |child|'s [=Element/shadow root=] with
-          |configuration| and |handle javascript navigation urls|.
+          |configuration| and |handleJavascriptNavigationUrls|.
     1. [=list/iterate|For each=] |attribute| in |child|'s [=Element/attribute list=]:
       1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
          [=Attr/local name=] and [=Attr/namespace=].
@@ -449,7 +460,7 @@ template contents). It consistes of these steps:
          - "data-" is a [=code unit prefix=] of [=Attr/local name=] and
             [=Attr/namespace=] is `null` and
             |configuration|["{{SanitizerConfig/dataAttributes}}"] is true
-      1. If |handle javascript navigation urls| and &laquo;[|elementName|, |attrName|]&raquo; matches an entry in the
+      1. If |handleJavascriptNavigationUrls| and &laquo;[|elementName|, |attrName|]&raquo; matches an entry in the
          [=navigating URL attributes list=], and if |attribute|'s [=protocol=] is
          "`javascript:`":
          1. Then remove |attribute| from |child|.
@@ -492,7 +503,7 @@ To <dfn for="Sanitizer">remove an element</dfn> |element| from a {{SanitizerConf
 </div>
 
 <div algorithm>
-To <dfn for="Sanitizer">replace an element</dfn> |element| from a {{SanitizerConfig}} |configuration|, do:
+To <dfn for="Sanitizer">replace an element with its children</dfn> |element| from a {{SanitizerConfig}} |configuration|, do:
 
 1. Set |element| to the result of [=canonicalize a sanitizer element=] with |element|.
 1. [=SanitizerConfig/Add=] |element| to |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"].
@@ -520,14 +531,14 @@ To <dfn for="Sanitizer">remove an attribute</dfn> |attribute| from a {{Sanitizer
 </div>
 
 <div algorithm>
-To <dfn for="Sanitizer">allow comments</dfn> with |allow| on a {{SanitizerConfig}} |configuration|, do:
+To <dfn for="Sanitizer">set comments</dfn> with |allow| on a {{SanitizerConfig}} |configuration|, do:
 
 1. Set |configuration|["{{SanitizerConfig/comments}}"] to |allow|.
 
 </div>
 
 <div algorithm>
-To <dfn for="Sanitizer">allow data attributes</dfn> with |allow| on a {{SanitizerConfig}} |configuration|, do:
+To <dfn for="Sanitizer">set data attributes</dfn> with |allow| on a {{SanitizerConfig}} |configuration|, do:
 
 1. Set |configuration|["{{SanitizerConfig/dataAttributes}}"] to |allow|.
 
@@ -568,13 +579,13 @@ To <dfn for="Sanitizer">set a config</dfn> |configuration| on a {{Sanitizer}} |s
 1. [=list/iterate|For each=] |element| of |configuration|["{{SanitizerConfig/removeElements}}"] do:
   1. Call [=remove an element=] with |element| and |sanitizer|.
 1. [=list/iterate|For each=] |element| of |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"] do:
-  1. Call [=replace an element=] with |element| and |sanitizer|.
+  1. Call [=replace an element with its children=] with |element| and |sanitizer|.
 1. [=list/iterate|For each=] |attribute| of |configuration|["{{SanitizerConfig/attributes}}"] do:
   1. Call [=allow an attribute=] with |attribute| and |sanitizer|.
 1. [=list/iterate|For each=] |attribute| of |configuration|["{{SanitizerConfig/removeAttributes}}"] do:
   1. Call [=Sanitizer/remove an attribute=] with |attribute| and |sanitizer|.
-1. Call [=allow comments=] with |configuration|["{{SanitizerConfig/comments}}"] and |sanitizer|.
-1. Call [=allow data attributes=] with |configuration|["{{SanitizerConfig/dataAttributes}}"] and |sanitizer|.
+1. Call [=set comments=] with |configuration|["{{SanitizerConfig/comments}}"] and |sanitizer|.
+1. Call [=set data attributes=] with |configuration|["{{SanitizerConfig/dataAttributes}}"] and |sanitizer|.
 1. Return whether all of the following are true:
     - [=list/size=] of |configuration|["{{SanitizerConfig/elements}}"] equals
       [=list/size=] of [=this=]'s [=Sanitizer/configuration=]["{{SanitizerConfig/elements}}"].
@@ -711,11 +722,10 @@ It is as follows:
   removeElements: [],
   attributes: [],
   removeAttributes: [],
-  comments: true,
 }
 ```
 
-The <dfn>built-in  safe baseline config</dfn> is meant to block only
+The <dfn>built-in safe baseline config</dfn> is meant to block only
 script-content, and nothing else. It is as follows:
 ```
 {
@@ -724,13 +734,12 @@ script-content, and nothing else. It is as follows:
     { name: "script", namespace: "http://www.w3.org/2000/svg" }
   ],
   removeAttributes: [....],
-  comments: true,
 }
 ```
 
 <div>
 The <dfn>navigating URL attributes list</dfn>, for which "`javascript:`"
-navigations are unsafe, are as follows:
+navigations are "unsafe", are as follows:
 
 &laquo;[
   <br>

--- a/index.bs
+++ b/index.bs
@@ -263,9 +263,6 @@ ISSUE(238): Final naming TBD.
 
 ISSUE(240): "other markup" TBD.
 
-ISSUE: Can a missing dict value and a dict entry with an empty sequence be
-    treated differently?
-
 ISSUE: Should these be setter methods -- particularly the setXXX(boolean) --
     or setters or properties or somesuch?
 
@@ -277,10 +274,8 @@ ISSUE: Should the modifier methods return a reference to [=this=], so that you
 The <dfn for="Sanitizer" export>constructor</dfn>(|config|)
 method steps are:
 
-1. [=Set a config|Set=] |config| on [=this=].
-
-Issue: This abandons all error handling, because setting a config will
-    just overwrite contradictory entries. Do we want this?
+1. Let |valid| be the return value of [=set a config|Set=] |config| on [=this=].
+1. If not |valid|, throw a {{TypeError}1. If not |valid|, throw a {{TypeError}}}
 
 </div>
 
@@ -580,10 +575,38 @@ To <dfn for="Sanitizer">set a config</dfn> |config| on a {{Sanitizer}} |sanitize
   1. Call |sanitizer|.{{Sanitizer/removeAttribute()|removeAttribute}}(|item|).
 1. Call |sanitizer|.{{Sanitizer/setComment()|setComment}}(|config|[{{SanitizerConfig/comments}}]).
 1. Call |sanitizer|.{{Sanitizer/setDataAttributes()|setDataAttributes}}(|config|[{{SanitizerConfig/dataAttributes}}]).
+1. Return whether all of the following are true:
+    - [=list/size=] of |config|[{{SanitizerConfig/elements}}] equals
+      [=list/size=] of [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}}.
+    - [=list/size=] of |config|[{{SanitizerConfig/removeElements}}] equals
+      [=list/size=] of [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeElements}}.
+    - [=list/size=] of |config|[{{SanitizerConfig/replaceWithChildrenElements}}] equals
+      [=list/size=] of [=this=]'s [=internal slot=]'s {{SanitizerConfig/replaceWithChildrenElements}}.
+    - [=list/size=] of |config|[{{SanitizerConfig/attributes}}] equals
+      [=list/size=] of [=this=]'s [=internal slot=]'s {{SanitizerConfig/attributes}}.
+    - [=list/size=] of |config|[{{SanitizerConfig/removeAttributes}}] equals
+      [=list/size=] of [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeAttributes}}.
+    - Either |config|[{{SanitizerConfig/elements}}] or
+      |config|[{{SanitizerConfig/removeElements}}] [=map/exist=],
+      or neither, but not both.
+    - Either |config|[{{SanitizerConfig/attributes}}] or
+      |config|[{{SanitizerConfig/removeAttributes}}] [=map/exist=],
+      or neither, but not both.
 
 Note: Previous versions of this spec had elaborate definitions of how to
   canonicalize a config. This has now effectively been moved into the method
   definitions.
+
+Note: This operation is defined in terms of the manipulation methods on the
+    {{Sanitizer}}. Those methods remove matching entries from other lists.
+    The size equality steps in the last step would then catch this.
+    For example:
+    `{ allow: ["div", "div"] }` would create a Sanitizer with one element in
+    the allow list. The final test would then return false, which would cause
+    the caller to throw an exception.
+
+Issue: This is still missing error checks for the per-element attribute lists
+    and syntax errors.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -270,7 +270,7 @@ A {{Sanitizer}} has an associated <dfn for="Sanitizer">configuration</dfn>, a {{
 The <dfn for="Sanitizer" export>constructor</dfn>(|configuration|)
 method steps are:
 
-1. Let |valid| be the return value of [=set a config|setting=] |configuration| on [=this=].
+1. Let |valid| be the return value of [=set a configuration|setting=] |configuration| on [=this=].
 1. If |valid| is false, then throw a {{TypeError}}.
 
 </div>
@@ -379,8 +379,9 @@ an options dictionary |options|, do:
 1. [=Assert=]: |options| is a [=dictionary=].
 1. If |options|["`sanitizer`"] doesn't [=map/exist=], then:
    1. Let |result| be a new {{Sanitizer}} instance.
-   1. Call [=set a config=] with an empty [=dictionary=] on |result|.
-   1. [=Assert=]: The return value is true.
+   1. Let |setConfigurationResult| be the result of [=set a configuration=]
+      with an empty [=dictionary=] on |result|.
+   1. [=Assert=]: The |setConfigurationResult| is true.
    1. Return |result|.
 1. [=Assert=]: |options|["`sanitizer`"] is either a {{Sanitizer}} instance
    or a [=dictionary=].
@@ -388,8 +389,8 @@ an options dictionary |options|, do:
    Then return  |options|["`sanitizer`"].
 1. [=Assert=]: |options|["`sanitizer`"] is a [=dictionary=].
 1. Let |result| be a new {{Sanitizer}} instance.
-1. Call [=set a config=] with |options|["`sanitizer`"].
-1. If [=set a config=] returned false, [=throw=] a {{TypeError}}.
+1. Call [=set a configuration=] with |options|["`sanitizer`"].
+1. If [=set a configuration=] returned false, [=throw=] a {{TypeError}}.
 1. Otherwise, return |result|.
 
 </div>
@@ -409,7 +410,7 @@ For the main <dfn>sanitize</dfn> operation, using a {{ParentNode}} |node|, a
 <div algorithm="sanitize core">
 The <dfn>sanitize core</dfn> operation,
 using a {{ParentNode}} |node|, a {{SanitizerConfig}} |configuration|, and a
-[=boolean=] <var><dfn type=argument>handleJavascriptNavigationUrls</dfn></var>, iterates over the DOM tree
+[=boolean=] <var><dfn>handleJavascriptNavigationUrls</dfn></var>, iterates over the DOM tree
 beginning with |node|, and may recurse to handle some special cases (e.g.
 template contents). It consistes of these steps:
 
@@ -554,26 +555,25 @@ Note: While this algorithm is called [=remove unsafe=], we use
 
 To <dfn for="SanitizerConfig">remove unsafe</dfn> from a |configuration|, do this:
 
-1. [=Assert=]: The [=built-in safe baseline config=] has
+1. [=Assert=]: The [=built-in safe baseline configuration=] has
    {{SanitizerConfig/removeElements}} and {{SanitizerConfig/removeAttributes}}
    keys set, but not {{SanitizerConfig/elements}},
    {{SanitizerConfig/replaceWithChildrenElements}}, or
    {{SanitizerConfig/attributes}}.
 1. Let |result| be a copy of |configuration|.
 1. [=list/For each=] |element| in
-   [=built-in safe baseline config=][{{SanitizerConfig/removeElements}}]:
+   [=built-in safe baseline configuration=][{{SanitizerConfig/removeElements}}]:
     1. Call [=remove an element=] with |element| and |result|.
 1. [=list/For each=] |attribute| in
-   [=built-in safe baseline config=][{{SanitizerConfig/removeAttributes}}]:
+   [=built-in safe baseline configuration=][{{SanitizerConfig/removeAttributes}}]:
     1. Call [=Sanitizer/remove an attribute=] with |attribute| and |result|.
 1. Return |result|.
 
 </div>
 
 <div algorithm>
-To <dfn for="Sanitizer">set a config</dfn> |configuration| on a {{Sanitizer}} |sanitizer|, do this:
+To <dfn for="Sanitizer">set a configuration</dfn>, given a [=dictionary=] |configuration| and a {{Sanitizer}} |sanitizer|:
 
-1. [=Assert=]: |configuration| is a [=dictionary=].
 1. [=list/iterate|For each=] |element| of |configuration|["{{SanitizerConfig/elements}}"] do:
   1. Call [=allow an element=] with |element| and |sanitizer|.
 1. [=list/iterate|For each=] |element| of |configuration|["{{SanitizerConfig/removeElements}}"] do:
@@ -704,17 +704,17 @@ regard to order:
 
 There are four builtins:
 
-* The [=built-in safe default config=],
-* the [=built-in unsafe default config=],
-* the [=built-in safe baseline config=], and
+* The [=built-in safe default configuration=],
+* the [=built-in unsafe default configuration=],
+* the [=built-in safe baseline configuration=], and
 * the [=navigating URL attributes list=].
 
-The <dfn>built-in safe default config</dfn> is the same as the [=built-in safe baseline config=].
+The <dfn>built-in safe default configuration</dfn> is the same as the [=built-in safe baseline configuration=].
 
 ISSUE(233): Determine if this actually holds.
 
 
-The <dfn>built-in unsafe default config</dfn> is meant to allow anything.
+The <dfn>built-in unsafe default configuration</dfn> is meant to allow anything.
 It is as follows:
 ```
 {
@@ -725,7 +725,7 @@ It is as follows:
 }
 ```
 
-The <dfn>built-in safe baseline config</dfn> is meant to block only
+The <dfn>built-in safe baseline configuration</dfn> is meant to block only
 script-content, and nothing else. It is as follows:
 ```
 {

--- a/index.bs
+++ b/index.bs
@@ -246,7 +246,7 @@ interface Sanitizer {
   SanitizerConfig get();
 
   // Modify a Sanitizer's lists and fields:
-  undefined allowElement(SanitizerElementNamespaceWithAttributes element);
+  undefined allowElement(SanitizerElementWithAttributes element);
   undefined removeElement(SanitizerElement element);
   undefined replaceWithChildrenElement(SanitizerElement element);
   undefined allowAttribute(SanitizerAttribute attribute);
@@ -295,11 +295,30 @@ The <dfn for="Sanitizer" export>get</dfn>() method steps are:
 The <dfn for="Sanitizer" export>allowElement</dfn>(|element|) method steps are:
 
 1. Let |name| be the result of [=canonicalize a sanitizer name=] |element| with [=HTML namespace=] as the default namespace.
-1. [=SanitizerConfig/Add=] |name| to [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}}.
-1. [=Merge attribute lists=] of |element| to [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}}.
+1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}}.
+1. [=list/Append=] |name| to [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}}.
+1. [=list/iterate|For each=] |attr| in
+    |element|[{{SanitizerElementNamespaceWithAttributes/attributes}}],
+    [=SanitizerConfig/add=] |attr| to [=this=]'s [=internal slot=]'s
+    {{SanitizerConfig/elements}}[|name|][{{SanitizerElementNamespaceWithAttributes/attributes}}].
+1. [=list/iterate|For each=] |attr| in
+    |element|[{{SanitizerElementNamespaceWithAttributes/removeAttributes}}],
+    [=SanitizerConfig/add=] |attr| to [=this=]'s [=internal slot=]'s
+    {{SanitizerConfig/elements}}[|name|][{{SanitizerElementNamespaceWithAttributes/removeAttributes}}].
 1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeElements}}.
 1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s
    {{SanitizerConfig/replaceWithChildrenElements}}.
+
+NOTE: Handling of [=allowElement=] is a little more complicated than the other
+    methods, because the element allow list can have per-element allow- and
+    remove-attribute lists. We first remove the given element from the list
+    before then adding it, which has the effect of re-setting (rather than
+    merging or elsehow modifying) the per-element list to whatever is passed
+    in. In other words, the per-element allow- and remove-lists can only be
+    set as a whole.
+
+</div>
+
 
 </div>
 
@@ -588,23 +607,6 @@ To <dfn for="SanitizerConfig">add</dfn> a |name| to a |list|, where |name| is
 
 1. If |list| [=SanitizerConfig/contains=] |name|, then return.
 1. [=list/Append=] |name| to |list|.
-
-</div>
-
-<div algorithm>
-To <dfn for="SanitizerConfig">merge attribute lists</dfn> of an |element| to a
-|list|, run these steps:
-
-1. [=Assert=]: |element| is an {{SanitizerElementNamespaceWithAttributes}}.
-1. [=Assert=]: |list| [=SanitizerConfig/contains=] |element|.
-1. [=list/iterate|For each=] |attr| in
-    |element|[{{SanitizerElementNamespaceWithAttributes/attributes}}],
-    [=SanitizerConfig/add=] |attr| to
-    |list|[|element|][{{SanitizerElementNamespaceWithAttributes/attributes}}].
-1. [=list/iterate|For each=] |attr| in
-    |element|[{{SanitizerElementNamespaceWithAttributes/removeAttributes}}],
-    [=SanitizerConfig/add=] |attr| to
-    |list|[|element|][{{SanitizerElementNamespaceWithAttributes/removeAttributes}}].
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -42,6 +42,18 @@ text: parse HTML from a string; type: dfn; url: https://html.spec.whatwg.org/#pa
   }
 }
 </pre>
+<style>
+/* Boxes around algorithms. */
+[data-algorithm]:not(.heading) {
+  padding: .5em;
+  border: thin solid #ddd; border-radius: .5em;
+  margin: .5em calc(-0.5em - 1px);
+}
+[data-algorithm]:not(.heading) > :first-child { margin-top: 0; }
+[data-algorithm]:not(.heading) > :last-child { margin-bottom: 0; }
+[data-algorithm] [data-algorithm] { margin: 1em 0; }
+</style>
+
 
 # Introduction # {#intro}
 
@@ -181,10 +193,9 @@ The <dfn for="Document" export>parseHTMLUnsafe</dfn>(|html|, |options|) method s
    Note: Since |document| does not have a browsing context, scripting is disabled.
 1. Set |document|'s [=allow declarative shadow roots=] to true.
 1. [=Parse HTML from a string=] given |document| and |compliantHTML|.
-1. Let |config| be the result of calling [=get a sanitizer config from options=]
-   with |options| and false.
-1. If |config| is not [=list/empty=],
-   then call [=sanitize=] on |document|'s [=tree/root|root node=] with |config|.
+1. Let |sanitizer| be the result of calling [=get a sanitizer instance from options=]
+   with |options|.
+1. Call [=sanitize=] on |document|'s [=tree/root|root node=] with |sanitizer|.
 1. Return |document|.
 
 </div>
@@ -198,9 +209,9 @@ The <dfn for="Document" export>parseHTML</dfn>(|html|, |options|) method steps a
    Note: Since |document| does not have a browsing context, scripting is disabled.
 1. Set |document|'s [=allow declarative shadow roots=] to true.
 1. [=Parse HTML from a string=] given |document| and |html|.
-1. Let |config| be the result of calling [=get a sanitizer config from options=]
-   with |options| and true.
-1. Call [=sanitize=] on |document|'s [=tree/root|root node=] with |config|.
+1. Let |sanitizer| be the result of calling [=get a sanitizer instance from options=]
+   with |options|.
+1. Call [=sanitize=] on |document|'s [=tree/root|root node=] with |sanitizer|.
 1. Return |document|.
 
 </div>
@@ -223,7 +234,7 @@ lifetime, and can then be used whenever needed. This allows implementations
 to pre-process configurations.
 
 The configuration object is also query-able and can return
-[=SanitizerConfig/canonical=] configuration dictionaries,
+configuration dictionaries,
 in both safe and unsafe variants. This allows a
 page to query and predict what effect a given configuration will have, or
 to build a new configuration based on an existing one.
@@ -232,8 +243,20 @@ to build a new configuration based on an existing one.
 [Exposed=(Window,Worker)]
 interface Sanitizer {
   constructor(optional SanitizerConfig config = {});
+
+  // Query configurations:
   SanitizerConfig get();
   SanitizerConfig getUnsafe();
+
+  // Modifying a Sanitizer:
+  undefined element(SanitizerElementNamespaceWithAttributes element);
+  undefined removeElement(SanitizerElement element);
+  undefined replaceWithChildren(SanitizerElement element);
+  undefined allowAttribute(SanitizerAttribute attribute);
+  undefined removeAttribute(SanitizerAttribute attribute);
+  undefined setComment(boolean allow);
+  undefined setDataAttributes(boolean allow);
+  undefined setOtherMarkup(boolean allow);
 };
 </pre>
 
@@ -241,23 +264,102 @@ interface Sanitizer {
 The <dfn for="Sanitizer" export>constructor</dfn>(|config|)
 method steps are:
 
-1. Store |config| in [=this=]'s [=internal slot=].
+1. [=Set a config|Set=] |config| on [=this=].
+
+Issue: This abandons all error handling, because setting a config will
+    just overwrite contradictory entries. Do we want this?
 
 </div>
 
 <div algorithm>
 The <dfn for="Sanitizer" export>get</dfn>() method steps are:
 
-1. Return the result of [=canonicalize a configuration=] with the value of
-   [=this=]'s [=internal slot=] and true.
+1. Return the result of calling [=safeify=] on the result of
+   [=Sanitizer/getUnsafe=].
 
 </div>
 
 <div algorithm>
 The <dfn for="Sanitizer" export>getUnsafe</dfn>() method steps are:
 
-1. Return the result of [=canonicalize a configuration=] with the value of
-   [=this=]'s [=internal slot=] and false.
+1. Return the value of [=this=]'s [=internal slot=].
+
+</div>
+
+<div algorithm>
+The <dfn for="Sanitizer" export>element</dfn>(|element|) method steps are:
+
+1. Let |name| be the result of [=canonicalize a sanitizer name=] |element| with [=HTML namespace=] as the default namespace.
+1. [=list/Append=] |name| to [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}} list.
+1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeElements}}.
+1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s 
+   {{SanitizerConfig/replaceWithChildrenElements}}.
+
+ISSUE: This does not handle per-element attribute allow/remove lists.
+</div>
+
+<div algorithm>
+The <dfn for="Sanitizer" export>removeElement</dfn>(|element|) method steps are:
+
+1. Let |name| be the result of [=canonicalize a sanitizer name=] |element| with [=HTML namespace=] as the default namespace.
+1. [=list/Append=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeElements}}.
+1. [=list/Remove=] |name| to [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}} list.
+1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s 
+   {{SanitizerConfig/replaceWithChildrenElements}}.
+
+</div>
+
+
+<div algorithm>
+The <dfn for="Sanitizer" export>replaceWithChildren</dfn>(|element|) method steps are:
+
+1. Let |name| be the result of [=canonicalize a sanitizer name=] |element| with [=HTML namespace=] as the default namespace.
+1. [=list/Append=] |name| from [=this=]'s [=internal slot=]'s 
+   {{SanitizerConfig/replaceWithChildrenElements}}.
+1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeElements}}.
+1. [=list/Remove=] |name| to [=this=]'s [=internal slot=]'s {{SanitizerConfig/elements}} list.
+
+</div>
+
+<div algorithm>
+The <dfn for="Sanitizer" export>allowAttribute</dfn>(|attribute|) method steps are:
+
+1. Let |name| be the result of [=canonicalize a sanitizer name=] |attribute| with the `null` as the default namespace.
+1. [=list/Append=] |name| from [=this=]'s [=internal slot=]'s 
+   {{SanitizerConfig/attributes}}.
+1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeAttributes}}.
+
+</div>
+</div>
+
+<div algorithm>
+The <dfn for="Sanitizer" export>removeAttribute</dfn>(|attribute|) method steps are:
+
+1. Let |name| be the result of [=canonicalize a sanitizer name=] |attribute| with the `null` as the default namespace.
+1. [=list/Append=] |name| from [=this=]'s [=internal slot=]'s {{SanitizerConfig/removeAttributes}}.
+1. [=list/Remove=] |name| from [=this=]'s [=internal slot=]'s 
+   {{SanitizerConfig/attributes}}.
+
+</div>
+
+<div algorithm>
+The <dfn for="Sanitizer" export>setComment</dfn>(|allow|) method steps are:
+
+1. Set [=this=]'s [=internal slot=]'s {{SanitizerConfig/comments}} to |allow|.
+
+</div>
+
+<div algorithm>
+The <dfn for="Sanitizer" export>setDataAttributes</dfn>(|allow|) method steps are:
+
+1. Set [=this=]'s [=internal slot=]'s {{SanitizerConfig/dataAttributes}} to |allow|.
+
+</div>
+
+<div algorithm>
+The <dfn for="Sanitizer" export>setOtherMarkup</dfn>(|allow|) method steps are:
+
+1. Set [=this=]'s [=internal slot=]'s {{SanitizerConfig/otherMarkup}} to |allow|.
 
 </div>
 
@@ -294,6 +396,7 @@ dictionary SanitizerConfig {
 
   boolean comments;
   boolean dataAttributes;
+  boolean otherMarkup;
 };
 </pre>
 
@@ -308,40 +411,53 @@ To <dfn>set and filter HTML</dfn>, given an {{Element}} or {{DocumentFragment}}
 1. If |safe| and |contextElement|'s [=Element/local name=] is "`script`" and
    |contextElement|'s [=Element/namespace=] is the [=HTML namespace=] or the
    [=SVG namespace=], then return.
-1. Let |config| be the result of calling [=get a sanitizer config from options=]
-   with |options| and |safe|.
+1. Let |sanitizer| be the result of calling [=get a sanitizer instance from options=]
+   with |options|.
 1. Let |newChildren| be the result of the HTML [=fragment parsing algorithm steps=]
    given |contextElement|, |html|, and true.
 1. Let |fragment| be a new {{DocumentFragment}} whose [=node document=] is |contextElement|'s [=node document=].
 1. [=list/iterate|For each=] |node| in |newChildren|, [=list/append=] |node| to |fragment|.
-1. If |config| is not [=list/empty=], then run [=sanitize=] on |fragment| using |config|.
+1. Run [=sanitize=] on |fragment| using |sanitizer| and |safe|.
 1. [=Replace all=] with |fragment| within |target|.
 
 </div>
 
 <div algorithm>
-To <dfn for="SanitizerConfig">get a sanitizer config from options</dfn> for
-an options dictionary |options| and a boolean |safe|, do:
+To <dfn for="SanitizerConfig">get a sanitizer instance from options</dfn> for
+an options dictionary |options|, do:
 
 1. Assert: |options| is a [=dictionary=].
-1. If |options|["`sanitizer`"] doesn't [=map/exist=], then return undefined.
+1. If |options|["`sanitizer`"] doesn't [=map/exist=],
+   then return new {{Sanitizer}}().
 1. Assert: |options|["`sanitizer`"] is either a {{Sanitizer}} instance
    or a [=dictionary=].
 1. If |options|["`sanitizer`"] is a {{Sanitizer}} instance:
-   1. Then let |config| be the value of |options|["`sanitizer`"]'s [=internal slot=].
-   1. Otherwise let |config| be the value of |options|["`sanitizer`"].
-1. Return the result of calling [=canonicalize a configuration=] on
-   |config| and |safe|.
+   Then return  |options|["`sanitizer`"].
+1. Assert: |options|["`sanitizer`"] is a [=dictionary=].
+1. Return new {{Sanitizer}}(|options|["`sanitizer`"]).
 
 </div>
 
 ## Sanitization Algorithms ## {#sanitization}
 
-<div algorithm="sanitize">
+<div algorithm>
 For the main <dfn>sanitize</dfn> operation, using a {{ParentNode}} |node|, a
-[=SanitizerConfig/canonical=] {{SanitizerConfig}} |config|, run these steps:
+{{Sanitizer}} |sanitizer| and a [=boolean=] |safe|, run these steps:
 
-1. [=Assert=]: |config| is [=SanitizerConfig/canonical=].
+1. Let |config| be the value of |sanitizer|'s [=internal slot=].
+1. If |safe|, let |config| be the result of calling [=safeify=] on |config|.
+1. Call [=sanitize core=] on |node|, |config|, and |safe| (as value for
+    handling javascript navigation urls).
+
+</div>
+
+<div algorithm>
+The <dfn>sanitize core</dfn> operation,
+using a {{ParentNode}} |node|, a {{SanitizerConfig}} |config|, and a
+[=boolean=] |handle javascript navigation urls|, iterates over the DOM tree
+beginning with |node|, and may recurse to handle some special cases (e.g. 
+template contents). It consistes of these steps:
+
 1. Let |current| be |node|.
 1. [=list/iterate|For each=] |child| in |current|'s [=tree/children=]:
   1. [=Assert=]: |child| [=implements=] {{Text}}, {{Comment}}, or {{Element}}.
@@ -358,324 +474,87 @@ For the main <dfn>sanitize</dfn> operation, using a {{ParentNode}} |node|, a
   1. else:
     1. Let |elementName| be a {{SanitizerElementNamespace}} with |child|'s
        [=Element/local name=] and [=Element/namespace=].
-    1. If |config|["{{SanitizerConfig/elements}}"] exists and
-       |config|["{{SanitizerConfig/elements}}"] does not [=SanitizerConfig/contain=]
-       [|elementName|]:
+    1. If |config|["{{SanitizerConfig/removeElements}}"] [=SanitizerConfig/contains=] |elementName|, or if |config|["{{SanitizerConfig/elements}}"] does not [=SanitizerConfig/contain=] |elementName| and |config|["{{SanitizerConfig/otherMarkup}}"] is false:
        1. [=/remove=] |child|.
-    1. else if |config|["{{SanitizerConfig/removeElements}}"] exists and
-       |config|["{{SanitizerConfig/removeElements}}"] [=SanitizerConfig/contains=]
-       [|elementName|]:
-       1. [=/remove=] |child|.
-    1. If |config|["{{SanitizerConfig/replaceWithChildrenElements}}"] exists and |config|["{{SanitizerConfig/replaceWithChildrenElements}}"] [=SanitizerConfig/contains=] |elementName|:
-      1. Call [=sanitize=] on |child| with |config|.
+    1. If |config|["{{SanitizerConfig/replaceWithChildrenElements}}"] [=SanitizerConfig/contains=] |elementName|:
+      1. Call [=sanitize core=] on |child| with |config| and
+          |handle javascript navigation urls|.
       1. Call [=replace all=] with |child|'s [=tree/children=] within |child|.
     1. If |elementName| [=equals=] &laquo;[ "`name`" &rightarrow; "`template`",
        "`namespace`" &rightarrow; [=HTML namespace=] ]&raquo;
-      1. Then call [=sanitize=] on |child|'s [=template contents=] with |config|.
+      1. Then call [=sanitize core=] on |child|'s [=template contents=] with
+          |config| and |handle javascript navigation urls|.
     1. If |child| is a [=shadow host=]:
-      1. Then call [=sanitize=] on |child|'s [=Element/shadow root=] with |config|.
-    1. [=list/iterate|For each=] |attr| in |current|'s [=Element/attribute list=]:
+      1. Then call [=sanitize core=] on |child|'s [=Element/shadow root=] with
+          |config| and |handle javascript navigation urls|.
+    1. [=list/iterate|For each=] |attr| in |child|'s [=Element/attribute list=]:
       1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attr|'s
          [=Attr/local name=] and [=Attr/namespace=].
-      1. If |config|["{{SanitizerConfig/attributes}}"] exists and
-         |config|["{{SanitizerConfig/attributes}}"] does not [=SanitizerConfig/contain=]
-         |attrName|:
-         1. If "data-" is a [=code unit prefix=] of [=Attr/local name=] and
-            if [=Attr/namespace=] is `null` and
-            if |config|["{{SanitizerConfig/dataAttributes}}"] exists and is false:
-            1. Remove |attr| from |child|.
-      1. else if |config|["{{SanitizerConfig/removeAttributes}}"] exists and
-         |config|["{{SanitizerConfig/removeAttributes}}"] [=SanitizerConfig/contains=]
-         |attrName|:
+      1. If |config|["{{SanitizerConfig/removeAttributes}}"]
+           [=SanitizerConfig/contains=] |attrName|:
          1. Remove |attr| from |child|.
-      1. If |config|["{{SanitizerConfig/elements}}"][|elementName|] exists,
-         and if
-         |config|["{{SanitizerConfig/elements}}"][|elementName|]["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
-         exists, and if
-         |config|["{{SanitizerConfig/elements}}"][|elementName|]["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
-         does not [=SanitizerConfig/contain=] |attrName|:
+      1. If |config|["{{SanitizerConfig/elements}}"]["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
+           [=SanitizerConfig/contains=] |attrName|:
          1. Remove |attr| from |child|.
-      1. If |config|["{{SanitizerConfig/elements}}"][|elementName|] exists,
-         and if
-         |config|["{{SanitizerConfig/elements}}"][|elementName|]["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-         exists, and if
-         |config|["{{SanitizerConfig/elements}}"][|elementName|]["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-         [=SanitizerConfig/contains=] |attrName|:
-         1. Remove |attr| from |child|.
-      1. If &laquo;[|elementName|, |attrName|]&raquo; matches an entry in the
+
+      1. If all of the following are false, then remove |attr| from |child|.
+         - |config|["{{SanitizerConfig/attributes}}"]
+           [=SanitizerConfig/contains=] |attrName|
+         - |config|["{{SanitizerConfig/elements}}"]["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
+           [=SanitizerConfig/contains=] |attrName|
+         - "data-" is a [=code unit prefix=] of [=Attr/local name=] and
+            [=Attr/namespace=] is `null` and
+            |config|["{{SanitizerConfig/dataAttributes}}"] is true
+         - |config|["{{SanitizerConfig/otherMarkup}}"]
+      1. If |handle javascript navigation urls|and &laquo;[|elementName|, |attrName|]&raquo; matches an entry in the
          [=navigating URL attributes list=], and if |attr|'s [=protocol=] is
          "`javascript:`":
          1. Then remove |attr| from |child|.
-       1. Call [=sanitize=] on |child|'s [=Element/shadow root=] with |config|.
-    1. else:
-      1. [=/remove=] |child|.
 
 </div>
 
 ## Configuration Processing ## {#configuration-processing}
 
 <div algorithm>
-A |config| is <dfn for="SanitizerConfig">valid</dfn> if all these conditions are met:
+To <dfn for="SanitizerConfig">safeify</dfn> a |config|, do this:
 
-1. |config| is a [=dictionary=]
-1. |config|'s [=map/keys|key set=] does not [=list/contain=] both
-   "{{SanitizerConfig/elements}}" and "{{SanitizerConfig/removeElements}}"
-1. |config|'s [=map/keys|key set=] does not [=list/contain=] both
-   "{{SanitizerConfig/removeAttributes}}" and "{{SanitizerConfig/attributes}}".
-1. [=list/iterate|For any=] |key| of &laquo;[
-   "{{SanitizerConfig/elements}}",
-   "{{SanitizerConfig/removeElements}}",
-   "{{SanitizerConfig/replaceWithChildrenElements}}",
-   "{{SanitizerConfig/attributes}}",
-   "{{SanitizerConfig/removeAttributes}}"
-    ]&raquo; where |config|[|key|] [=map/exists=]:
-   1. |config|[|key|] is [=SanitizerNameList/valid=].
-1. If |config|["{{SanitizerConfig/elements}}"] exists, then
-   [=list/iterate|for any=] |element| in |config|[|key|] that is a [=dictionary=]:
-   1. |element| does not [=list/contain=] both
-      "{{SanitizerElementNamespaceWithAttributes/attributes}}" and
-      "{{SanitizerElementNamespaceWithAttributes/removeAttributes}}".
-   1. If either |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
-      or |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-      [=map/exists=], then it is [=SanitizerNameList/valid=].
-   1. Let |tmp| be a [=dictionary=], and for any |key| &laquo;[
-      "{{SanitizerConfig/elements}}",
-      "{{SanitizerConfig/removeElements}}",
-      "{{SanitizerConfig/replaceWithChildrenElements}}",
-      "{{SanitizerConfig/attributes}}",
-      "{{SanitizerConfig/removeAttributes}}"
-      ]&raquo; |tmp|[|key|] is set to the result of [=canonicalize a sanitizer
-      element list=] called on |config|[|key|], and [=HTML namespace=] as default
-      namespace for the element lists, and `null` as default namespace for the
-      attributes lists.
-
-      Note: The intent here is to assert about list elements, but without regard
-            to whether the string shortcut syntax or the explicit dictionary
-            syntax is used. For example, having "img" in `elements` and
-            `{ name: "img" }` in `removeElements`. An implementation might well
-            do this without explicitly canonicalizing the lists at this point.
-
-      1. Given theses canonicalized name lists, all of the following conditions hold:
-
-        1. The [=set/intersection=] between
-           |tmp|["{{SanitizerConfig/elements}}"] and
-           |tmp|["{{SanitizerConfig/removeElements}}"]
-           is [=set/empty=].
-        1. The [=set/intersection=] between
-           |tmp|["{{SanitizerConfig/removeElements}}"]
-           |tmp|["{{SanitizerConfig/replaceWithChildrenElements}}"]
-           is [=set/empty=].
-        1. The [=set/intersection=] between
-           |tmp|["{{SanitizerConfig/replaceWithChildrenElements}}"] and
-           |tmp|["{{SanitizerConfig/elements}}"]
-           is [=set/empty=].
-        1. The [=set/intersection=] between
-           |tmp|["{{SanitizerConfig/attributes}}"] and
-           |tmp|["{{SanitizerConfig/removeAttributes}}"]
-           is [=set/empty=].
-
-    1. Let |tmpattrs| be |tmp|["{{SanitizerConfig/attributes}}"] if it exists,
-       and otherwise [=built-in default config=]["{{SanitizerConfig/attributes}}"].
-    1. [=list/iterate|For any=] |item| in |tmp|["{{SanitizerConfig/elements}}"]:
-       1. If either |item|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
-          or |item|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-          exists:
-          1. Then the [=set/difference=] between it and |tmpattrs| is [=set/empty=].
-
-</div>
-
-<div algorithm>
-A |list| of names is <dfn for="SanitizerNameList">valid</dfn> if all these
-conditions are met:
-
-1. |list| is a [=/list=].
-1. [=list/iterate|For all=] of its members |name|:
-   1. |name| is a {{string}} or a [=dictionary=].
-   1. If |name| is a [=dictionary=]:
-      1. |name|["{{SanitizerElementNamespace/name}}"] [=map/exists=] and is a {{string}}.
-
-</div>
-
-<div algorithm>
-A |config| is <dfn for="SanitizerConfig">canonical</dfn> if all these conditions are met:
-
-1. |config| is [=SanitizerConfig/valid=].
-1. |config|'s [=map/keys|key set=] is a [=set/subset=] of
-   &laquo;[
-   "{{SanitizerConfig/elements}}",
-   "{{SanitizerConfig/removeElements}}",
-   "{{SanitizerConfig/replaceWithChildrenElements}}",
-   "{{SanitizerConfig/attributes}}",
-   "{{SanitizerConfig/removeAttributes}}",
-   "{{SanitizerConfig/comments}}",
-   "{{SanitizerConfig/dataAttributes}}"
-   ]&raquo;
-1. |config|'s [=map/keys|key set=] [=list/contains=] either:
-   1. both "{{SanitizerConfig/elements}}" and "{{SanitizerConfig/attributes}}",
-      but neither of
-      "{{SanitizerConfig/removeElements}}" or "{{SanitizerConfig/removeAttributes}}".
-   1. or both
-      "{{SanitizerConfig/removeElements}}" and "{{SanitizerConfig/removeAttributes}}",
-      but neither of
-      "{{SanitizerConfig/elements}}" or "{{SanitizerConfig/attributes}}".
-1. For any |key| of &laquo;[
-      "{{SanitizerConfig/replaceWithChildrenElements}}",
-      "{{SanitizerConfig/removeElements}}",
-      "{{SanitizerConfig/attributes}}",
-      "{{SanitizerConfig/removeAttributes}}"
-      ]&raquo; where |config|[|key|] [=map/exists=]:
-   1. |config|[|key|] is [=SanitizerNameList/canonical=].
-1. If |config|["{{SanitizerConfig/elements}}"] [=map/exists=]:
-   1. |config|["{{SanitizerConfig/elements}}"] is [=SanitizerNameWithAttributesList/canonical=].
-1. For any |key| of &laquo;[
-   "{{SanitizerConfig/comments}}",
-   "{{SanitizerConfig/dataAttributes}}"
-   ]&raquo;:
-   1. if |config|[|key|] [=map/exists=], |config|[|key|] is a {{boolean}}.
-
-</div>
-
-<div algorithm>
-A |list| of names is <dfn for="SanitizerNameList">canonical</dfn> if all these
-conditions are met:
-
-1. |list|[|key|] is a [=/list=].
-1. [=list/iterate|For all=] of its |list|[|key|]'s members |name|:
-   1. |name| is a [=dictionary=].
-   1. |name|'s [=map/keys|key set=] [=set/equals=] &laquo;[
-    "{{SanitizerElementNamespace/name}}", "{{SanitizerElementNamespace/namespace}}"
-     ]&raquo;
-  1. |name|'s [=map/values=] are [=string=]s.
-
-</div>
-
-<div algorithm>
-A |list| of names is <dfn for="SanitizerNameWithAttributesList">canonical</dfn>
-if all these conditions are met:
-
-1. |list|[|key|] is a [=/list=].
-1. [=list/iterate|For all=] of its |list|[|key|]'s members |name|:
-   1. |name| is a [=dictionary=].
-   1. |name|'s [=map/keys|key set=] [=set/equals=] one of:
-      1. &laquo;[
-         "{{SanitizerElementNamespace/name}}",
-         "{{SanitizerElementNamespace/namespace}}"
-         ]&raquo;
-      1. &laquo;[
-         "{{SanitizerElementNamespace/name}}",
-         "{{SanitizerElementNamespace/namespace}}",
-         "{{SanitizerElementNamespaceWithAttributes/attributes}}"
-         ]&raquo;
-      1. &laquo;[
-         "{{SanitizerElementNamespace/name}}",
-         "{{SanitizerElementNamespace/namespace}}",
-         "{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"
-         ]&raquo;
-   1. |name|["{{SanitizerElementNamespace/name}}"] and
-      |name|["{{SanitizerElementNamespace/namespace}}"] are [=string=]s.
-   1. |name|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] and
-      |name|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-      are [=SanitizerNameList/canonical=] if they [=map/exist=].
-
-</div>
-
-
-<div algorithm>
-To <dfn>canonicalize a configuration</dfn> |config| with a [=boolean=] |safe|:
-
-Note: The initial set of [=assert=]s assert properties of the built-in
-      constants, like the [=built-in default config|defaults=] and
-      the lists of known [=known elements|elements=] and
-      [=known attributes|attributes=].
-
-1. [=Assert=]: [=built-in default config=] is [=SanitizerConfig/canonical=].
-1. [=Assert=]: [=built-in default config=]["elements"] is a [=subset=] of [=known elements=].
-1. [=Assert=]: [=built-in default config=]["attributes"] is a [=subset=] of [=known attributes=].
-1. [=Assert=]: &laquo;[
-   "elements" &rightarrow; [=known elements=],
-   "attributes" &rightarrow; [=known attributes=],
-   ]&raquo; is [=SanitizerConfig/canonical=].
-1. If |config| is [=list/empty=] and not |safe|, then return &laquo;[]&raquo;
-1. If |config| is not [=SanitizerConfig/valid=], then [=throw=] a {{TypeError}}.
-1. Let |result| be a new [=dictionary=].
-1. For each |key| of &laquo;[
-   "{{SanitizerConfig/elements}}",
-   "{{SanitizerConfig/removeElements}}",
-   "{{SanitizerConfig/replaceWithChildrenElements}}" ]&raquo;:
-  1. If |config|[|key|] exists, set |result|[|key|] to the result of running
-     [=canonicalize a sanitizer element list=] on |config|[|key|] with
-     [=HTML namespace=] as the default namespace.
-1. For each |key| of &laquo;[
-   "{{SanitizerConfig/attributes}}",
-   "{{SanitizerConfig/removeAttributes}}" ]&raquo;:
-  1. If |config|[|key|] exists, set |result|[|key|] to the result of running
-     [=canonicalize a sanitizer element list=] on |config|[|key|] with `null` as
-     the default namespace.
-1. Set |result|["{{SanitizerConfig/comments}}"] to
-   |config|["{{SanitizerConfig/comments}}"].
-1. Let |default| be the result of [=canonicalizing a configuration=] for the
-   [=built-in default config=].
-1. If |safe|:
-   1. If |config|["{{SanitizerConfig/elements}}"] [=map/exists=]:
-      1. Let |elementBlockList| be the [=set/difference=] between
-         [=known elements=] |default|["{{SanitizerConfig/elements}}"].
-
-         Note: The "natural" way to enforce the default element list would be
-               to intersect with it. But that would also eliminate any unknown
-               (i.e., non-HTML supplied element, like &lt;foo&gt;). So we
-               construct this helper to be able to use it to subtract any "unsafe"
-               elements.
-      1. Set |result|["{{SanitizerConfig/elements}}"] to the
-         [=set/difference=] of |result|["{{SanitizerConfig/elements}}"] and
-         |elementBlockList|.
-   1. If |config|["{{SanitizerConfig/removeElements}}"] [=map/exists=]:
-       1. Set |result|["{{SanitizerConfig/elements}}"] to the
-          [=set/difference=] of |default|["{{SanitizerConfig/elements}}"]
-          and |result|["{{SanitizerConfig/removeElements}}"].
-       1. [=set/Remove=] "{{SanitizerConfig/removeElements}}" from |result|.
-   1. If neither |config|["{{SanitizerConfig/elements}}"] nor
-      |config|["{{SanitizerConfig/removeElements}}"] [=map/exist=]:
-      1. Set |result|["{{SanitizerConfig/elements}}"] to
-         |default|["{{SanitizerConfig/elements}}"].
-   1. If |config|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
-      1. Let |attributeBlockList| be the [=set/difference=] between
-         [=known attributes=] and |default|["{{SanitizerConfig/attributes}}"];
-      1. Set |result|["{{SanitizerConfig/attributes}}"] to the
-         [=set/difference=] of |result|["{{SanitizerConfig/attributes}}"] and
-         |attributeBlockList|.
-   1. If |config|["{{SanitizerConfig/removeAttributes}}"] [=map/exists=]:
-       1. Set |result|["{{SanitizerConfig/attributes}}"] to the
-          [=set/difference=] of |default|["{{SanitizerConfig/attributes}}"]
-          and |result|["{{SanitizerConfig/removeAttributes}}"].
-       1. [=set/Remove=] "{{SanitizerConfig/removeAttributes}}" from |result|.
-   1. If neither |config|["{{SanitizerConfig/attributes}}"] nor
-      |config|["{{SanitizerConfig/removeAttributes}}"] [=map/exist=]:
-      1. Set |result|["{{SanitizerConfig/attributes}}"] to
-         |default|["{{SanitizerConfig/attributes}}"].
-1. Else (if not |safe|):
-   1. If neither  |config|["{{SanitizerConfig/elements}}"] nor
-      |config|["{{SanitizerConfig/removeElements}}"] [=map/exist=]:
-      1. Set |result|["{{SanitizerConfig/elements}}"] to
-         |default|["{{SanitizerConfig/elements}}"].
-   1. If neither  |config|["{{SanitizerConfig/attributes}}"] nor
-      |config|["{{SanitizerConfig/removeAttributes}}"] [=map/exist=]:
-      1. Set |result|["{{SanitizerConfig/attributes}}"] to
-         |default|["{{SanitizerConfig/attributes}}"].
-1. [=Assert=]: |result| is [=SanitizerConfig/valid=].
-1. [=Assert=]: |result| is [=SanitizerConfig/canonical=].
+1. [=Assert=]: The [=built-in safe baseline config=] has
+   {{SanitizerConfig/removeElements}} and {{SanitizerConfig/removeAttributes}}
+   keys set, but not {{SanitizerConfig/elements}},
+   {{SanitizerConfig/replaceWithChildrenElements}}, or
+   {{SanitizerConfig/attributes}}.
+1. Let |result| be a copy of |config|.
+1. [=list/For each=] |elem| in
+   [=built-in safe baseline config=][{{SanitizerConfig/removeElements}}]:
+    1. Call |result|.removeElement(|elem|)
+1. [=list/For each=] |attr| in
+   [=built-in safe baseline config=][{{SanitizerConfig/removeAttributes}}]:
+    1. Call |result|.removeAttributes(|attr|)
 1. Return |result|.
 
 </div>
 
 <div algorithm>
-In order to <dfn>canonicalize a sanitizer element list</dfn> |list|, with a
-default namespace |defaultNamespace|, run the following steps:
+To <dfn for="Sanitizer">set a config</dfn> |config| on a {{Sanitizer}} |sanitizer|, do this:
 
-1. Let |result| be a new [=ordered set=].
-2. [=list/iterate|For each=] |name| in |list|, call
-   [=canonicalize a sanitizer name=] on |name| with |defaultNamespace| and
-   [=set/append=] to |result|.
-3. Return |result|.
+1. [=Assert=]: |config| is a [=dictionary=].
+1. [=list/iterate|For each=] |item| of |config|[{{SanitizerConfig/elements}}] do:
+  1. Call |sanitizer|.element(|item|).
+1. [=list/iterate|For each=] |item| of |config|[{{SanitizerConfig/removeElements}}] do:
+  1. Call |sanitizer|.removeElement(|item|).
+1. [=list/iterate|For each=] |item| of |config|[{{SanitizerConfig/replaceWithChildrenElements}}] do:
+  1. Call |sanitizer|.replaceWithChildren(|item|).
+1. [=list/iterate|For each=] |item| of |config|[{{SanitizerConfig/attributes}}] do:
+  1. Call |sanitizer|.attribute(|item|).
+1. [=list/iterate|For each=] |item| of |config|[{{SanitizerConfig/removeAttributes}}] do:
+  1. Call |sanitizer|.removeAttributes(|item|).
+1. Call |sanitizer|.comments(|config|[{{SanitizerConfig/comments}}]).
+1. Call |sanitizer|.dataAttributes(|config|[{{SanitizerConfig/dataAttributes}}]).
+1. Call |sanitizer|.otherMarkup(|config|[{{SanitizerConfig/otherMarkup}}]).
+
+Note: Previous versions of this spec had elaborate definitions of how to
+  canonicalize a config. This has now effectively been moved into the method
+  definitions.
 
 </div>
 
@@ -688,7 +567,7 @@ namespace |defaultNamespace|, run the following steps:
 1. [=Assert=]: |name| is a [=dictionary=] and |name|["name"] [=map/exists=].
 1. Return &laquo;[ <br>
   "`name`" &rightarrow; |name|["name"], <br>
-  "`namespace`" &rightarrow; |name|["namespace"] if it [=map/exists=], otherwise |defaultNamespace| <br>
+  "`namespace`" &rightarrow; ( |name|["namespace"] if it [=map/exists=], otherwise |defaultNamespace| ) <br>
   ]&raquo;.
 
 </div>
@@ -730,37 +609,44 @@ regard to order:
 
 ## Defaults ## {#sanitization-defaults}
 
-Note: The defaults should follow a certain form, which is checked for at the
-      beginning of [=canonicalize a configuration=].
+There are four builtins:
 
-The <dfn>built-in default config</dfn> is as follows:
+* The [=built-in safe default config=],
+* the [=built-in unsafe default config=],
+* the [=built-in safe baseline config=], and
+* the [=navigating URL attributes list=].
+
+The <dfn>built-in safe default config</dfn> is the same as the [=built-in safe baseline config=].
+
+ISSUE: Determine if this actually holds.
+
+
+The <dfn>built-in unsafe default config</dfn> is meant to allow anything.
+It is as follows:
 ```
 {
-  elements: [....],
-  attributes: [....],
+  allow: [],
+  removeElements: [],
+  attributes: [],
+  removeAttributes: [],
   comments: true,
+  otherMarkup: true,
 }
 ```
 
-The <dfn>known elements</dfn> are as follows:
+The <dfn>built-in  safe baseline config</dfn> is meant to block only
+script-content, and nothing else. It is as follows:
 ```
-[
-  { name: "div", namespace: "http://www.w3.org/1999/xhtml" },
-  ...
-]
+{
+  removeElements: [
+    { name: "script", namespace: "http://www.w3.org/1999/xhtml" },
+    { name: "script", namespace: "http://www.w3.org/2000/svg" }
+  ],
+  removeAttributes: [....],
+  comments: true,
+  otherMarkup: true
+}
 ```
-
-The <dfn>known attributes</dfn> are as follows:
-```
-[
-  { name: "class", namespace: null },
-  ...
-]
-```
-
-Note: The [=known elements=] and [=known attributes=] should be derived from the
-      HTML5 specification, rather than being explicitly listed here. Currently,
-      there are no mechanics to do so.
 
 <div>
 The <dfn>navigating URL attributes list</dfn>, for which "`javascript:`"
@@ -769,27 +655,27 @@ navigations are unsafe, are as follows:
 &laquo;[
   <br>
   [
-    { "`name`" &rightarrow; "`a`", "`namespace`" &rightarrow; "[=HTML namespace=]" },
+    { "`name`" &rightarrow; "`a`", "`namespace`" &rightarrow; [=HTML namespace=] },
     { "`name`" &rightarrow; "`href`", "`namespace`" &rightarrow; `null` }
   ],
   <br>
   [
-    { "`name`" &rightarrow; "`area`", "`namespace`" &rightarrow; "[=HTML namespace=]" },
+    { "`name`" &rightarrow; "`area`", "`namespace`" &rightarrow; [=HTML namespace=] },
     { "`name`" &rightarrow; "`href`", "`namespace`" &rightarrow; `null` }
   ],
   <br>
   [
-    { "`name`" &rightarrow; "`form`", "`namespace`" &rightarrow; "[=HTML namespace=]" },
+    { "`name`" &rightarrow; "`form`", "`namespace`" &rightarrow; [=HTML namespace=] },
     { "`name`" &rightarrow; "`action`", "`namespace`" &rightarrow; `null` }
   ],
   <br>
   [
-    { "`name`" &rightarrow; "`input`", "`namespace`" &rightarrow; "[=HTML namespace=]" },
+    { "`name`" &rightarrow; "`input`", "`namespace`" &rightarrow; [=HTML namespace=] },
     { "`name`" &rightarrow; "`formaction`", "`namespace`" &rightarrow; `null` }
   ],
   <br>
   [
-    { "`name`" &rightarrow; "`button`", "`namespace`" &rightarrow; "[=HTML namespace=]" },
+    { "`name`" &rightarrow; "`button`", "`namespace`" &rightarrow; [=HTML namespace=] },
     { "`name`" &rightarrow; "`formaction`", "`namespace`" &rightarrow; `null` }
   ],
   <br>

--- a/index.bs
+++ b/index.bs
@@ -253,7 +253,6 @@ interface Sanitizer {
   undefined removeAttribute(SanitizerAttribute attribute);
   undefined setComment(boolean allow);
   undefined setDataAttributes(boolean allow);
-  undefined setOtherMarkup(boolean allow);
 
   // Remove markup that executes script. May modify multiple lists:
   undefined removeUnsafe();
@@ -264,8 +263,15 @@ ISSUE(238): Final naming TBD.
 
 ISSUE(240): "other markup" TBD.
 
+ISSUE: Can a missing dict value and a dict entry with an empty sequence be
+    treated differently?
+
 ISSUE: Should these be setter methods -- particularly the setXXX(boolean) --
     or setters or properties or somesuch?
+
+ISSUE: Should the modifier methods return a reference to [=this=], so that you
+    can 'chain' methods?
+    (e.g. `sanitizer.allowElement("a").allowElement("span")`).
 
 <div algorithm>
 The <dfn for="Sanitizer" export>constructor</dfn>(|config|)
@@ -355,13 +361,6 @@ The <dfn for="Sanitizer" export>setDataAttributes</dfn>(|allow|) method steps ar
 </div>
 
 <div algorithm>
-The <dfn for="Sanitizer" export>setOtherMarkup</dfn>(|allow|) method steps are:
-
-1. Set [=this=]'s [=internal slot=]'s {{SanitizerConfig/otherMarkup}} to |allow|.
-
-</div>
-
-<div algorithm>
 The <dfn for="Sanitizer" export>removeUnsafe</dfn>() method steps are:
 
 1. Update [=this=]'s [=internal slot=] with the result of calling [=remove unsafe=]
@@ -402,10 +401,10 @@ dictionary SanitizerConfig {
 
   boolean comments;
   boolean dataAttributes;
-  boolean otherMarkup;
 };
 </pre>
 
+ISSUE: Sould members be required, or have declared defaults?
 
 # Algorithms # {#algorithms}
 
@@ -480,7 +479,7 @@ template contents). It consistes of these steps:
   1. else:
     1. Let |elementName| be a {{SanitizerElementNamespace}} with |child|'s
        [=Element/local name=] and [=Element/namespace=].
-    1. If |config|["{{SanitizerConfig/removeElements}}"] [=SanitizerConfig/contains=] |elementName|, or if |config|["{{SanitizerConfig/elements}}"] does not [=SanitizerConfig/contain=] |elementName| and |config|["{{SanitizerConfig/otherMarkup}}"] is false:
+    1. If |config|["{{SanitizerConfig/removeElements}}"] [=SanitizerConfig/contains=] |elementName|, or if |config|["{{SanitizerConfig/elements}}"] is not [=list/empty=] and does not [=SanitizerConfig/contain=] |elementName|:
        1. [=/remove=] |child|.
     1. If |config|["{{SanitizerConfig/replaceWithChildrenElements}}"] [=SanitizerConfig/contains=] |elementName|:
       1. Call [=sanitize core=] on |child| with |config| and
@@ -504,14 +503,13 @@ template contents). It consistes of these steps:
          1. Remove |attr| from |child|.
 
       1. If all of the following are false, then remove |attr| from |child|.
-         - |config|["{{SanitizerConfig/attributes}}"]
+         - |config|["{{SanitizerConfig/attributes}}"] [=list/exists=] and 
            [=SanitizerConfig/contains=] |attrName|
          - |config|["{{SanitizerConfig/elements}}"]["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
            [=SanitizerConfig/contains=] |attrName|
          - "data-" is a [=code unit prefix=] of [=Attr/local name=] and
             [=Attr/namespace=] is `null` and
             |config|["{{SanitizerConfig/dataAttributes}}"] is true
-         - |config|["{{SanitizerConfig/otherMarkup}}"]
       1. If |handle javascript navigation urls| and &laquo;[|elementName|, |attrName|]&raquo; matches an entry in the
          [=navigating URL attributes list=], and if |attr|'s [=protocol=] is
          "`javascript:`":
@@ -563,7 +561,6 @@ To <dfn for="Sanitizer">set a config</dfn> |config| on a {{Sanitizer}} |sanitize
   1. Call |sanitizer|.{{Sanitizer/removeAttribute()|removeAttribute}}(|item|).
 1. Call |sanitizer|.{{Sanitizer/setComment()|setComment}}(|config|[{{SanitizerConfig/comments}}]).
 1. Call |sanitizer|.{{Sanitizer/setDataAttributes()|setDataAttributes}}(|config|[{{SanitizerConfig/dataAttributes}}]).
-1. Call |sanitizer|.{{Sanitizer/setOtherMarkup()|setOtherMarkup}}(|config|[{{SanitizerConfig/otherMarkup}}]).
 
 Note: Previous versions of this spec had elaborate definitions of how to
   canonicalize a config. This has now effectively been moved into the method
@@ -657,7 +654,6 @@ It is as follows:
   attributes: [],
   removeAttributes: [],
   comments: true,
-  otherMarkup: true,
 }
 ```
 
@@ -671,7 +667,6 @@ script-content, and nothing else. It is as follows:
   ],
   removeAttributes: [....],
   comments: true,
-  otherMarkup: true
 }
 ```
 


### PR DESCRIPTION
[This isn't quite ready yet. Using a PR for tool support and discussion.]

This re-writes the config logic, based on discussions in the recent meetings, and with the intent to address issues #228, #229, and #233.

The corner stones are:

- The Sanitizer (and thus its config) become mutable. It has methods to add stuff to  any of the allow or deny lists.
- The actual config processing is now defined in terms of those methods.
- There is only one "safe-ify" operation, and it gets called once (for safe methods). This is the only different between safe and unsafe versions.
  - (Well, this is only a half-truth. The handling of javascript:-navigation URLs remains an odd-ball that is magically different between "safe" and "unsafe" versions.)
- The configs have an "other" setting, which allows them to express "everything" and "nothing" filters, which in turn allows us to treat the unsafe defaults as just another regular case.
- The entire "known" logic is gone. But in turn, the "baseline" is now back, and is a deny-list.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/237.html" title="Last updated on Nov 28, 2024, 5:42 PM UTC (e05db5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/237/85d25b5...otherdaniel:e05db5a.html" title="Last updated on Nov 28, 2024, 5:42 PM UTC (e05db5a)">Diff</a>