### PR TITLE
Fix reference to HTML fragment parsing algorithm.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -27,6 +27,7 @@ spec:infra; type:dfn; text: user agent
 <pre class="anchors">
 text: window.toStaticHTML(); type: method; url: https://msdn.microsoft.com/en-us/library/cc848922(v=vs.85).aspx
 text: parse HTML from a string; type: dfn; url: https://html.spec.whatwg.org/#parse-html-from-a-string
+text: HTML fragment parsing algorithm; type: dfn; url: https://html.spec.whatwg.org/#html-fragment-parsing-algorithm
 </pre>
 <pre class="biblio">
 {
@@ -378,7 +379,7 @@ To <dfn>set and filter HTML</dfn>, given an {{Element}} or {{DocumentFragment}}
    [=SVG namespace=], then return.
 1. Let |sanitizer| be the result of calling [=get a sanitizer instance from options=]
    with |options| and |safe|.
-1. Let |newChildren| be the result of the HTML [=fragment parsing algorithm steps=]
+1. Let |newChildren| be the result of the [=HTML fragment parsing algorithm=]
    given |contextElement|, |html|, and true.
 1. Let |fragment| be a new {{DocumentFragment}} whose [=node document=] is |contextElement|'s [=node document=].
 1. [=list/iterate|For each=] |node| in |newChildren|, [=list/append=] |node| to |fragment|.


### PR DESCRIPTION
It turns out that "fragment parsing algorithm steps" and "HTML fragment parsing algorithm" are related, but not the same reference. This fixes the confusion. Also add "HTML fragment parsing algorithm" as an explicit anchor, since the
reference isn't exported.

Fixes: #272


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/276.html" title="Last updated on Mar 19, 2025, 3:22 PM UTC (2784290)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/276/445eca6...otherdaniel:2784290.html" title="Last updated on Mar 19, 2025, 3:22 PM UTC (2784290)">Diff</a>