### PR TITLE
Sort built-in navigating URL attributes list and add iframe src

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -754,17 +754,22 @@ navigations are "unsafe", are as follows:
   ],
   <br>
   [
+    { "`name`" &rightarrow; "`button`", "`namespace`" &rightarrow; [=HTML namespace=] },
+    { "`name`" &rightarrow; "`formaction`", "`namespace`" &rightarrow; `null` }
+  ],
+  <br>
+  [
     { "`name`" &rightarrow; "`form`", "`namespace`" &rightarrow; [=HTML namespace=] },
     { "`name`" &rightarrow; "`action`", "`namespace`" &rightarrow; `null` }
   ],
   <br>
   [
-    { "`name`" &rightarrow; "`input`", "`namespace`" &rightarrow; [=HTML namespace=] },
-    { "`name`" &rightarrow; "`formaction`", "`namespace`" &rightarrow; `null` }
+    { "`name`" &rightarrow; "`iframe`", "`namespace`" &rightarrow; [=HTML namespace=] },
+    { "`name`" &rightarrow; "`src`", "`namespace`" &rightarrow; `null` }
   ],
   <br>
   [
-    { "`name`" &rightarrow; "`button`", "`namespace`" &rightarrow; [=HTML namespace=] },
+    { "`name`" &rightarrow; "`input`", "`namespace`" &rightarrow; [=HTML namespace=] },
     { "`name`" &rightarrow; "`formaction`", "`namespace`" &rightarrow; `null` }
   ],
   <br>


### PR DESCRIPTION
The list was missing `iframe src` and I also sorted the list


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mozfreddyb/sanitizer-api/pull/247.html" title="Last updated on Dec 19, 2024, 12:08 PM UTC (be6c893)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/247/4497de3...mozfreddyb:be6c893.html" title="Last updated on Dec 19, 2024, 12:08 PM UTC (be6c893)">Diff</a>