### PR TITLE
Rename: replaceElementWithChildren to replaceWithChildrenElement

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -265,7 +265,7 @@ interface Sanitizer {
   // Modify a Sanitizer's lists and fields:
   undefined allowElement(SanitizerElementWithAttributes element);
   undefined removeElement(SanitizerElement element);
-  undefined replaceElementWithChildren(SanitizerElement element);
+  undefined replaceWithChildrenElement(SanitizerElement element);
   undefined allowAttribute(SanitizerAttribute attribute);
   undefined removeAttribute(SanitizerAttribute attribute);
   undefined setComments(boolean allow);
@@ -304,7 +304,7 @@ to [=remove an element=] with |element| and [=this=]'s [=Sanitizer/configuration
 </div>
 
 <div algorithm>
-The <dfn for="Sanitizer" export>replaceElementWithChildren</dfn>(|element|) method steps are to [=replace an element with its children=] with |element| and [=this=]'s [=Sanitizer/configuration=].
+The <dfn for="Sanitizer" export>replaceWithChildrenElement</dfn>(|element|) method steps are to [=replace an element with its children=] with |element| and [=this=]'s [=Sanitizer/configuration=].
 </div>
 
 <div algorithm>


### PR DESCRIPTION
This renames the replaceElementWithChildren method to replaceWithChildrenElement.

The new name is consistent with the dictionary naming, with naming of the other methods, and with the tests.
And, as far as I remember, with what the group had decided. I'm guessing I had just mistyped the name in the PR and
then didn't notice. :) 

Thanks for evilpie for pointing it out.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/267.html" title="Last updated on Mar 5, 2025, 2:31 PM UTC (0140f8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/267/80dfa6f...otherdaniel:0140f8b.html" title="Last updated on Mar 5, 2025, 2:31 PM UTC (0140f8b)">Diff</a>