### PR TITLE
Dedupe defaults

### DIFF
--- a/builtins/safe-default-configuration.json
+++ b/builtins/safe-default-configuration.json
@@ -248,22 +248,12 @@
     {
       "name": "dfn",
       "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": [
-        {
-          "name": "title",
-          "namespace": null
-        }
-      ]
+      "attributes": []
     },
     {
       "name": "abbr",
       "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": [
-        {
-          "name": "title",
-          "namespace": null
-        }
-      ]
+      "attributes": []
     },
     {
       "name": "ruby",
@@ -353,22 +343,12 @@
     {
       "name": "bdi",
       "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": [
-        {
-          "name": "dir",
-          "namespace": null
-        }
-      ]
+      "attributes": []
     },
     {
       "name": "bdo",
       "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": [
-        {
-          "name": "dir",
-          "namespace": null
-        }
-      ]
+      "attributes": []
     },
     {
       "name": "span",


### PR DESCRIPTION
The safe-default-configuration.txt mirrors the HTML spec, and contains a few attributes both as global attributes as well as per-element attributes (because those elements assign specific semantics to them). Copying both of them into our default config is redundant, and leaves to surprising behaviour if users remove the global attributes (and would still find per-element attributes).

This follows discussion in #271. We remove any dupes from the builtins; but leave the algorithms themselves alone.
This is implemented by more comprehensive dupe-filtering in the script that generates the builtins.

Fixes: #271


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/278.html" title="Last updated on Mar 20, 2025, 12:09 PM UTC (c6d555f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/278/8265187...otherdaniel:c6d555f.html" title="Last updated on Mar 20, 2025, 12:09 PM UTC (c6d555f)">Diff</a>