### PR TITLE
Re-work configuration handling and sanitize-core.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -411,10 +411,10 @@ Several conditions need to hold for a configuration to be valid:
     {{SanitizerConfig/attributes}} allow-list. The {{SanitizerConfig/dataAttributes}}
     attribute is only allowed when a {{SanitizerConfig/attributes}} list is used.
 - Duplicate entries between different global lists:
-  - There are no duplicate entries (i.e. no same elements) between
+  - There are no duplicate entries (i.e., no same elements) between
     {{SanitizerConfig/elements}}, {{SanitizerConfig/removeElements}}, or
     {{SanitizerConfig/replaceWithChildrenElements}}.
-  - There are no duplicate entries (i.e. no same attributes) between
+  - There are no duplicate entries (i.e., no same attributes) between
     {{SanitizerConfig/attributes}} or {{SanitizerConfig/removeAttributes}}.
 - Duplicate entries on the same element:
   - There are no duplicate entries between {{SanitizerElementNamespaceWithAttributes/attributes}}
@@ -572,7 +572,7 @@ Note: [=set a configuration|Setting a configuration=] from a [=dictionary=] will
 normalization. In particular, if both allow- and remove-lists are missing, it will interpret this
 as an empty remove-list. So `{}` itself is not a [=SanitizerConfig/valid=] configuration, but it
 will be normalized to `{removeElements:[],removeAttributes:[]}`, which is. This normalization step
-was chosen in order to have a missing dictionary be consistent with an empty one, i.e. to have
+was chosen in order to have a missing dictionary be consistent with an empty one, i.e., to have
 `setHTMLUnsafe(txt)` be consistent with `setHTMLUnsafe(txt, {sanitizer: {}})`.
 
 # Algorithms # {#algorithms}


### PR DESCRIPTION
This PR is meant to capture our recent discussion. It surely needs more editing; but I think the general structure is there. I'd be particularly interested in quick feedback on whether this accurately captures the discussion consensus.

-------------------
This re-writes config handling and sanitize-core based on 2025-05-28 and 2025-05-14 meeting discussion. This would replace #285.

Since we couldn't quite agree on whether redundent global attribute and per-element attribute definitions should be considered an error, I have tried to cover both. Where they differ, a statement "IF DISALLOW REDUNDANT PER-ELEMENT-ATTRIBUTES" contains the additional checks needed to disallow this.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/296.html" title="Last updated on Sep 12, 2025, 3:21 PM UTC (f1e0dae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/296/50ed6b6...otherdaniel:f1e0dae.html" title="Last updated on Sep 12, 2025, 3:21 PM UTC (f1e0dae)">Diff</a>