### PR TITLE
Run URL parser to determine URL protocol.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -478,7 +478,7 @@ template contents). It consistes of these steps:
 </div>
 
 <div algorithm>
-To determine whether an |attribute| <dfn>contains a javascript: URL</dfn>, do:
+To determine whether an |attribute| <dfn>contains a javascript: URL</dfn>:
 1. Let |url| be the result of running the [=basic URL parser=]
    on |attribute|'s [=get an attribute value|value=].
 1. If |url| is `failure`, then return false.

--- a/index.bs
+++ b/index.bs
@@ -471,9 +471,18 @@ template contents). It consistes of these steps:
             [=Attr/namespace=] is `null` and
             |configuration|["{{SanitizerConfig/dataAttributes}}"] is true
       1. If |handleJavascriptNavigationUrls| and &laquo;[|elementName|, |attrName|]&raquo; matches an entry in the
-         [=built-in navigating URL attributes list=], and if |attribute|'s [=protocol=] is
-         "`javascript:`":
+         [=built-in navigating URL attributes list=], and if |attribute|
+         [=contains a javascript: URL=]:
          1. Then remove |attribute| from |child|.
+
+</div>
+
+<div algorithm>
+To determine whether an |attribute| <dfn>contains a javascript: URL</dfn>, do:
+1. Let |url| be the result of running the [=basic URL parser=]
+   on |attribute|'s [=get an attribute value|value=].
+1. If |url| is `failure` return false.
+1. Return whether |url|'s [=url/scheme=] [=string/is=] "`javascript`".
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -481,7 +481,7 @@ template contents). It consistes of these steps:
 To determine whether an |attribute| <dfn>contains a javascript: URL</dfn>, do:
 1. Let |url| be the result of running the [=basic URL parser=]
    on |attribute|'s [=get an attribute value|value=].
-1. If |url| is `failure` return false.
+1. If |url| is `failure`, then return false.
 1. Return whether |url|'s [=url/scheme=] [=string/is=] "`javascript`".
 
 </div>


### PR DESCRIPTION
Run the basic URL parser to determine whether a URL is a `javascript:` URL.

Fixes: #246


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/248.html" title="Last updated on Jan 10, 2025, 12:53 PM UTC (2c33101)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/248/0e58018...otherdaniel:2c33101.html" title="Last updated on Jan 10, 2025, 12:53 PM UTC (2c33101)">Diff</a>