### PR TITLE
Don't allow comments and data-attributes when creating a default Sanitizer

### DIFF
--- a/builtins/safe-default-configuration.json
+++ b/builtins/safe-default-configuration.json
@@ -783,5 +783,7 @@
       "name": "scriptlevel",
       "namespace": null
     }
-  ]
+  ],
+  "comments": false,
+  "dataAttributes": false
 }

--- a/builtins/safe-default-configuration.py
+++ b/builtins/safe-default-configuration.py
@@ -19,7 +19,7 @@ def main():
     except BaseException as err:
       parser.error("Cannot read from --input file.")
 
-    result = { "elements": [], "attributes": [] }
+    result = { "elements": [], "attributes": [], "comments": False, "dataAttributes": False }
     current = []
     for line in lines.split("\n"):
       if not line:

--- a/index.bs
+++ b/index.bs
@@ -408,7 +408,7 @@ Note: This algorithm works for both {{SetHTMLOptions}} and
 1. If |sanitizerSpec| is a [=dictionary=]:
    1. Let |sanitizer| be a new {{Sanitizer}} instance.
    1. Let |setConfigurationResult| be the result of [=set a configuration=]
-      with |sanitizerSpec| and |safe| on |sanitizer|.
+      with |sanitizerSpec| and [=boolean/not=] |safe| on |sanitizer|.
    1. If |setConfigurationResult| is false, [=throw=] a {{TypeError}}.
    1. Set |sanitizerSpec| to |sanitizer|.
 1. [=Assert=]: |sanitizerSpec| is a {{Sanitizer}} instance.
@@ -637,7 +637,7 @@ To <dfn for="SanitizerConfig">remove unsafe</dfn> from a |configuration|, do thi
 </div>
 
 <div algorithm>
-To <dfn for="Sanitizer">set a configuration</dfn>, given a [=dictionary=] |configuration|, a [=boolean=] |safe|, and a {{Sanitizer}} |sanitizer|:
+To <dfn for="Sanitizer">set a configuration</dfn>, given a [=dictionary=] |configuration|, a [=boolean=] |allowCommentsAndDataAttributes|, and a {{Sanitizer}} |sanitizer|:
 
 1. [=list/iterate|For each=] |element| of |configuration|["{{SanitizerConfig/elements}}"] do:
   1. Call [=allow an element=] with |element| and |sanitizer|'s [=Sanitizer/configuration=].
@@ -652,13 +652,13 @@ To <dfn for="Sanitizer">set a configuration</dfn>, given a [=dictionary=] |confi
 1. If |configuration|["{{SanitizerConfig/comments}}"] [=map/exists=]:
   1. Then call [=set comments=] with |configuration|["{{SanitizerConfig/comments}}"]
       and |sanitizer|'s [=Sanitizer/configuration=].
-  1. Otherwise call [=set comments=] with [=boolean/not=] |safe|
+  1. Otherwise call [=set comments=] with |allowCommentsAndDataAttributes|
       and |sanitizer|'s [=Sanitizer/configuration=].
 1. If |configuration|["{{SanitizerConfig/dataAttributes}}"] [=map/exists=]:
     1. Then call [=set data attributes=] with
         |configuration|["{{SanitizerConfig/dataAttributes}}"]
         and |sanitizer|'s [=Sanitizer/configuration=].
-    1. Otherwise call [=set data attributes=] with [=boolean/not=] |safe|
+    1. Otherwise call [=set data attributes=] with |allowCommentsAndDataAttributes|
         and |sanitizer|'s [=Sanitizer/configuration=].
 1. Return whether all of the following are true:
     - [=list/size=] of |configuration|["{{SanitizerConfig/elements}}"] equals

--- a/index.bs
+++ b/index.bs
@@ -286,7 +286,8 @@ method steps are:
 1. If |configuration| is a {{SanitizerPresets}} [=string=], then:
     1. [=Assert=]: |configuration| [=is=] {{SanitizerPresets/default}}.
     1. Set |configuration| to the [=built-in safe default configuration=].
-1. Let |valid| be the return value of [=set a configuration|setting=] |configuration| on [=this=].
+1. Let |valid| be the return value of [=set a configuration=] with
+   |configuration| and true on [=this=].
 1. If |valid| is false, then throw a {{TypeError}}.
 
 </div>


### PR DESCRIPTION
1. Changes the parameter of **_set a configuration_** from *safe* to the inverted *allowCommentsAndDataAttributes*.
2. From the constructor don't allow comment/attributes when creating a `"default"` Sanitizer.

Fixes #273


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evilpie/sanitizer-api/pull/284.html" title="Last updated on Apr 2, 2025, 9:58 AM UTC (f94ccc1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/284/3cd0ca8...evilpie:f94ccc1.html" title="Last updated on Apr 2, 2025, 9:58 AM UTC (f94ccc1)">Diff</a>