### PR TITLE
De-normalize built-in safe default configuration, for better readability.

### DIFF
--- a/builtins/safe-default-configuration.json
+++ b/builtins/safe-default-configuration.json
@@ -1,1413 +1,560 @@
 {
   "elements": [
-    {
-      "name": "html",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "head",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "title",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "body",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "article",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "section",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "nav",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "aside",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "h1",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "h2",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "h3",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "h4",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "h5",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "h6",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "hgroup",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "header",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "footer",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "address",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "p",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "hr",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "pre",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
+    "html",
+    "head",
+    "title",
+    "body",
+    "article",
+    "section",
+    "nav",
+    "aside",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "hgroup",
+    "header",
+    "footer",
+    "address",
+    "p",
+    "hr",
+    "pre",
     {
       "name": "blockquote",
       "namespace": "http://www.w3.org/1999/xhtml",
       "attributes": [
-        {
-          "name": "cite",
-          "namespace": null
-        }
+        "cite"
       ]
     },
     {
       "name": "ol",
       "namespace": "http://www.w3.org/1999/xhtml",
       "attributes": [
-        {
-          "name": "reversed",
-          "namespace": null
-        },
-        {
-          "name": "start",
-          "namespace": null
-        },
-        {
-          "name": "type",
-          "namespace": null
-        }
+        "reversed",
+        "start",
+        "type"
       ]
     },
-    {
-      "name": "ul",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "menu",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
+    "ul",
+    "menu",
     {
       "name": "li",
       "namespace": "http://www.w3.org/1999/xhtml",
       "attributes": [
-        {
-          "name": "value",
-          "namespace": null
-        }
+        "value"
       ]
     },
-    {
-      "name": "dl",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "dt",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "dd",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "figure",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "figcaption",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "main",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "search",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "div",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
+    "dl",
+    "dt",
+    "dd",
+    "figure",
+    "figcaption",
+    "main",
+    "search",
+    "div",
     {
       "name": "a",
       "namespace": "http://www.w3.org/1999/xhtml",
       "attributes": [
-        {
-          "name": "href",
-          "namespace": null
-        },
-        {
-          "name": "rel",
-          "namespace": null
-        },
-        {
-          "name": "hreflang",
-          "namespace": null
-        },
-        {
-          "name": "type",
-          "namespace": null
-        }
+        "href",
+        "rel",
+        "hreflang",
+        "type"
       ]
     },
-    {
-      "name": "em",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "strong",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "small",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "s",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "cite",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "q",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "dfn",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "abbr",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "ruby",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "rt",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "rp",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
+    "em",
+    "strong",
+    "small",
+    "s",
+    "cite",
+    "q",
+    "dfn",
+    "abbr",
+    "ruby",
+    "rt",
+    "rp",
     {
       "name": "data",
       "namespace": "http://www.w3.org/1999/xhtml",
       "attributes": [
-        {
-          "name": "value",
-          "namespace": null
-        }
+        "value"
       ]
     },
     {
       "name": "time",
       "namespace": "http://www.w3.org/1999/xhtml",
       "attributes": [
-        {
-          "name": "datetime",
-          "namespace": null
-        }
+        "datetime"
       ]
     },
-    {
-      "name": "code",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "var",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "samp",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "kbd",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "sub",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "sup",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "i",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "b",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "u",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "mark",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "bdi",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "bdo",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "span",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "br",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "wbr",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
+    "code",
+    "var",
+    "samp",
+    "kbd",
+    "sub",
+    "sup",
+    "i",
+    "b",
+    "u",
+    "mark",
+    "bdi",
+    "bdo",
+    "span",
+    "br",
+    "wbr",
     {
       "name": "ins",
       "namespace": "http://www.w3.org/1999/xhtml",
       "attributes": [
-        {
-          "name": "cite",
-          "namespace": null
-        },
-        {
-          "name": "datetime",
-          "namespace": null
-        }
+        "cite",
+        "datetime"
       ]
     },
     {
       "name": "del",
       "namespace": "http://www.w3.org/1999/xhtml",
       "attributes": [
-        {
-          "name": "cite",
-          "namespace": null
-        },
-        {
-          "name": "datetime",
-          "namespace": null
-        }
+        "cite",
+        "datetime"
       ]
     },
-    {
-      "name": "table",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "caption",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
+    "table",
+    "caption",
     {
       "name": "colgroup",
       "namespace": "http://www.w3.org/1999/xhtml",
       "attributes": [
-        {
-          "name": "span",
-          "namespace": null
-        }
+        "span"
       ]
     },
     {
       "name": "col",
       "namespace": "http://www.w3.org/1999/xhtml",
       "attributes": [
-        {
-          "name": "span",
-          "namespace": null
-        }
+        "span"
       ]
     },
-    {
-      "name": "tbody",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "thead",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "tfoot",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
-    {
-      "name": "tr",
-      "namespace": "http://www.w3.org/1999/xhtml",
-      "attributes": []
-    },
+    "tbody",
+    "thead",
+    "tfoot",
+    "tr",
     {
       "name": "td",
       "namespace": "http://www.w3.org/1999/xhtml",
       "attributes": [
-        {
-          "name": "colspan",
-          "namespace": null
-        },
-        {
-          "name": "rowspan",
-          "namespace": null
-        },
-        {
-          "name": "headers",
-          "namespace": null
-        }
+        "colspan",
+        "rowspan",
+        "headers"
       ]
     },
     {
       "name": "th",
       "namespace": "http://www.w3.org/1999/xhtml",
       "attributes": [
-        {
-          "name": "colspan",
-          "namespace": null
-        },
-        {
-          "name": "rowspan",
-          "namespace": null
-        },
-        {
-          "name": "headers",
-          "namespace": null
-        },
-        {
-          "name": "scope",
-          "namespace": null
-        },
-        {
-          "name": "abbr",
-          "namespace": null
-        }
+        "colspan",
+        "rowspan",
+        "headers",
+        "scope",
+        "abbr"
       ]
     },
     {
       "name": "math",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "merror",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "mfrac",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "mi",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "mmultiscripts",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "mn",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "mo",
       "namespace": "http://www.w3.org/1998/Math/MathML",
       "attributes": [
-        {
-          "name": "form",
-          "namespace": null
-        },
-        {
-          "name": "fence",
-          "namespace": null
-        },
-        {
-          "name": "separator",
-          "namespace": null
-        },
-        {
-          "name": "lspace",
-          "namespace": null
-        },
-        {
-          "name": "rspace",
-          "namespace": null
-        },
-        {
-          "name": "stretchy",
-          "namespace": null
-        },
-        {
-          "name": "symmetric",
-          "namespace": null
-        },
-        {
-          "name": "maxsize",
-          "namespace": null
-        },
-        {
-          "name": "minsize",
-          "namespace": null
-        },
-        {
-          "name": "largeop",
-          "namespace": null
-        },
-        {
-          "name": "movablelimits",
-          "namespace": null
-        }
+        "form",
+        "fence",
+        "separator",
+        "lspace",
+        "rspace",
+        "stretchy",
+        "symmetric",
+        "maxsize",
+        "minsize",
+        "largeop",
+        "movablelimits"
       ]
     },
     {
       "name": "mover",
       "namespace": "http://www.w3.org/1998/Math/MathML",
       "attributes": [
-        {
-          "name": "accent",
-          "namespace": null
-        }
+        "accent"
       ]
     },
     {
       "name": "mpadded",
       "namespace": "http://www.w3.org/1998/Math/MathML",
       "attributes": [
-        {
-          "name": "width",
-          "namespace": null
-        },
-        {
-          "name": "height",
-          "namespace": null
-        },
-        {
-          "name": "depth",
-          "namespace": null
-        },
-        {
-          "name": "lspace",
-          "namespace": null
-        },
-        {
-          "name": "voffset",
-          "namespace": null
-        }
+        "width",
+        "height",
+        "depth",
+        "lspace",
+        "voffset"
       ]
     },
     {
       "name": "mphantom",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "mprescripts",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "mroot",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "mrow",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "ms",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "mspace",
       "namespace": "http://www.w3.org/1998/Math/MathML",
       "attributes": [
-        {
-          "name": "width",
-          "namespace": null
-        },
-        {
-          "name": "height",
-          "namespace": null
-        },
-        {
-          "name": "depth",
-          "namespace": null
-        }
+        "width",
+        "height",
+        "depth"
       ]
     },
     {
       "name": "msqrt",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "mstyle",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "msub",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "msubsup",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "msup",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "mtable",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "mtd",
       "namespace": "http://www.w3.org/1998/Math/MathML",
       "attributes": [
-        {
-          "name": "columnspan",
-          "namespace": null
-        },
-        {
-          "name": "rowspan",
-          "namespace": null
-        }
+        "columnspan",
+        "rowspan"
       ]
     },
     {
       "name": "mtext",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "mtr",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "munder",
       "namespace": "http://www.w3.org/1998/Math/MathML",
       "attributes": [
-        {
-          "name": "accentunder",
-          "namespace": null
-        }
+        "accentunder"
       ]
     },
     {
       "name": "munderover",
       "namespace": "http://www.w3.org/1998/Math/MathML",
       "attributes": [
-        {
-          "name": "accent",
-          "namespace": null
-        },
-        {
-          "name": "accentunder",
-          "namespace": null
-        }
+        "accent",
+        "accentunder"
       ]
     },
     {
       "name": "semantics",
-      "namespace": "http://www.w3.org/1998/Math/MathML",
-      "attributes": []
+      "namespace": "http://www.w3.org/1998/Math/MathML"
     },
     {
       "name": "svg",
       "namespace": "http://www.w3.org/2000/svg",
       "attributes": [
-        {
-          "name": "viewBox",
-          "namespace": null
-        },
-        {
-          "name": "preserveAspectRatio",
-          "namespace": null
-        },
-        {
-          "name": "height",
-          "namespace": null
-        },
-        {
-          "name": "width",
-          "namespace": null
-        },
-        {
-          "name": "x",
-          "namespace": null
-        },
-        {
-          "name": "y",
-          "namespace": null
-        }
+        "viewBox",
+        "preserveAspectRatio",
+        "height",
+        "width",
+        "x",
+        "y"
       ]
     },
     {
       "name": "g",
-      "namespace": "http://www.w3.org/2000/svg",
-      "attributes": []
+      "namespace": "http://www.w3.org/2000/svg"
     },
     {
       "name": "defs",
-      "namespace": "http://www.w3.org/2000/svg",
-      "attributes": []
+      "namespace": "http://www.w3.org/2000/svg"
     },
     {
       "name": "symbol",
       "namespace": "http://www.w3.org/2000/svg",
       "attributes": [
-        {
-          "name": "preserveAspectRatio",
-          "namespace": null
-        },
-        {
-          "name": "viewBox",
-          "namespace": null
-        },
-        {
-          "name": "refX",
-          "namespace": null
-        },
-        {
-          "name": "refY",
-          "namespace": null
-        },
-        {
-          "name": "height",
-          "namespace": null
-        },
-        {
-          "name": "width",
-          "namespace": null
-        },
-        {
-          "name": "x",
-          "namespace": null
-        },
-        {
-          "name": "y",
-          "namespace": null
-        }
+        "preserveAspectRatio",
+        "viewBox",
+        "refX",
+        "refY",
+        "height",
+        "width",
+        "x",
+        "y"
       ]
     },
     {
       "name": "title",
-      "namespace": "http://www.w3.org/2000/svg",
-      "attributes": []
+      "namespace": "http://www.w3.org/2000/svg"
     },
     {
       "name": "desc",
-      "namespace": "http://www.w3.org/2000/svg",
-      "attributes": []
+      "namespace": "http://www.w3.org/2000/svg"
     },
     {
       "name": "metadata",
-      "namespace": "http://www.w3.org/2000/svg",
-      "attributes": []
+      "namespace": "http://www.w3.org/2000/svg"
     },
     {
       "name": "path",
       "namespace": "http://www.w3.org/2000/svg",
       "attributes": [
-        {
-          "name": "pathLength",
-          "namespace": null
-        },
-        {
-          "name": "d",
-          "namespace": null
-        }
+        "pathLength",
+        "d"
       ]
     },
     {
       "name": "rect",
       "namespace": "http://www.w3.org/2000/svg",
       "attributes": [
-        {
-          "name": "pathLength",
-          "namespace": null
-        },
-        {
-          "name": "x",
-          "namespace": null
-        },
-        {
-          "name": "y",
-          "namespace": null
-        },
-        {
-          "name": "width",
-          "namespace": null
-        },
-        {
-          "name": "height",
-          "namespace": null
-        },
-        {
-          "name": "rx",
-          "namespace": null
-        },
-        {
-          "name": "ry",
-          "namespace": null
-        }
+        "pathLength",
+        "x",
+        "y",
+        "width",
+        "height",
+        "rx",
+        "ry"
       ]
     },
     {
       "name": "circle",
       "namespace": "http://www.w3.org/2000/svg",
       "attributes": [
-        {
-          "name": "pathLength",
-          "namespace": null
-        },
-        {
-          "name": "cx",
-          "namespace": null
-        },
-        {
-          "name": "cy",
-          "namespace": null
-        },
-        {
-          "name": "r",
-          "namespace": null
-        }
+        "pathLength",
+        "cx",
+        "cy",
+        "r"
       ]
     },
     {
       "name": "ellipse",
       "namespace": "http://www.w3.org/2000/svg",
       "attributes": [
-        {
-          "name": "pathLength",
-          "namespace": null
-        },
-        {
-          "name": "cx",
-          "namespace": null
-        },
-        {
-          "name": "cy",
-          "namespace": null
-        },
-        {
-          "name": "rx",
-          "namespace": null
-        },
-        {
-          "name": "ry",
-          "namespace": null
-        }
+        "pathLength",
+        "cx",
+        "cy",
+        "rx",
+        "ry"
       ]
     },
     {
       "name": "line",
       "namespace": "http://www.w3.org/2000/svg",
       "attributes": [
-        {
-          "name": "pathLength",
-          "namespace": null
-        },
-        {
-          "name": "x1",
-          "namespace": null
-        },
-        {
-          "name": "y1",
-          "namespace": null
-        },
-        {
-          "name": "x2",
-          "namespace": null
-        },
-        {
-          "name": "y2",
-          "namespace": null
-        }
+        "pathLength",
+        "x1",
+        "y1",
+        "x2",
+        "y2"
       ]
     },
     {
       "name": "polyline",
       "namespace": "http://www.w3.org/2000/svg",
       "attributes": [
-        {
-          "name": "pathLength",
-          "namespace": null
-        },
-        {
-          "name": "points",
-          "namespace": null
-        }
+        "pathLength",
+        "points"
       ]
     },
     {
       "name": "polygon",
       "namespace": "http://www.w3.org/2000/svg",
       "attributes": [
-        {
-          "name": "pathLength",
-          "namespace": null
-        },
-        {
-          "name": "points",
-          "namespace": null
-        }
+        "pathLength",
+        "points"
       ]
     },
     {
       "name": "text",
       "namespace": "http://www.w3.org/2000/svg",
       "attributes": [
-        {
-          "name": "lengthAdjust",
-          "namespace": null
-        },
-        {
-          "name": "x",
-          "namespace": null
-        },
-        {
-          "name": "y",
-          "namespace": null
-        },
-        {
-          "name": "dx",
-          "namespace": null
-        },
-        {
-          "name": "dy",
-          "namespace": null
-        },
-        {
-          "name": "rotate",
-          "namespace": null
-        },
-        {
-          "name": "textLength",
-          "namespace": null
-        }
+        "lengthAdjust",
+        "x",
+        "y",
+        "dx",
+        "dy",
+        "rotate",
+        "textLength"
       ]
     },
     {
       "name": "tspan",
       "namespace": "http://www.w3.org/2000/svg",
       "attributes": [
-        {
-          "name": "lengthAdjust",
-          "namespace": null
-        },
-        {
-          "name": "x",
-          "namespace": null
-        },
-        {
-          "name": "y",
-          "namespace": null
-        },
-        {
-          "name": "dx",
-          "namespace": null
-        },
-        {
-          "name": "dy",
-          "namespace": null
-        },
-        {
-          "name": "rotate",
-          "namespace": null
-        },
-        {
-          "name": "textLength",
-          "namespace": null
-        }
+        "lengthAdjust",
+        "x",
+        "y",
+        "dx",
+        "dy",
+        "rotate",
+        "textLength"
       ]
     },
     {
       "name": "textPath",
       "namespace": "http://www.w3.org/2000/svg",
       "attributes": [
-        {
-          "name": "lengthAdjust",
-          "namespace": null
-        },
-        {
-          "name": "textLength",
-          "namespace": null
-        },
-        {
-          "name": "path",
-          "namespace": null
-        },
-        {
-          "name": "startOffset",
-          "namespace": null
-        },
-        {
-          "name": "method",
-          "namespace": null
-        },
-        {
-          "name": "spacing",
-          "namespace": null
-        },
-        {
-          "name": "side",
-          "namespace": null
-        }
+        "lengthAdjust",
+        "textLength",
+        "path",
+        "startOffset",
+        "method",
+        "spacing",
+        "side"
       ]
     },
     {
       "name": "foreignObject",
       "namespace": "http://www.w3.org/2000/svg",
       "attributes": [
-        {
-          "name": "x",
-          "namespace": null
-        },
-        {
-          "name": "y",
-          "namespace": null
-        },
-        {
-          "name": "width",
-          "namespace": null
-        },
-        {
-          "name": "height",
-          "namespace": null
-        }
+        "x",
+        "y",
+        "width",
+        "height"
       ]
     },
     {
       "name": "marker",
       "namespace": "http://www.w3.org/2000/svg",
       "attributes": [
-        {
-          "name": "viewBox",
-          "namespace": null
-        },
-        {
-          "name": "preserveAspectRatio",
-          "namespace": null
-        },
-        {
-          "name": "refX",
-          "namespace": null
-        },
-        {
-          "name": "refY",
-          "namespace": null
-        },
-        {
-          "name": "markerUnits",
-          "namespace": null
-        },
-        {
-          "name": "markerWidth",
-          "namespace": null
-        },
-        {
-          "name": "markerHeight",
-          "namespace": null
-        },
-        {
-          "name": "orient",
-          "namespace": null
-        }
+        "viewBox",
+        "preserveAspectRatio",
+        "refX",
+        "refY",
+        "markerUnits",
+        "markerWidth",
+        "markerHeight",
+        "orient"
       ]
     }
   ],
   "attributes": [
-    {
-      "name": "dir",
-      "namespace": null
-    },
-    {
-      "name": "lang",
-      "namespace": null
-    },
-    {
-      "name": "title",
-      "namespace": null
-    },
-    {
-      "name": "displaystyle",
-      "namespace": null
-    },
-    {
-      "name": "mathbackground",
-      "namespace": null
-    },
-    {
-      "name": "mathcolor",
-      "namespace": null
-    },
-    {
-      "name": "mathsize",
-      "namespace": null
-    },
-    {
-      "name": "scriptlevel",
-      "namespace": null
-    },
-    {
-      "name": "fill",
-      "namespace": null
-    },
-    {
-      "name": "transform",
-      "namespace": null
-    },
-    {
-      "name": "alignment-baseline",
-      "namespace": null
-    },
-    {
-      "name": "baseline-shift",
-      "namespace": null
-    },
-    {
-      "name": "clip-path",
-      "namespace": null
-    },
-    {
-      "name": "clip-rule",
-      "namespace": null
-    },
-    {
-      "name": "color",
-      "namespace": null
-    },
-    {
-      "name": "color-interpolation",
-      "namespace": null
-    },
-    {
-      "name": "color-interpolation-filters",
-      "namespace": null
-    },
-    {
-      "name": "cursor",
-      "namespace": null
-    },
-    {
-      "name": "direction",
-      "namespace": null
-    },
-    {
-      "name": "display",
-      "namespace": null
-    },
-    {
-      "name": "dominant-baseline",
-      "namespace": null
-    },
-    {
-      "name": "fill-opacity",
-      "namespace": null
-    },
-    {
-      "name": "fill-rule",
-      "namespace": null
-    },
-    {
-      "name": "filter",
-      "namespace": null
-    },
-    {
-      "name": "flood-color",
-      "namespace": null
-    },
-    {
-      "name": "flood-opacity",
-      "namespace": null
-    },
-    {
-      "name": "font-family",
-      "namespace": null
-    },
-    {
-      "name": "font-size",
-      "namespace": null
-    },
-    {
-      "name": "font-size-adjust",
-      "namespace": null
-    },
-    {
-      "name": "font-stretch",
-      "namespace": null
-    },
-    {
-      "name": "font-style",
-      "namespace": null
-    },
-    {
-      "name": "font-variant",
-      "namespace": null
-    },
-    {
-      "name": "font-weight",
-      "namespace": null
-    },
-    {
-      "name": "glyph-orientation-horizontal",
-      "namespace": null
-    },
-    {
-      "name": "glyph-orientation-vertical",
-      "namespace": null
-    },
-    {
-      "name": "image-rendering",
-      "namespace": null
-    },
-    {
-      "name": "letter-spacing",
-      "namespace": null
-    },
-    {
-      "name": "lighting-color",
-      "namespace": null
-    },
-    {
-      "name": "marker-end",
-      "namespace": null
-    },
-    {
-      "name": "marker-mid",
-      "namespace": null
-    },
-    {
-      "name": "marker-start",
-      "namespace": null
-    },
-    {
-      "name": "mask",
-      "namespace": null
-    },
-    {
-      "name": "mask-type",
-      "namespace": null
-    },
-    {
-      "name": "opacity",
-      "namespace": null
-    },
-    {
-      "name": "paint-order",
-      "namespace": null
-    },
-    {
-      "name": "pointer-events",
-      "namespace": null
-    },
-    {
-      "name": "shape-rendering",
-      "namespace": null
-    },
-    {
-      "name": "stop-color",
-      "namespace": null
-    },
-    {
-      "name": "stop-opacity",
-      "namespace": null
-    },
-    {
-      "name": "stroke",
-      "namespace": null
-    },
-    {
-      "name": "stroke-dasharray",
-      "namespace": null
-    },
-    {
-      "name": "stroke-dashoffset",
-      "namespace": null
-    },
-    {
-      "name": "stroke-linecap",
-      "namespace": null
-    },
-    {
-      "name": "stroke-linejoin",
-      "namespace": null
-    },
-    {
-      "name": "stroke-miterlimit",
-      "namespace": null
-    },
-    {
-      "name": "stroke-opacity",
-      "namespace": null
-    },
-    {
-      "name": "stroke-width",
-      "namespace": null
-    },
-    {
-      "name": "text-anchor",
-      "namespace": null
-    },
-    {
-      "name": "text-decoration",
-      "namespace": null
-    },
-    {
-      "name": "text-overflow",
-      "namespace": null
-    },
-    {
-      "name": "text-rendering",
-      "namespace": null
-    },
-    {
-      "name": "transform-origin",
-      "namespace": null
-    },
-    {
-      "name": "unicode-bidi",
-      "namespace": null
-    },
-    {
-      "name": "vector-effect",
-      "namespace": null
-    },
-    {
-      "name": "visibility",
-      "namespace": null
-    },
-    {
-      "name": "white-space",
-      "namespace": null
-    },
-    {
-      "name": "word-spacing",
-      "namespace": null
-    },
-    {
-      "name": "writing-mode",
-      "namespace": null
-    }
+    "dir",
+    "lang",
+    "title",
+    "displaystyle",
+    "mathbackground",
+    "mathcolor",
+    "mathsize",
+    "scriptlevel",
+    "fill",
+    "transform",
+    "alignment-baseline",
+    "baseline-shift",
+    "clip-path",
+    "clip-rule",
+    "color",
+    "color-interpolation",
+    "color-interpolation-filters",
+    "cursor",
+    "direction",
+    "display",
+    "dominant-baseline",
+    "fill-opacity",
+    "fill-rule",
+    "filter",
+    "flood-color",
+    "flood-opacity",
+    "font-family",
+    "font-size",
+    "font-size-adjust",
+    "font-stretch",
+    "font-style",
+    "font-variant",
+    "font-weight",
+    "glyph-orientation-horizontal",
+    "glyph-orientation-vertical",
+    "image-rendering",
+    "letter-spacing",
+    "lighting-color",
+    "marker-end",
+    "marker-mid",
+    "marker-start",
+    "mask",
+    "mask-type",
+    "opacity",
+    "paint-order",
+    "pointer-events",
+    "shape-rendering",
+    "stop-color",
+    "stop-opacity",
+    "stroke",
+    "stroke-dasharray",
+    "stroke-dashoffset",
+    "stroke-linecap",
+    "stroke-linejoin",
+    "stroke-miterlimit",
+    "stroke-opacity",
+    "stroke-width",
+    "text-anchor",
+    "text-decoration",
+    "text-overflow",
+    "text-rendering",
+    "transform-origin",
+    "unicode-bidi",
+    "vector-effect",
+    "visibility",
+    "white-space",
+    "word-spacing",
+    "writing-mode"
   ],
   "comments": false,
   "dataAttributes": false

--- a/builtins/safe-default-configuration.py
+++ b/builtins/safe-default-configuration.py
@@ -36,7 +36,7 @@ def main():
       elif line.startswith("- xml "):
         current.append({"name": line[6:], "namespace": "http://www.w3.org/XML/1998/namespace"})
       elif line.startswith("- "):
-        current.append({"name": line[2:], "namespace": None})
+        current.append(line[2:])
       elif line.startswith("[") and line.endswith("Global]"):
         current = result["attributes"]
       else:
@@ -60,6 +60,18 @@ def main():
       if "attributes" in element:
         element["attributes"] = remove_from(element["attributes"],
                                             result["attributes"])
+
+    # Remove empty per-element allow lists.
+    for element in result["elements"]:
+      if "attributes" in element and not element["attributes"]:
+        element.pop("attributes")
+
+    # Replace element dictionaries with string (if the default handling would
+    # create the same dictionary again).
+    for index, element in enumerate(result["elements"]):
+      if (element["namespace"] == "http://www.w3.org/1999/xhtml" and
+          not "attributes" in element and not "removeAttributes" in element):
+        result["elements"][index] = element["name"]
 
     try:
       json.dump(result, args.out, indent=2)


### PR DESCRIPTION
Configuration processing includes normalization steps, so that e.g. `"div"` gets turned into `{ "name": "div", "namespace": "http://www.w3.org/1999/xhtml" }`. The safe default config we include in the spec is already normalized.

The normalized configuration is rather verbose, and IMHO difficult to read. This patch modifies the script to "de-normlize" config text. This reduces the text by about 2/3.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/299.html" title="Last updated on Jul 3, 2025, 12:11 PM UTC (f9a53c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/299/7f24d56...otherdaniel:f9a53c1.html" title="Last updated on Jul 3, 2025, 12:11 PM UTC (f9a53c1)">Diff</a>