### PR TITLE
Handle replaceWithChildrenElements before the elements allowlist in sanitize core

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -448,14 +448,14 @@ template contents). It consistes of these steps:
   1. Otherwise:
     1. Let |elementName| be a {{SanitizerElementNamespace}} with |child|'s
        [=Element/local name=] and [=Element/namespace=].
-    1. If |configuration|["{{SanitizerConfig/removeElements}}"] [=SanitizerConfig/contains=] |elementName|, or if |configuration|["{{SanitizerConfig/elements}}"] is not [=list/empty=] and does not [=SanitizerConfig/contain=] |elementName|:
-       1. [=/Remove=] |child|.
-       1. [=Continue=].
     1. If |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"] [=SanitizerConfig/contains=] |elementName|:
       1. Call [=sanitize core=] on |child| with |configuration| and
           |handleJavascriptNavigationUrls|.
       1. Call [=replace all=] with |child|'s [=tree/children=] within |child|.
       1. [=Continue=].
+    1. If |configuration|["{{SanitizerConfig/removeElements}}"] [=SanitizerConfig/contains=] |elementName|, or if |configuration|["{{SanitizerConfig/elements}}"] is not [=list/empty=] and does not [=SanitizerConfig/contain=] |elementName|:
+       1. [=/Remove=] |child|.
+       1. [=Continue=].
     1. If |elementName| [=equals=] &laquo;[ "`name`" &rightarrow; "`template`",
        "`namespace`" &rightarrow; [=HTML namespace=] ]&raquo;
       1. Then call [=sanitize core=] on |child|'s [=template contents=] with


### PR DESCRIPTION
Fixes #261

Currently, using a replaceWithChildrenElements list together with an elements list does not really work.
Because we first remove all elements that are not in the elements list, which means there is nothing to replace,
because it's impossible for an element to be in both lists.

Example:
```
setHTML("<p><i>hi<i></p>") { elements: ["i"], replaceWithChildrenElements: ["p"] })
```

Before this would just remove the `<p>` element. After this change they are replaced with their allowed child elements
(i.e. `<i>`).


Depends on #275


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evilpie/sanitizer-api/pull/277.html" title="Last updated on Mar 19, 2025, 3:53 PM UTC (49b26b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/277/8265187...evilpie:49b26b0.html" title="Last updated on Mar 19, 2025, 3:53 PM UTC (49b26b0)">Diff</a>