### PR TITLE
Normalize the empty string as namespace to be the null namespace.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -707,7 +707,7 @@ return the result of [=canonicalize a sanitizer name=] with |element| and the [=
 
 <div algorithm>
 In order to <dfn>canonicalize a sanitizer attribute</dfn> a
-{{SanitizerAttribute}} |attribute|, 
+{{SanitizerAttribute}} |attribute|,
 return the result of [=canonicalize a sanitizer name=] with |attribute| and `null` as the default namespace.
 </div>
 
@@ -718,9 +718,11 @@ namespace |defaultNamespace|, run the following steps:
 1. [=Assert=]: |name| is either a {{DOMString}} or a [=dictionary=].
 1. If |name| is a {{DOMString}}, then return &laquo;[ "`name`" &rightarrow; |name|, "`namespace`" &rightarrow; |defaultNamespace|]&raquo;.
 1. [=Assert=]: |name| is a [=dictionary=] and |name|["name"] [=map/exists=].
+1. Let |namespace| be |name|["namespace"] if it [=map/exists=], otherwise |defaultNamespace|.
+1. If |namespace| is `""`, set it to null.
 1. Return &laquo;[ <br>
   "`name`" &rightarrow; |name|["name"], <br>
-  "`namespace`" &rightarrow; ( |name|["namespace"] if it [=map/exists=], otherwise |defaultNamespace| ) <br>
+  "`namespace`" &rightarrow; |namespace| <br>
   ]&raquo;.
 
 </div>


### PR DESCRIPTION
This follows discussion in #262 and precedent in
https://dom.spec.whatwg.org/#validate-and-extract

Fixes: #262