### PR TITLE
Add note about relative URLs in javascript:-URL origins.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -522,6 +522,12 @@ The SVG animation case is covered by the
 
 </div>
 
+Note: Within an origin with a `javascript:` URL &mdash; that is, after the
+    browser has already navigated to a `javascript:`-URL &mdash;
+    [=relative-URL strings=] may turn into `javascript:`-URLs, because the
+    origin may be used as the [=base URL=]. These cases are not handled by
+    the Sanitizer.
+
 <div algorithm>
 To determine whether an |attribute| <dfn>contains a javascript: URL</dfn>:
 1. Let |url| be the result of running the [=basic URL parser=]


### PR DESCRIPTION
A relative URL in a javascript:-origin may turn into another javascript:-URL. Add a note to alert the reader that Sanitizer API will not handle this case.

This follows discussion in #154.