### PR TITLE
Remove stray otherwise

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -821,7 +821,7 @@ allow- or remove-lists for attributes. This requires that we distinguish 4 cases
                 [=set/difference=] of
                 |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] and
                 |configuration|["{{SanitizerConfig/removeAttributes}}"].
-    1. Otherwise if |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
+    1. If |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
         [=map/exists=]:
         1. If |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
             1. Set |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to the


### PR DESCRIPTION
Elements can have both `attributes` and `removeAttributes` so the "otherwise" seems wrong here.