### PR TITLE
Don't allow local attributes+removeAttributes together with global removeAttributes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -448,6 +448,16 @@ Several conditions need to hold for a configuration to be valid:
     {{SanitizerConfig/replaceWithChildrenElements}}.
   - There are no duplicate entries (i.e., no same attributes) between
     {{SanitizerConfig/attributes}} or {{SanitizerConfig/removeAttributes}}.
+- Mixing local allow- and remove-lists on the same element:
+  - When a {{SanitizerConfig/attributes}} list exists, both, either or none of the
+    {{SanitizerElementNamespaceWithAttributes/attributes}} and
+    {{SanitizerElementNamespaceWithAttributes/removeAttributes}}
+    lists are allowed  on the same element.
+  - When a {{SanitizerConfig/removeAttributes}} list exists, either or none of the
+    {{SanitizerElementNamespaceWithAttributes/attributes}} and
+    {{SanitizerElementNamespaceWithAttributes/removeAttributes}}
+    lists are allowed on the same element,
+    but not both.
 - Duplicate entries on the same element:
   - There are no duplicate entries between {{SanitizerElementNamespaceWithAttributes/attributes}}
     and {{SanitizerElementNamespaceWithAttributes/removeAttributes}} on the same element.
@@ -532,18 +542,20 @@ Putting these rules in words:
 
 * Duplicates and interactions between global and local lists:
   * If a global {{SanitizerConfig/attributes}} allow list exists, then all element's local lists:
-    * If a local {{SanitizerElementNamespaceWithAttributes/attributes}} allow lists exists,
+    * If a local {{SanitizerElementNamespaceWithAttributes/attributes}} allow list exists,
         there may be no duplicate entries between these lists.
-    * If a local {{SanitizerElementNamespaceWithAttributes/removeAttributes}} remove lists exists,
+    * If a local {{SanitizerElementNamespaceWithAttributes/removeAttributes}} remove list exists,
         then all its entries must also be listed in the global {{SanitizerConfig/attributes}}
         allow list.
     * If {{SanitizerConfig/dataAttributes}} is true, then no [=custom data attributes=] may be
         listed in any of the allow-lists.
   * If a global {{SanitizerConfig/removeAttributes}} remove list exists, then:
-    * If a local {{SanitizerElementNamespaceWithAttributes/attributes}} allow lists exists,
+    * If a local {{SanitizerElementNamespaceWithAttributes/attributes}} allow list exists,
         there may be no duplicate entries between these lists.
-    * If a local {{SanitizerElementNamespaceWithAttributes/removeAttributes}} remove lists exists,
+    * If a local {{SanitizerElementNamespaceWithAttributes/removeAttributes}} remove list exists,
         there may be no duplicate entries between these lists.
+    * Not both a local {{SanitizerElementNamespaceWithAttributes/attributes}} allow list
+        and local {{SanitizerElementNamespaceWithAttributes/removeAttributes}} remove list exists.
     * {{SanitizerConfig/dataAttributes}} must be absent.
 
 <div algorithm>
@@ -592,6 +604,8 @@ conditions hold:
 1. If |config|[{{SanitizerConfig/removeAttributes}}] [=map/exists=]:
     1. If |config|[{{SanitizerConfig/elements}}] [=map/exists=],
        then [=list/iterate|for each=] |element| of |config|[{{SanitizerConfig/elements}}]:
+        1. Not both |element|[{{SanitizerElementNamespaceWithAttributes/attributes}}] and
+            |element|[{{SanitizerElementNamespaceWithAttributes/removeAttributes}}] [=map/exist=].
         1. Neither |element|[{{SanitizerElementNamespaceWithAttributes/attributes}}] nor
            |element|[{{SanitizerElementNamespaceWithAttributes/removeAttributes}}], if they exist, [=SanitizerConfig/has duplicates=].
         1. The [=set/intersection=] of |config|[{{SanitizerConfig/removeAttributes}}] and
@@ -841,37 +855,43 @@ allow- or remove-lists for attributes. This requires that we distinguish 4 cases
        |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"].
     1. [=Comment=]: We need to make sure the per-element attributes do not overlap with global
         attributes.
-    1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/exists=]:
+    1. If |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
+      1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/exists=]:
         1. Set |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] to
            [=SanitizerConfig/remove duplicates=] from |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"].
-        1. If |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
-            1. Set |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] to the
+        1. Set |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] to the
+           [=set/difference=] of |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] and
+           |configuration|["{{SanitizerConfig/attributes}}"].
+        1. If |configuration|["{{SanitizerConfig/dataAttributes}}"] is true:
+            1. [=list/Remove=] all items |item| from
+               |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] where |item| is a [=custom data attribute=].
+      1. If |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
+          [=map/exists=]:
+          1. Set |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to
+             [=SanitizerConfig/remove duplicates=] from |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"].
+          1. Set |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to the
+             [=set/intersection=] of |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] and
+             |configuration|["{{SanitizerConfig/attributes}}"].
+    1. Otherwise:
+      1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/exists=]:
+        1. Set |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] to
+           [=SanitizerConfig/remove duplicates=] from |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"].
+        1. Set |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] to the
                 [=set/difference=] of
                 |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] and
-                |configuration|["{{SanitizerConfig/attributes}}"].
-            1. If |configuration|["{{SanitizerConfig/dataAttributes}}"] is true:
-                1. [=list/Remove=] all items |item| from
-                    |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
-                    where |item| is a [=custom data attribute=].
-        1. If |configuration|["{{SanitizerConfig/removeAttributes}}"] [=map/exists=]:
-            1. Set |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] to the
+                |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
+                [=map/with default=] &laquo; &raquo;.
+        1. [=map/Remove=] |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"].
+        1. Set |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] to the
                 [=set/difference=] of
                 |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] and
                 |configuration|["{{SanitizerConfig/removeAttributes}}"].
-    1. If |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-        [=map/exists=]:
+      1. If |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/exists=]:
         1. Set |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to
-               [=SanitizerConfig/remove duplicates=] from |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"].
-        1. If |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
-            1. Set |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to the
-                [=set/intersection=] of
-                |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] and
-                |configuration|["{{SanitizerConfig/attributes}}"].
-        1. If |configuration|["{{SanitizerConfig/removeAttributes}}"] [=map/exists=]:
-            1. Set |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to the
-                [=set/difference=] of
-                |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] and
-                |configuration|["{{SanitizerConfig/removeAttributes}}"].
+           [=SanitizerConfig/remove duplicates=] from |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"].
+        1. Set |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to the
+           [=set/difference=] of |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] and
+           |configuration|["{{SanitizerConfig/removeAttributes}}"].
     1. If |configuration|["{{SanitizerConfig/elements}}"] does not [=map/contain=] |element|:
         1. [=Comment=]: This is the case with a global allow-list that does not yet contain
             |element|.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,5867 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <title>HTML Sanitizer API</title>
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" rel="stylesheet">
+  <meta content="Bikeshed version 3f621ba99, updated Mon Jul 28 15:38:36 2025 -0700" name="generator">
+  <link href="https://wicg.github.io/sanitizer-api/" rel="canonical">
+  <meta content="fc36ba125ff6f175e1b5619c4ec20ab611cc5858" name="revision">
+  <meta content="dark light" name="color-scheme">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
+<style>
+/* Boxes around algorithms. */
+[data-algorithm]:not(.heading) {
+  padding: .5em;
+  border: thin solid #ddd; border-radius: .5em;
+  margin: .5em calc(-0.5em - 1px);
+}
+[data-algorithm]:not(.heading) > :first-child { margin-top: 0; }
+[data-algorithm]:not(.heading) > :last-child { margin-bottom: 0; }
+[data-algorithm] [data-algorithm] { margin: 1em 0; }
+
+/* Support [=Comment=] references. */
+p:has(a[href="#comment"]) { color: var(--noteheading-text); }
+a[href="#comment"] { text-transform: uppercase; }
+</style>
+<style>/* Boilerplate: style-autolinks */
+.css.css, .property.property, .descriptor.descriptor {
+    color: var(--a-normal-text);
+    font-size: inherit;
+    font-family: inherit;
+}
+.css::before, .property::before, .descriptor::before {
+    content: "‘";
+}
+.css::after, .property::after, .descriptor::after {
+    content: "’";
+}
+.property, .descriptor {
+    /* Don't wrap property and descriptor names */
+    white-space: nowrap;
+}
+.type { /* CSS value <type> */
+    font-style: italic;
+}
+pre .property::before, pre .property::after {
+    content: "";
+}
+[data-link-type="property"]::before,
+[data-link-type="propdesc"]::before,
+[data-link-type="descriptor"]::before,
+[data-link-type="value"]::before,
+[data-link-type="function"]::before,
+[data-link-type="at-rule"]::before,
+[data-link-type="selector"]::before,
+[data-link-type="maybe"]::before {
+    content: "‘";
+}
+[data-link-type="property"]::after,
+[data-link-type="propdesc"]::after,
+[data-link-type="descriptor"]::after,
+[data-link-type="value"]::after,
+[data-link-type="function"]::after,
+[data-link-type="at-rule"]::after,
+[data-link-type="selector"]::after,
+[data-link-type="maybe"]::after {
+    content: "’";
+}
+
+[data-link-type].production::before,
+[data-link-type].production::after,
+.prod [data-link-type]::before,
+.prod [data-link-type]::after {
+    content: "";
+}
+
+[data-link-type=element],
+[data-link-type=element-attr] {
+    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    font-size: .9em;
+}
+[data-link-type=element]::before { content: "<" }
+[data-link-type=element]::after  { content: ">" }
+
+[data-link-type=biblio] {
+    white-space: pre;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --selflink-text: black;
+        --selflink-bg: silver;
+        --selflink-hover-text: white;
+    }
+}
+</style>
+<style>/* Boilerplate: style-colors */
+/* Any --*-text not paired with a --*-bg is assumed to have a transparent bg */
+:root {
+    color-scheme: light dark;
+
+    --text: black;
+    --bg: white;
+
+    --unofficial-watermark: url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
+
+    --logo-bg: #1a5e9a;
+    --logo-active-bg: #c00;
+    --logo-text: white;
+
+    --tocnav-normal-text: #707070;
+    --tocnav-normal-bg: var(--bg);
+    --tocnav-hover-text: var(--tocnav-normal-text);
+    --tocnav-hover-bg: #f8f8f8;
+    --tocnav-active-text: #c00;
+    --tocnav-active-bg: var(--tocnav-normal-bg);
+
+    --tocsidebar-text: var(--text);
+    --tocsidebar-bg: #f7f8f9;
+    --tocsidebar-shadow: rgba(0,0,0,.1);
+    --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+    --toclink-text: var(--text);
+    --toclink-underline: #3980b5;
+    --toclink-visited-text: var(--toclink-text);
+    --toclink-visited-underline: #054572;
+
+    --heading-text: #005a9c;
+
+    --hr-text: var(--text);
+
+    --algo-border: #def;
+
+    --del-text: red;
+    --del-bg: transparent;
+    --ins-text: #080;
+    --ins-bg: transparent;
+
+    --a-normal-text: #034575;
+    --a-normal-underline: #bbb;
+    --a-visited-text: var(--a-normal-text);
+    --a-visited-underline: #707070;
+    --a-hover-bg: rgba(75%, 75%, 75%, .25);
+    --a-active-text: #c00;
+    --a-active-underline: #c00;
+
+    --blockquote-border: silver;
+    --blockquote-bg: transparent;
+    --blockquote-text: currentcolor;
+
+    --issue-border: #e05252;
+    --issue-bg: #fbe9e9;
+    --issue-text: var(--text);
+    --issueheading-text: #831616;
+
+    --example-border: #e0cb52;
+    --example-bg: #fcfaee;
+    --example-text: var(--text);
+    --exampleheading-text: #574b0f;
+
+    --note-border: #52e052;
+    --note-bg: #e9fbe9;
+    --note-text: var(--text);
+    --noteheading-text: hsl(120, 70%, 30%);
+    --notesummary-underline: silver;
+
+    --assertion-border: #aaa;
+    --assertion-bg: #eee;
+    --assertion-text: black;
+
+    --advisement-border: orange;
+    --advisement-bg: #fec;
+    --advisement-text: var(--text);
+    --advisementheading-text: #b35f00;
+
+    --warning-border: red;
+    --warning-bg: hsla(40,100%,50%,0.95);
+    --warning-text: var(--text);
+
+    --amendment-border: #330099;
+    --amendment-bg: #F5F0FF;
+    --amendment-text: var(--text);
+    --amendmentheading-text: #220066;
+
+    --def-border: #8ccbf2;
+    --def-bg: #def;
+    --def-text: var(--text);
+    --defrow-border: #bbd7e9;
+
+    --datacell-border: silver;
+
+    --indexinfo-text: #707070;
+
+    --indextable-hover-text: black;
+    --indextable-hover-bg: #f7f8f9;
+
+    --outdatedspec-bg: rgba(0, 0, 0, .5);
+    --outdatedspec-text: black;
+    --outdated-bg: maroon;
+    --outdated-text: white;
+    --outdated-shadow: red;
+
+    --editedrec-bg: darkorange;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --text: #ddd;
+        --bg: black;
+
+        --unofficial-watermark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400'%3E%3Cg fill='%23100808' transform='translate(200 200) rotate(-45) translate(-200 -200)' stroke='%23100808' stroke-width='3'%3E%3Ctext x='50%25' y='220' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EUNOFFICIAL%3C/text%3E%3Ctext x='50%25' y='305' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EDRAFT%3C/text%3E%3C/g%3E%3C/svg%3E");
+
+        --logo-bg: #1a5e9a;
+        --logo-active-bg: #c00;
+        --logo-text: white;
+
+        --tocnav-normal-text: #999;
+        --tocnav-normal-bg: var(--bg);
+        --tocnav-hover-text: var(--tocnav-normal-text);
+        --tocnav-hover-bg: #080808;
+        --tocnav-active-text: #f44;
+        --tocnav-active-bg: var(--tocnav-normal-bg);
+
+        --tocsidebar-text: var(--text);
+        --tocsidebar-bg: #080808;
+        --tocsidebar-shadow: rgba(255,255,255,.1);
+        --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+        --toclink-text: var(--text);
+        --toclink-underline: #6af;
+        --toclink-visited-text: var(--toclink-text);
+        --toclink-visited-underline: #054572;
+
+        --heading-text: #8af;
+
+        --hr-text: var(--text);
+
+        --algo-border: #456;
+
+        --del-text: #f44;
+        --del-bg: transparent;
+        --ins-text: #4a4;
+        --ins-bg: transparent;
+
+        --a-normal-text: #6af;
+        --a-normal-underline: #555;
+        --a-visited-text: var(--a-normal-text);
+        --a-visited-underline: var(--a-normal-underline);
+        --a-hover-bg: rgba(25%, 25%, 25%, .2);
+        --a-active-text: #f44;
+        --a-active-underline: var(--a-active-text);
+
+        --borderedblock-bg: rgba(255, 255, 255, .05);
+
+        --blockquote-border: silver;
+        --blockquote-bg: var(--borderedblock-bg);
+        --blockquote-text: currentcolor;
+
+        --issue-border: #e05252;
+        --issue-bg: var(--borderedblock-bg);
+        --issue-text: var(--text);
+        --issueheading-text: hsl(0deg, 70%, 70%);
+
+        --example-border: hsl(50deg, 90%, 60%);
+        --example-bg: var(--borderedblock-bg);
+        --example-text: var(--text);
+        --exampleheading-text: hsl(50deg, 70%, 70%);
+
+        --note-border: hsl(120deg, 100%, 35%);
+        --note-bg: var(--borderedblock-bg);
+        --note-text: var(--text);
+        --noteheading-text: hsl(120, 70%, 70%);
+        --notesummary-underline: silver;
+
+        --assertion-border: #444;
+        --assertion-bg: var(--borderedblock-bg);
+        --assertion-text: var(--text);
+
+        --advisement-border: orange;
+        --advisement-bg: #222218;
+        --advisement-text: var(--text);
+        --advisementheading-text: #f84;
+
+        --warning-border: red;
+        --warning-bg: hsla(40,100%,20%,0.95);
+        --warning-text: var(--text);
+
+        --amendment-border: #330099;
+        --amendment-bg: #080010;
+        --amendment-text: var(--text);
+        --amendmentheading-text: #cc00ff;
+
+        --def-border: #8ccbf2;
+        --def-bg: #080818;
+        --def-text: var(--text);
+        --defrow-border: #136;
+
+        --datacell-border: silver;
+
+        --indexinfo-text: #aaa;
+
+        --indextable-hover-text: var(--text);
+        --indextable-hover-bg: #181818;
+
+        --outdatedspec-bg: rgba(255, 255, 255, .5);
+        --outdatedspec-text: black;
+        --outdated-bg: maroon;
+        --outdated-text: white;
+        --outdated-shadow: red;
+
+        --editedrec-bg: darkorange;
+    }
+    /* In case a transparent-bg image doesn't expect to be on a dark bg,
+       which is quite common in practice... */
+    img { background: white; }
+}
+</style>
+<style>/* Boilerplate: style-counters */
+body {
+    counter-reset: example figure issue;
+}
+.issue {
+    counter-increment: issue;
+}
+.issue:not(.no-marker)::before {
+    content: "Issue " counter(issue);
+}
+
+.example {
+    counter-increment: example;
+}
+.example:not(.no-marker)::before {
+    content: "Example " counter(example);
+}
+.invalid.example:not(.no-marker)::before,
+.illegal.example:not(.no-marker)::before {
+    content: "Invalid Example" counter(example);
+}
+
+figcaption {
+    counter-increment: figure;
+}
+figcaption:not(.no-marker)::before {
+    content: "Figure " counter(figure) " ";
+}
+</style>
+<style>/* Boilerplate: style-dfn-panel */
+:root {
+    --dfnpanel-bg: #ddd;
+    --dfnpanel-text: var(--text);
+    --dfnpanel-target-bg: #ffc;
+    --dfnpanel-target-outline: orange;
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --dfnpanel-bg: #222;
+        --dfnpanel-text: var(--text);
+        --dfnpanel-target-bg: #333;
+        --dfnpanel-target-outline: silver;
+    }
+}
+.dfn-panel {
+    position: absolute;
+    z-index: 35;
+    width: 20em;
+    width: 300px;
+    height: auto;
+    max-height: 500px;
+    overflow: auto;
+    padding: 0.5em 0.75em;
+    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+    background: var(--dfnpanel-bg);
+    color: var(--dfnpanel-text);
+    border: outset 0.2em;
+    white-space: normal; /* in case it's moved into a pre */
+}
+.dfn-panel:not(.on) { display: none; }
+.dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+.dfn-panel > b { display: block; }
+.dfn-panel a { color: var(--dfnpanel-text); }
+.dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+.dfn-panel a:focus {
+    outline: 5px auto Highlight;
+    outline: 5px auto -webkit-focus-ring-color;
+}
+.dfn-panel > b + b { margin-top: 0.25em; }
+.dfn-panel ul { padding: 0 0 0 1em; list-style: none; }
+.dfn-panel li a {
+    max-width: calc(300px - 1.5em - 1em);
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.dfn-panel.activated {
+    display: inline-block;
+    position: fixed;
+    left: 8px;
+    bottom: 2em;
+    margin: 0 auto;
+    max-width: calc(100vw - 1.5em - .4em - .5em);
+    max-height: 30vh;
+    transition: left 1s ease-out, bottom 1s ease-out;
+}
+
+.dfn-panel .link-item:hover {
+    text-decoration: underline;
+}
+.dfn-panel .link-item .copy-icon {
+    opacity: 0;
+}
+.dfn-panel .link-item:hover .copy-icon,
+.dfn-panel .link-item .copy-icon:focus {
+    opacity: 1;
+}
+
+.dfn-panel .copy-icon {
+    display: inline-block;
+    margin-right: 0.5em;
+    width: 0.85em;
+    height: 1em;
+    border-radius: 3px;
+    background-color: #ccc;
+    cursor: pointer;
+}
+
+.dfn-panel .copy-icon .icon {
+    width: 100%;
+    height: 100%;
+    background-color: #fff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+}
+
+.dfn-panel .copy-icon .icon::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 1px solid black;
+    background-color: #ccc;
+    opacity: 0.25;
+    transform: translate(3px, -3px);
+}
+
+.dfn-panel .copy-icon:active .icon::before {
+    opacity: 1;
+}
+
+.dfn-paneled[role="button"] { cursor: help; }
+
+.highlighted {
+    animation: target-fade 3s;
+}
+
+@keyframes target-fade {
+    from {
+        background-color: var(--dfnpanel-target-bg);
+        outline: 5px solid var(--dfnpanel-target-outline);
+    }
+    to {
+        color: var(--a-normal-text);
+        background-color: transparent;
+        outline: transparent;
+    }
+}
+</style>
+<style>/* Boilerplate: style-idl-highlighting */
+pre.idl.highlight {
+    background: var(--borderedblock-bg, var(--def-bg));
+}
+</style>
+<style>/* Boilerplate: style-issues */
+a[href].issue-return {
+    float: right;
+    float: inline-end;
+    color: var(--issueheading-text);
+    font-weight: bold;
+    text-decoration: none;
+}
+</style>
+<style>/* Boilerplate: style-md-lists */
+/* This is a weird hack for me not yet following the commonmark spec
+   regarding paragraph and lists. */
+[data-md] > :first-child {
+    margin-top: 0;
+}
+[data-md] > :last-child {
+    margin-bottom: 0;
+}
+</style>
+<style>/* Boilerplate: style-ref-hints */
+:root {
+    --ref-hint-bg: #ddd;
+    --ref-hint-text: var(--text);
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --ref-hint-bg: #222;
+        --ref-hint-text: var(--text);
+    }
+}
+
+.ref-hint {
+    display: inline-block;
+    position: absolute;
+    z-index: 35;
+    width: 20em;
+    width: 300px;
+    height: auto;
+    max-height: 500px;
+    overflow: auto;
+    padding: 0.5em 0.5em;
+    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+    background: var(--ref-hint-bg);
+    color: var(--ref-hint-text);
+    border: outset 0.2em;
+    white-space: normal; /* in case it's moved into a pre */
+}
+
+.ref-hint * { margin: 0; padding: 0; text-indent: 0; }
+
+.ref-hint ul { padding: 0 0 0 1em; list-style: none; }
+</style>
+<style>/* Boilerplate: style-selflinks */
+:root {
+    --selflink-text: white;
+    --selflink-bg: gray;
+    --selflink-hover-text: black;
+}
+.heading, .issue, .note, .example, li, dt {
+    position: relative;
+}
+a.self-link {
+    position: absolute;
+    top: 0;
+    left: calc(-1 * (3.5rem - 26px));
+    width: calc(3.5rem - 26px);
+    height: 2em;
+    text-align: center;
+    border: none;
+    transition: opacity .2s;
+    opacity: .5;
+}
+a.self-link:hover {
+    opacity: 1;
+}
+.heading > a.self-link {
+    font-size: 83%;
+}
+.example > a.self-link,
+.note > a.self-link,
+.issue > a.self-link {
+    /* These blocks are overflow:auto, so positioning outside
+       doesn't work. */
+    left: auto;
+    right: 0;
+}
+li > a.self-link {
+    left: calc(-1 * (3.5rem - 26px) - 2em);
+}
+dfn > a.self-link {
+    top: auto;
+    left: auto;
+    opacity: 0;
+    width: 1.5em;
+    height: 1.5em;
+    background: var(--selflink-bg);
+    color: var(--selflink-text);
+    font-style: normal;
+    transition: opacity .2s, background-color .2s, color .2s;
+}
+dfn:hover > a.self-link {
+    opacity: 1;
+}
+dfn > a.self-link:hover {
+    color: var(--selflink-hover-text);
+}
+
+a.self-link::before            { content: "¶"; }
+.heading > a.self-link::before { content: "§"; }
+dfn > a.self-link::before      { content: "#"; }
+</style>
+<style>/* Boilerplate: style-syntax-highlighting */
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+
+.highlight:not(.idl) { background: rgba(0, 0, 0, .03); }
+c-[a] { color: #990055 } /* Keyword.Declaration */
+c-[b] { color: #990055 } /* Keyword.Type */
+c-[c] { color: #708090 } /* Comment */
+c-[d] { color: #708090 } /* Comment.Multiline */
+c-[e] { color: #0077aa } /* Name.Attribute */
+c-[f] { color: #669900 } /* Name.Tag */
+c-[g] { color: #222222 } /* Name.Variable */
+c-[k] { color: #990055 } /* Keyword */
+c-[l] { color: #000000 } /* Literal */
+c-[m] { color: #000000 } /* Literal.Number */
+c-[n] { color: #0077aa } /* Name */
+c-[o] { color: #999999 } /* Operator */
+c-[p] { color: #999999 } /* Punctuation */
+c-[s] { color: #a67f59 } /* Literal.String */
+c-[t] { color: #a67f59 } /* Literal.String.Single */
+c-[u] { color: #a67f59 } /* Literal.String.Double */
+c-[cp] { color: #708090 } /* Comment.Preproc */
+c-[c1] { color: #708090 } /* Comment.Single */
+c-[cs] { color: #708090 } /* Comment.Special */
+c-[kc] { color: #990055 } /* Keyword.Constant */
+c-[kn] { color: #990055 } /* Keyword.Namespace */
+c-[kp] { color: #990055 } /* Keyword.Pseudo */
+c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[ld] { color: #000000 } /* Literal.Date */
+c-[nc] { color: #0077aa } /* Name.Class */
+c-[no] { color: #0077aa } /* Name.Constant */
+c-[nd] { color: #0077aa } /* Name.Decorator */
+c-[ni] { color: #0077aa } /* Name.Entity */
+c-[ne] { color: #0077aa } /* Name.Exception */
+c-[nf] { color: #0077aa } /* Name.Function */
+c-[nl] { color: #0077aa } /* Name.Label */
+c-[nn] { color: #0077aa } /* Name.Namespace */
+c-[py] { color: #0077aa } /* Name.Property */
+c-[ow] { color: #999999 } /* Operator.Word */
+c-[mb] { color: #000000 } /* Literal.Number.Bin */
+c-[mf] { color: #000000 } /* Literal.Number.Float */
+c-[mh] { color: #000000 } /* Literal.Number.Hex */
+c-[mi] { color: #000000 } /* Literal.Number.Integer */
+c-[mo] { color: #000000 } /* Literal.Number.Oct */
+c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
+c-[sc] { color: #a67f59 } /* Literal.String.Char */
+c-[sd] { color: #a67f59 } /* Literal.String.Doc */
+c-[se] { color: #a67f59 } /* Literal.String.Escape */
+c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
+c-[si] { color: #a67f59 } /* Literal.String.Interpol */
+c-[sx] { color: #a67f59 } /* Literal.String.Other */
+c-[sr] { color: #a67f59 } /* Literal.String.Regex */
+c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
+c-[vc] { color: #0077aa } /* Name.Variable.Class */
+c-[vg] { color: #0077aa } /* Name.Variable.Global */
+c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
+
+@media (prefers-color-scheme: dark) {
+    .highlight:not(.idl) { background: rgba(255, 255, 255, .05); }
+
+    c-[a] { color: #d33682 } /* Keyword.Declaration */
+    c-[b] { color: #d33682 } /* Keyword.Type */
+    c-[c] { color: #2aa198 } /* Comment */
+    c-[d] { color: #2aa198 } /* Comment.Multiline */
+    c-[e] { color: #268bd2 } /* Name.Attribute */
+    c-[f] { color: #b58900 } /* Name.Tag */
+    c-[g] { color: #cb4b16 } /* Name.Variable */
+    c-[k] { color: #d33682 } /* Keyword */
+    c-[l] { color: #657b83 } /* Literal */
+    c-[m] { color: #657b83 } /* Literal.Number */
+    c-[n] { color: #268bd2 } /* Name */
+    c-[o] { color: #657b83 } /* Operator */
+    c-[p] { color: #657b83 } /* Punctuation */
+    c-[s] { color: #6c71c4 } /* Literal.String */
+    c-[t] { color: #6c71c4 } /* Literal.String.Single */
+    c-[u] { color: #6c71c4 } /* Literal.String.Double */
+    c-[ch] { color: #2aa198 } /* Comment.Hashbang */
+    c-[cp] { color: #2aa198 } /* Comment.Preproc */
+    c-[cpf] { color: #2aa198 } /* Comment.PreprocFile */
+    c-[c1] { color: #2aa198 } /* Comment.Single */
+    c-[cs] { color: #2aa198 } /* Comment.Special */
+    c-[kc] { color: #d33682 } /* Keyword.Constant */
+    c-[kn] { color: #d33682 } /* Keyword.Namespace */
+    c-[kp] { color: #d33682 } /* Keyword.Pseudo */
+    c-[kr] { color: #d33682 } /* Keyword.Reserved */
+    c-[ld] { color: #657b83 } /* Literal.Date */
+    c-[nc] { color: #268bd2 } /* Name.Class */
+    c-[no] { color: #268bd2 } /* Name.Constant */
+    c-[nd] { color: #268bd2 } /* Name.Decorator */
+    c-[ni] { color: #268bd2 } /* Name.Entity */
+    c-[ne] { color: #268bd2 } /* Name.Exception */
+    c-[nf] { color: #268bd2 } /* Name.Function */
+    c-[nl] { color: #268bd2 } /* Name.Label */
+    c-[nn] { color: #268bd2 } /* Name.Namespace */
+    c-[py] { color: #268bd2 } /* Name.Property */
+    c-[ow] { color: #657b83 } /* Operator.Word */
+    c-[mb] { color: #657b83 } /* Literal.Number.Bin */
+    c-[mf] { color: #657b83 } /* Literal.Number.Float */
+    c-[mh] { color: #657b83 } /* Literal.Number.Hex */
+    c-[mi] { color: #657b83 } /* Literal.Number.Integer */
+    c-[mo] { color: #657b83 } /* Literal.Number.Oct */
+    c-[sa] { color: #6c71c4 } /* Literal.String.Affix */
+    c-[sb] { color: #6c71c4 } /* Literal.String.Backtick */
+    c-[sc] { color: #6c71c4 } /* Literal.String.Char */
+    c-[dl] { color: #6c71c4 } /* Literal.String.Delimiter */
+    c-[sd] { color: #6c71c4 } /* Literal.String.Doc */
+    c-[se] { color: #6c71c4 } /* Literal.String.Escape */
+    c-[sh] { color: #6c71c4 } /* Literal.String.Heredoc */
+    c-[si] { color: #6c71c4 } /* Literal.String.Interpol */
+    c-[sx] { color: #6c71c4 } /* Literal.String.Other */
+    c-[sr] { color: #6c71c4 } /* Literal.String.Regex */
+    c-[ss] { color: #6c71c4 } /* Literal.String.Symbol */
+    c-[fm] { color: #268bd2 } /* Name.Function.Magic */
+    c-[vc] { color: #cb4b16 } /* Name.Variable.Class */
+    c-[vg] { color: #cb4b16 } /* Name.Variable.Global */
+    c-[vi] { color: #cb4b16 } /* Name.Variable.Instance */
+    c-[vm] { color: #cb4b16 } /* Name.Variable.Magic */
+    c-[il] { color: #657b83 } /* Literal.Number.Integer.Long */
+}
+</style>
+<style>/* Boilerplate: style-var-click-highlighting */
+/*
+Colors were chosen in Lab using https://nixsensor.com/free-color-converter/
+D50 2deg illuminant, L in [0,100], a and b in [-128, 128]
+0 = lab(85,0,85)
+1 = lab(85,80,30)
+2 = lab(85,-40,40)
+3 = lab(85,-50,0)
+4 = lab(85,5,15)
+5 = lab(85,-10,-50)
+6 = lab(85,35,-15)
+
+For darkmode:
+0 = oklab(50%   0%  108%)
+1 = oklab(50% -51%   51%)
+2 = oklab(50% -64%  -20%)
+3 = oklab(50%   6%   19%)
+4 = oklab(50% -12%  -64%)
+5 = oklab(50%  44%  -19%)  
+6 = oklab(50% 102%   38%)
+*/
+
+[data-algorithm] var { cursor: pointer; }
+var[data-var-color] { background-color: var(--var-bg); box-shadow: 0 0 0 2px var(--var-bg); }
+
+var[data-var-color] { --var-bg: #F4D200; }
+var[data-var-color="1"] { --var-bg: #FF87A2; }
+var[data-var-color="2"] { --var-bg: #96E885; }
+var[data-var-color="3"] { --var-bg: #3EEED2; }
+var[data-var-color="4"] { --var-bg: #EACFB6; }
+var[data-var-color="5"] { --var-bg: #82DDFF; }
+var[data-var-color="6"] { --var-vg: #FFBCF2; }
+
+@media (prefers-color-scheme: dark) {
+	var[data-var-color] { --var-bg: #bc1a00; }
+	var[data-var-color="1"] { --var-bg: #007f00; }
+	var[data-var-color="2"] { --var-bg: #008698; }
+	var[data-var-color="3"] { --var-bg: #7f5b2b; }
+	var[data-var-color="4"] { --var-bg: #004df3; }
+	var[data-var-color="5"] { --var-bg: #a1248a; }
+	var[data-var-color="6"] { --var-vg: #ff0000; }
+}
+</style>
+ <body class="h-entry">
+  <div class="head">
+   <h1 class="p-name no-ref" id="title">HTML Sanitizer API</h1>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types/#CG-DRAFT">Draft Community Group Report</a>,
+    <time class="dt-updated" datetime="2025-10-15">15 October 2025</time></p>
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="https://wicg.github.io/sanitizer-api/">https://wicg.github.io/sanitizer-api/</a>
+     <dt>Issue Tracking:
+     <dd><a href="https://github.com/WICG/sanitizer-api/issues/">GitHub</a>
+     <dt class="editor">Editors:
+     <dd class="editor p-author h-card vcard" data-editor-id="68466"><a class="p-name fn u-url url" href="https://frederik-braun.com">Frederik Braun</a> (<span class="p-org org">Mozilla</span>) <a class="u-email email" href="mailto:fbraun@mozilla.com">fbraun@mozilla.com</a>
+     <dd class="editor p-author h-card vcard"><a class="p-name fn u-url url" href="https://cure53.de">Mario Heiderich</a> (<span class="p-org org">Cure53</span>) <a class="u-email email" href="mailto:mario@cure53.de">mario@cure53.de</a>
+     <dd class="editor p-author h-card vcard"><a class="p-name fn u-url url" href="https://www.google.com">Daniel Vogelheim</a> (<span class="p-org org">Google LLC</span>) <a class="u-email email" href="mailto:vogelheim@google.com">vogelheim@google.com</a>
+     <dd class="editor p-author h-card vcard"><a class="p-name fn u-url url" href="https://mozilla.com">Tom Schuster</a> (<span class="p-org org">Mozilla</span>) <a class="u-email email" href="mailto:tschuster@mozilla.com">tschuster@mozilla.com</a>
+    </dl>
+   </div>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright"><a href="https://www.w3.org/policies/#copyright">Copyright</a> © 2025 the Contributors to the HTML Sanitizer API Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.
+</p>
+   <hr title="Separator for header">
+  </div>
+  <div class="p-summary" data-fill-with="abstract">
+   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+   <p>This document specifies a set of APIs which allow developers to take
+untrusted HTML input and sanitize it for safe insertion into a document’s
+DOM.</p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
+  <div data-fill-with="status">
+   <p>
+  This specification was published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a>.
+  It is not a W3C Standard nor is it on the W3C Standards Track.
+
+  Please note that under the
+  <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>
+  there is a limited opt-out and other conditions apply.
+
+  Learn more about
+  <a href="http://www.w3.org/community/">W3C Community and Business Groups</a>.
+</p>
+   <p></p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
+    <li>
+     <a href="#intro"><span class="secno">1</span> <span class="content">Introduction</span></a>
+     <ol class="toc">
+      <li><a href="#goals"><span class="secno">1.1</span> <span class="content">Goals</span></a>
+      <li><a href="#api-summary"><span class="secno">1.2</span> <span class="content">API Summary</span></a>
+     </ol>
+    <li>
+     <a href="#framework"><span class="secno">2</span> <span class="content">Framework</span></a>
+     <ol class="toc">
+      <li><a href="#sanitizer-api"><span class="secno">2.1</span> <span class="content">Sanitizer API</span></a>
+      <li><a href="#configobject"><span class="secno">2.2</span> <span class="content">SetHTML options and the configuration object.</span></a>
+      <li><a href="#config"><span class="secno">2.3</span> <span class="content">The Configuration Dictionary</span></a>
+      <li><a href="#invariants"><span class="secno">2.4</span> <span class="content">Configuration Invariants</span></a>
+     </ol>
+    <li>
+     <a href="#algorithms"><span class="secno">3</span> <span class="content">Algorithms</span></a>
+     <ol class="toc">
+      <li><a href="#sanitization"><span class="secno">3.1</span> <span class="content">Sanitize</span></a>
+      <li><a href="#configuration-modify"><span class="secno">3.2</span> <span class="content">Modify the Configuration</span></a>
+      <li><a href="#configuration-set"><span class="secno">3.3</span> <span class="content">Set the Configuration</span></a>
+      <li><a href="#configuration-canonicalize"><span class="secno">3.4</span> <span class="content">Canonicalize the Configuration</span></a>
+      <li><a href="#alg-support"><span class="secno">3.5</span> <span class="content">Supporting Algorithms</span></a>
+      <li><a href="#sanitization-defaults"><span class="secno">3.6</span> <span class="content">Builtins</span></a>
+     </ol>
+    <li>
+     <a href="#security-considerations"><span class="secno">4</span> <span class="content">Security Considerations</span></a>
+     <ol class="toc">
+      <li><a href="#server-side-xss"><span class="secno">4.1</span> <span class="content">Server-Side Reflected and Stored XSS</span></a>
+      <li><a href="#dom-clobbering"><span class="secno">4.2</span> <span class="content">DOM clobbering</span></a>
+      <li><a href="#script-gadgets"><span class="secno">4.3</span> <span class="content">XSS with Script gadgets</span></a>
+      <li><a href="#mutated-xss"><span class="secno">4.4</span> <span class="content">Mutated XSS</span></a>
+     </ol>
+    <li><a href="#ack"><span class="secno">5</span> <span class="content">Acknowledgements</span></a>
+    <li>
+     <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+     <ol class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+      <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
+     </ol>
+    <li>
+     <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ol class="toc">
+      <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
+      <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
+     </ol>
+    <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
+   </ol>
+  </nav>
+  <main>
+   <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
+   <p><em>This section is not normative.</em></p>
+   <p>Web applications often need to work with strings of HTML on the client side,
+perhaps as part of a client-side templating solution, perhaps as part of
+rendering user generated content, etc. It is difficult to do so in a safe way.
+The naive approach of joining strings together and stuffing them into
+an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element">Element</a></code>’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-element-innerhtml" id="ref-for-dom-element-innerhtml">innerHTML</a></code> is fraught with risk, as it can cause
+JavaScript execution in a number of unexpected ways.</p>
+   <p>Libraries like <a data-link-type="biblio" href="#biblio-dompurify" title="DOMPurify">[DOMPURIFY]</a> attempt to manage this problem by carefully
+parsing and sanitizing strings before insertion, by constructing a DOM and
+filtering its members through an allow-list. This has proven to be a fragile
+approach, as the parsing APIs exposed to the web don’t always map in
+reasonable ways to the browser’s behavior when actually rendering a string as
+HTML in the "real" DOM. Moreover, the libraries need to keep on top of
+browsers' changing behavior over time; things that once were safe may turn
+into time-bombs based on new platform-level features.</p>
+   <p>The browser has a fairly good idea of when it is going to
+execute code. We can improve upon the user-space libraries by teaching the
+browser how to render HTML from an arbitrary string in a safe manner, and do
+so in a way that is much more likely to be maintained and updated along with
+the browser’s own changing parser implementation. This document outlines an
+API which aims to do just that.</p>
+   <h3 class="heading settled" data-level="1.1" id="goals"><span class="secno">1.1. </span><span class="content">Goals</span><a class="self-link" href="#goals"></a></h3>
+   <ul>
+    <li data-md>
+     <p>Mitigate the risk of DOM-based cross-site scripting attacks by providing
+  developers with mechanisms for handling user-controlled HTML which prevent
+  direct script execution upon injection.</p>
+    <li data-md>
+     <p>Make HTML output safe for use within the current user agent, taking into
+  account its current understanding of HTML.</p>
+    <li data-md>
+     <p>Allow developers to override the default set of elements and attributes.
+  Adding certain elements and attributes can prevent
+  <a href="https://github.com/google/security-research-pocs/tree/master/script-gadgets">script gadget</a>
+  attacks.</p>
+   </ul>
+   <h3 class="heading settled" data-level="1.2" id="api-summary"><span class="secno">1.2. </span><span class="content">API Summary</span><a class="self-link" href="#api-summary"></a></h3>
+   <p>The Sanitizer API offers functionality to parse a string containing HTML into
+a DOM tree, and to filter the resulting tree according to a user-supplied
+configuration. The methods come in two by two flavours:</p>
+   <ul>
+    <li data-md>
+     <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="safe-and-unsafe">Safe and unsafe</dfn>: The "safe" methods will not generate any markup that
+executes script. That is, they should be safe from XSS. The "unsafe" methods
+will parse and filter whatever they’re supposed to.
+See also: <a href="#security-considerations">§ 4 Security Considerations</a>.</p>
+    <li data-md>
+     <p>Context: Methods are defined on <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element①">Element</a></code> and <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#shadowroot" id="ref-for-shadowroot">ShadowRoot</a></code> and will
+replace these <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#node" id="ref-for-node">Node</a></code>’s children, and are largely analogous to <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-element-innerhtml" id="ref-for-dom-element-innerhtml①">innerHTML</a></code>.
+There are also static methods on the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document">Document</a></code>, which parse an entire
+document are largely analogous to <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#domparser" id="ref-for-domparser">DOMParser</a></code>.<code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring" id="ref-for-dom-domparser-parsefromstring">parseFromString()</a></code>.</p>
+   </ul>
+   <h2 class="heading settled" data-level="2" id="framework"><span class="secno">2. </span><span class="content">Framework</span><a class="self-link" href="#framework"></a></h2>
+   <h3 class="heading settled" data-level="2.1" id="sanitizer-api"><span class="secno">2.1. </span><span class="content">Sanitizer API</span><a class="self-link" href="#sanitizer-api"></a></h3>
+   <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element②">Element</a></code> interface defines two methods, <code class="idl"><a data-link-type="idl" href="#dom-element-sethtml" id="ref-for-dom-element-sethtml">setHTML()</a></code> and
+<code class="idl"><a data-link-type="idl" href="#dom-element-sethtmlunsafe" id="ref-for-dom-element-sethtmlunsafe">setHTMLUnsafe()</a></code>. Both of these take a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString">DOMString</a></code> with HTML
+markup, and an optional configuration.</p>
+<pre class="extract idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#element" id="ref-for-element③"><c- g>Element</c-></a> {
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions"><c- g>CEReactions</c-></a>] <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-element-sethtmlunsafe" id="ref-for-dom-element-sethtmlunsafe①"><c- g>setHTMLUnsafe</c-></a>((<a data-link-type="idl-name" href="https://w3c.github.io/trusted-types/dist/spec/#trustedhtml" id="ref-for-trustedhtml"><c- n>TrustedHTML</c-></a> <c- b>or</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-for="Element/setHTMLUnsafe(html, options), Element/setHTMLUnsafe(html)" data-dfn-type="argument" data-export id="dom-element-sethtmlunsafe-html-options-html"><code><c- g>html</c-></code></dfn>, <c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-sethtmlunsafeoptions" id="ref-for-dictdef-sethtmlunsafeoptions"><c- n>SetHTMLUnsafeOptions</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Element/setHTMLUnsafe(html, options), Element/setHTMLUnsafe(html)" data-dfn-type="argument" data-export id="dom-element-sethtmlunsafe-html-options-options"><code><c- g>options</c-></code></dfn> = {});
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions①"><c- g>CEReactions</c-></a>] <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined①"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-element-sethtml" id="ref-for-dom-element-sethtml①"><c- g>setHTML</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Element/setHTML(html, options), Element/setHTML(html)" data-dfn-type="argument" data-export id="dom-element-sethtml-html-options-html"><code><c- g>html</c-></code></dfn>, <c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-sethtmloptions" id="ref-for-dictdef-sethtmloptions"><c- n>SetHTMLOptions</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Element/setHTML(html, options), Element/setHTML(html)" data-dfn-type="argument" data-export id="dom-element-sethtml-html-options-options"><code><c- g>options</c-></code></dfn> = {});
+};
+</pre>
+   <div class="algorithm" data-algorithm="setHTMLUnsafe(html, options)" data-algorithm-for="Element">
+    
+<code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element④">Element</a></code>’s <dfn class="dfn-paneled idl-code" data-dfn-for="Element" data-dfn-type="method" data-export data-lt="setHTMLUnsafe(html, options)|setHTMLUnsafe(html)" id="dom-element-sethtmlunsafe"><code>setHTMLUnsafe(<var>html</var>, <var>options</var>)</code></dfn> method steps are:
+
+
+    <ol>
+     <li data-md>
+      <p>Let <var>compliantHTML</var> be the result of invoking the <a data-link-type="abstract-op" href="https://w3c.github.io/trusted-types/dist/spec/#abstract-opdef-get-trusted-type-compliant-string" id="ref-for-abstract-opdef-get-trusted-type-compliant-string">Get Trusted Type compliant string</a> algorithm with
+ <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/trusted-types/dist/spec/#trustedhtml" id="ref-for-trustedhtml①">TrustedHTML</a></code>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this">this</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global">relevant global object</a>, <var>html</var>, "Element setHTMLUnsafe", and "script".</p>
+     <li data-md>
+      <p>Let <var>target</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①">this</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#template-contents" id="ref-for-template-contents">template contents</a> if <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②">this</a> is a
+ <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/scripting.html#htmltemplateelement" id="ref-for-htmltemplateelement">template</a></code> element; otherwise <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③">this</a>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="#set-and-filter-html" id="ref-for-set-and-filter-html">Set and filter HTML</a> given <var>target</var>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④">this</a>, <var>compliantHTML</var>, <var>options</var>, and false.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="setHTML(html, options)" data-algorithm-for="Element">
+    
+<code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑤">Element</a></code>’s <dfn class="dfn-paneled idl-code" data-dfn-for="Element" data-dfn-type="method" data-export data-lt="setHTML(html, options)|setHTML(html)" id="dom-element-sethtml"><code>setHTML(<var>html</var>, <var>options</var>)</code></dfn> method steps are:
+
+
+    <ol>
+     <li data-md>
+      <p>Let <var>target</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑤">this</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#template-contents" id="ref-for-template-contents①">template contents</a> if <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑥">this</a> is a
+ <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/scripting.html#htmltemplateelement" id="ref-for-htmltemplateelement①">template</a></code>; otherwise <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑦">this</a>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="#set-and-filter-html" id="ref-for-set-and-filter-html①">Set and filter HTML</a> given <var>target</var>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑧">this</a>, <var>html</var>, <var>options</var>, and true.</p>
+    </ol>
+   </div>
+<pre class="extract idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#shadowroot" id="ref-for-shadowroot①"><c- g>ShadowRoot</c-></a> {
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions②"><c- g>CEReactions</c-></a>] <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined②"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-shadowroot-sethtmlunsafe" id="ref-for-dom-shadowroot-sethtmlunsafe"><c- g>setHTMLUnsafe</c-></a>((<a data-link-type="idl-name" href="https://w3c.github.io/trusted-types/dist/spec/#trustedhtml" id="ref-for-trustedhtml②"><c- n>TrustedHTML</c-></a> <c- b>or</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString③"><c- b>DOMString</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-for="ShadowRoot/setHTMLUnsafe(html, options), ShadowRoot/setHTMLUnsafe(html)" data-dfn-type="argument" data-export id="dom-shadowroot-sethtmlunsafe-html-options-html"><code><c- g>html</c-></code></dfn>, <c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-sethtmlunsafeoptions" id="ref-for-dictdef-sethtmlunsafeoptions①"><c- n>SetHTMLUnsafeOptions</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="ShadowRoot/setHTMLUnsafe(html, options), ShadowRoot/setHTMLUnsafe(html)" data-dfn-type="argument" data-export id="dom-shadowroot-sethtmlunsafe-html-options-options"><code><c- g>options</c-></code></dfn> = {});
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions" id="ref-for-cereactions③"><c- g>CEReactions</c-></a>] <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-undefined" id="ref-for-idl-undefined③"><c- b>undefined</c-></a> <a class="idl-code" data-link-type="method" href="#dom-shadowroot-sethtml" id="ref-for-dom-shadowroot-sethtml"><c- g>setHTML</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString④"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="ShadowRoot/setHTML(html, options), ShadowRoot/setHTML(html)" data-dfn-type="argument" data-export id="dom-shadowroot-sethtml-html-options-html"><code><c- g>html</c-></code></dfn>, <c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-sethtmloptions" id="ref-for-dictdef-sethtmloptions①"><c- n>SetHTMLOptions</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="ShadowRoot/setHTML(html, options), ShadowRoot/setHTML(html)" data-dfn-type="argument" data-export id="dom-shadowroot-sethtml-html-options-options"><code><c- g>options</c-></code></dfn> = {});
+};
+</pre>
+   <p>These methods are mirrored on the <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#shadowroot" id="ref-for-shadowroot②">ShadowRoot</a></code>:</p>
+   <div class="algorithm" data-algorithm="setHTMLUnsafe(html, options)" data-algorithm-for="ShadowRoot">
+    
+<code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#shadowroot" id="ref-for-shadowroot③">ShadowRoot</a></code>’s <dfn class="dfn-paneled idl-code" data-dfn-for="ShadowRoot" data-dfn-type="method" data-export data-lt="setHTMLUnsafe(html, options)|setHTMLUnsafe(html)" id="dom-shadowroot-sethtmlunsafe"><code>setHTMLUnsafe(<var>html</var>, <var>options</var>)</code></dfn> method steps are:
+
+
+    <ol>
+     <li data-md>
+      <p>Let <var>compliantHTML</var> be the result of invoking the <a data-link-type="abstract-op" href="https://w3c.github.io/trusted-types/dist/spec/#abstract-opdef-get-trusted-type-compliant-string" id="ref-for-abstract-opdef-get-trusted-type-compliant-string①">Get Trusted Type compliant string</a> algorithm with
+ <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/trusted-types/dist/spec/#trustedhtml" id="ref-for-trustedhtml③">TrustedHTML</a></code>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑨">this</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global①">relevant global object</a>, <var>html</var>, "ShadowRoot setHTMLUnsafe", and "script".</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="#set-and-filter-html" id="ref-for-set-and-filter-html②">Set and filter HTML</a> using <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⓪">this</a>,
+ <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①①">this</a>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#element-shadow-host" id="ref-for-element-shadow-host">shadow host</a> (as context element),
+ <var>compliantHTML</var>, <var>options</var>, and false.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="setHTML(html, options)" data-algorithm-for="ShadowRoot">
+    
+<code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#shadowroot" id="ref-for-shadowroot④">ShadowRoot</a></code>’s <dfn class="dfn-paneled idl-code" data-dfn-for="ShadowRoot" data-dfn-type="method" data-export data-lt="setHTML(html, options)|setHTML(html)" id="dom-shadowroot-sethtml"><code>setHTML(<var>html</var>, <var>options</var>)</code></dfn> method steps are:
+
+
+    <ol>
+     <li data-md>
+      <p><a data-link-type="dfn" href="#set-and-filter-html" id="ref-for-set-and-filter-html③">Set and filter HTML</a> using <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①②">this</a> (as target), <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①③">this</a> (as context element),
+ <var>html</var>, <var>options</var>, and true.</p>
+    </ol>
+   </div>
+   <p>The <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document①">Document</a></code> interface gains two new methods which parse an entire <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code>:</p>
+<pre class="extract idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#document" id="ref-for-document③"><c- g>Document</c-></a> {
+  <c- b>static</c-> <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#document" id="ref-for-document④"><c- n>Document</c-></a> <a class="idl-code" data-link-type="method" href="#dom-document-parsehtmlunsafe" id="ref-for-dom-document-parsehtmlunsafe"><c- g>parseHTMLUnsafe</c-></a>((<a data-link-type="idl-name" href="https://w3c.github.io/trusted-types/dist/spec/#trustedhtml" id="ref-for-trustedhtml④"><c- n>TrustedHTML</c-></a> <c- b>or</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString⑤"><c- b>DOMString</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-for="Document/parseHTMLUnsafe(html, options), Document/parseHTMLUnsafe(html)" data-dfn-type="argument" data-export id="dom-document-parsehtmlunsafe-html-options-html"><code><c- g>html</c-></code></dfn>, <c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-sethtmlunsafeoptions" id="ref-for-dictdef-sethtmlunsafeoptions②"><c- n>SetHTMLUnsafeOptions</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Document/parseHTMLUnsafe(html, options), Document/parseHTMLUnsafe(html)" data-dfn-type="argument" data-export id="dom-document-parsehtmlunsafe-html-options-options"><code><c- g>options</c-></code></dfn> = {});
+  <c- b>static</c-> <a data-link-type="idl-name" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑤"><c- n>Document</c-></a> <a class="idl-code" data-link-type="method" href="#dom-document-parsehtml" id="ref-for-dom-document-parsehtml"><c- g>parseHTML</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString⑥"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Document/parseHTML(html, options), Document/parseHTML(html)" data-dfn-type="argument" data-export id="dom-document-parsehtml-html-options-html"><code><c- g>html</c-></code></dfn>, <c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-sethtmloptions" id="ref-for-dictdef-sethtmloptions②"><c- n>SetHTMLOptions</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Document/parseHTML(html, options), Document/parseHTML(html)" data-dfn-type="argument" data-export id="dom-document-parsehtml-html-options-options"><code><c- g>options</c-></code></dfn> = {});
+};
+</pre>
+   <div class="algorithm" data-algorithm="parseHTMLUnsafe(html, options)" data-algorithm-for="Document">
+    
+The <dfn class="dfn-paneled idl-code" data-dfn-for="Document" data-dfn-type="method" data-export data-lt="parseHTMLUnsafe(html, options)|parseHTMLUnsafe(html)" id="dom-document-parsehtmlunsafe"><code>parseHTMLUnsafe(<var>html</var>, <var>options</var>)</code></dfn> method steps are:
+
+
+    <ol>
+     <li data-md>
+      <p>Let <var>compliantHTML</var> be the result of invoking the <a data-link-type="abstract-op" href="https://w3c.github.io/trusted-types/dist/spec/#abstract-opdef-get-trusted-type-compliant-string" id="ref-for-abstract-opdef-get-trusted-type-compliant-string②">Get Trusted Type compliant string</a> algorithm with
+ <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/trusted-types/dist/spec/#trustedhtml" id="ref-for-trustedhtml⑤">TrustedHTML</a></code>, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①④">this</a>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global" id="ref-for-concept-relevant-global②">relevant global object</a>, <var>html</var>, "Document parseHTMLUnsafe", and "script".</p>
+     <li data-md>
+      <p>Let <var>document</var> be a new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code>, whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-content-type" id="ref-for-concept-document-content-type">content type</a> is "text/html".</p>
+      <p class="note" role="note"><span class="marker">Note:</span> Since <var>document</var> does not have a browsing context, scripting is disabled.</p>
+     <li data-md>
+      <p>Set <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#document-allow-declarative-shadow-roots" id="ref-for-document-allow-declarative-shadow-roots">allow declarative shadow roots</a> to true.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/#parse-html-from-a-string" id="ref-for-parse-html-from-a-string">Parse HTML from a string</a> given <var>document</var> and <var>compliantHTML</var>.</p>
+     <li data-md>
+      <p>Let <var>sanitizer</var> be the result of calling <a data-link-type="dfn" href="#sanitizerconfig-get-a-sanitizer-instance-from-options" id="ref-for-sanitizerconfig-get-a-sanitizer-instance-from-options">get a sanitizer instance from options</a>
+ with <var>options</var> and false.</p>
+     <li data-md>
+      <p>Call <a data-link-type="dfn" href="#sanitize" id="ref-for-sanitize">sanitize</a> on <var>document</var> with <var>sanitizer</var> and false.</p>
+     <li data-md>
+      <p>Return <var>document</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="parseHTML(html, options)" data-algorithm-for="Document">
+    
+The <dfn class="dfn-paneled idl-code" data-dfn-for="Document" data-dfn-type="method" data-export data-lt="parseHTML(html, options)|parseHTML(html)" id="dom-document-parsehtml"><code>parseHTML(<var>html</var>, <var>options</var>)</code></dfn> method steps are:
+
+
+    <ol>
+     <li data-md>
+      <p>Let <var>document</var> be a new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code>, whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-document-content-type" id="ref-for-concept-document-content-type①">content type</a> is "text/html".</p>
+      <p class="note" role="note"><span class="marker">Note:</span> Since <var>document</var> does not have a browsing context, scripting is disabled.</p>
+     <li data-md>
+      <p>Set <var>document</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#document-allow-declarative-shadow-roots" id="ref-for-document-allow-declarative-shadow-roots①">allow declarative shadow roots</a> to true.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/#parse-html-from-a-string" id="ref-for-parse-html-from-a-string①">Parse HTML from a string</a> given <var>document</var> and <var>html</var>.</p>
+     <li data-md>
+      <p>Let <var>sanitizer</var> be the result of calling <a data-link-type="dfn" href="#sanitizerconfig-get-a-sanitizer-instance-from-options" id="ref-for-sanitizerconfig-get-a-sanitizer-instance-from-options①">get a sanitizer instance from options</a>
+ with <var>options</var> and true.</p>
+     <li data-md>
+      <p>Call <a data-link-type="dfn" href="#sanitize" id="ref-for-sanitize①">sanitize</a> on <var>document</var> with <var>sanitizer</var> and true.</p>
+     <li data-md>
+      <p>Return <var>document</var>.</p>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="2.2" id="configobject"><span class="secno">2.2. </span><span class="content">SetHTML options and the configuration object.</span><a class="self-link" href="#configobject"></a></h3>
+   <p>The family of <code class="idl"><a data-link-type="idl" href="#dom-element-sethtml" id="ref-for-dom-element-sethtml②">setHTML()</a></code>-like methods all accept an options
+dictionary. Right now, only one member of this dictionary is defined:</p>
+<pre class="idl highlight def"><c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-sanitizerpresets"><code><c- g>SanitizerPresets</c-></code></dfn> { <dfn class="dfn-paneled idl-code" data-dfn-for="SanitizerPresets" data-dfn-type="enum-value" data-export id="dom-sanitizerpresets-default"><code><c- s>"default"</c-></code></dfn> };
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-sethtmloptions"><code><c- g>SetHTMLOptions</c-></code></dfn> {
+  (<a data-link-type="idl-name" href="#sanitizer" id="ref-for-sanitizer"><c- n>Sanitizer</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig"><c- n>SanitizerConfig</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#enumdef-sanitizerpresets" id="ref-for-enumdef-sanitizerpresets"><c- n>SanitizerPresets</c-></a>) <dfn class="dfn-paneled idl-code" data-default="&quot;default&quot;" data-dfn-for="SetHTMLOptions" data-dfn-type="dict-member" data-export data-type="(Sanitizer or SanitizerConfig or SanitizerPresets)" id="dom-sethtmloptions-sanitizer"><code><c- g>sanitizer</c-></code></dfn> = "default";
+};
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-sethtmlunsafeoptions"><code><c- g>SetHTMLUnsafeOptions</c-></code></dfn> {
+  (<a data-link-type="idl-name" href="#sanitizer" id="ref-for-sanitizer①"><c- n>Sanitizer</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig①"><c- n>SanitizerConfig</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#enumdef-sanitizerpresets" id="ref-for-enumdef-sanitizerpresets①"><c- n>SanitizerPresets</c-></a>) <dfn class="dfn-paneled idl-code" data-default="{}" data-dfn-for="SetHTMLUnsafeOptions" data-dfn-type="dict-member" data-export data-type="(Sanitizer or SanitizerConfig or SanitizerPresets)" id="dom-sethtmlunsafeoptions-sanitizer"><code><c- g>sanitizer</c-></code></dfn> = {};
+};
+</pre>
+   <p>The <code class="idl"><a data-link-type="idl" href="#sanitizer" id="ref-for-sanitizer②">Sanitizer</a></code> configuration object encapsulates a filter configuration.
+The same configuration can be used with both <a data-link-type="dfn" href="#safe-and-unsafe" id="ref-for-safe-and-unsafe">"safe"
+or "unsafe"</a> methods, where the "safe" methods perform an implicit
+<code class="idl"><a data-link-type="idl" href="#dom-sanitizer-removeunsafe" id="ref-for-dom-sanitizer-removeunsafe">removeUnsafe</a></code> operation on the passed in configuration and have a default
+configuration when none is passed. The default differs between "safe" and
+"unsafe" methods: The "safe" methods are aiming to be safe by default and
+have a restrictive default, while the "unsafe" methods are unrestricted by
+default. The intent for configuration use is
+that one (or a few) configurations will be built-up early on in a page’s
+lifetime, and can then be used whenever needed. This allows implementations
+to pre-process configurations.</p>
+   <p>The configuration object can be queried to return a configuration dictionary.
+It can also be modified directly.</p>
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="sanitizer"><code><c- g>Sanitizer</c-></code></dfn> {
+  <a class="idl-code" data-link-type="constructor" href="#dom-sanitizer-constructor" id="ref-for-dom-sanitizer-constructor"><c- g>constructor</c-></a>(<c- b>optional</c-> (<a data-link-type="idl-name" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig②"><c- n>SanitizerConfig</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#enumdef-sanitizerpresets" id="ref-for-enumdef-sanitizerpresets②"><c- n>SanitizerPresets</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer/Sanitizer(configuration), Sanitizer/constructor(configuration), Sanitizer/Sanitizer(), Sanitizer/constructor()" data-dfn-type="argument" data-export id="dom-sanitizer-sanitizer-configuration-configuration"><code><c- g>configuration</c-></code></dfn> = "default");
+
+  // Query configuration:
+  <a data-link-type="idl-name" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig③"><c- n>SanitizerConfig</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-get" id="ref-for-dom-sanitizer-get"><c- g>get</c-></a>();
+
+  // Modify a Sanitizer’s lists and fields:
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-allowelement" id="ref-for-dom-sanitizer-allowelement"><c- g>allowElement</c-></a>(<a data-link-type="idl-name" href="#typedefdef-sanitizerelementwithattributes" id="ref-for-typedefdef-sanitizerelementwithattributes"><c- n>SanitizerElementWithAttributes</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer/allowElement(element)" data-dfn-type="argument" data-export id="dom-sanitizer-allowelement-element-element"><code><c- g>element</c-></code></dfn>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean①"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-removeelement" id="ref-for-dom-sanitizer-removeelement"><c- g>removeElement</c-></a>(<a data-link-type="idl-name" href="#typedefdef-sanitizerelement" id="ref-for-typedefdef-sanitizerelement"><c- n>SanitizerElement</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer/removeElement(element)" data-dfn-type="argument" data-export id="dom-sanitizer-removeelement-element-element"><code><c- g>element</c-></code></dfn>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean②"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-replaceelementwithchildren" id="ref-for-dom-sanitizer-replaceelementwithchildren"><c- g>replaceElementWithChildren</c-></a>(<a data-link-type="idl-name" href="#typedefdef-sanitizerelement" id="ref-for-typedefdef-sanitizerelement①"><c- n>SanitizerElement</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer/replaceElementWithChildren(element)" data-dfn-type="argument" data-export id="dom-sanitizer-replaceelementwithchildren-element-element"><code><c- g>element</c-></code></dfn>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean③"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-allowattribute" id="ref-for-dom-sanitizer-allowattribute"><c- g>allowAttribute</c-></a>(<a data-link-type="idl-name" href="#typedefdef-sanitizerattribute" id="ref-for-typedefdef-sanitizerattribute"><c- n>SanitizerAttribute</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer/allowAttribute(attribute)" data-dfn-type="argument" data-export id="dom-sanitizer-allowattribute-attribute-attribute"><code><c- g>attribute</c-></code></dfn>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean④"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-removeattribute" id="ref-for-dom-sanitizer-removeattribute"><c- g>removeAttribute</c-></a>(<a data-link-type="idl-name" href="#typedefdef-sanitizerattribute" id="ref-for-typedefdef-sanitizerattribute①"><c- n>SanitizerAttribute</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer/removeAttribute(attribute)" data-dfn-type="argument" data-export id="dom-sanitizer-removeattribute-attribute-attribute"><code><c- g>attribute</c-></code></dfn>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean⑤"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-setcomments" id="ref-for-dom-sanitizer-setcomments"><c- g>setComments</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean⑥"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer/setComments(allow)" data-dfn-type="argument" data-export id="dom-sanitizer-setcomments-allow-allow"><code><c- g>allow</c-></code></dfn>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean⑦"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-setdataattributes" id="ref-for-dom-sanitizer-setdataattributes"><c- g>setDataAttributes</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean⑧"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer/setDataAttributes(allow)" data-dfn-type="argument" data-export id="dom-sanitizer-setdataattributes-allow-allow"><code><c- g>allow</c-></code></dfn>);
+
+  // Remove markup that executes script.
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean⑨"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-removeunsafe" id="ref-for-dom-sanitizer-removeunsafe①"><c- g>removeUnsafe</c-></a>();
+};
+</pre>
+   <p>A <code class="idl"><a data-link-type="idl" href="#sanitizer" id="ref-for-sanitizer③">Sanitizer</a></code> has an associated <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig④">SanitizerConfig</a></code> <dfn class="dfn-paneled" data-dfn-for="Sanitizer" data-dfn-type="dfn" data-noexport id="sanitizer-configuration">configuration</dfn>.</p>
+   <div class="algorithm" data-algorithm="constructor(configuration)" data-algorithm-for="Sanitizer">
+    
+The <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer" data-dfn-type="constructor" data-export data-lt="Sanitizer(configuration)|constructor(configuration)|Sanitizer()|constructor()" id="dom-sanitizer-constructor"><code>constructor(<var>configuration</var>)</code></dfn>
+method steps are:
+
+
+    <ol>
+     <li data-md>
+      <p>If <var>configuration</var> is a <code class="idl"><a data-link-type="idl" href="#enumdef-sanitizerpresets" id="ref-for-enumdef-sanitizerpresets③">SanitizerPresets</a></code> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string">string</a>, then:</p>
+      <ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert">Assert</a>: <var>configuration</var> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is" id="ref-for-string-is">is</a> <code class="idl"><a data-link-type="idl" href="#dom-sanitizerpresets-default" id="ref-for-dom-sanitizerpresets-default">default</a></code>.</p>
+       <li data-md>
+        <p>Set <var>configuration</var> to the <a data-link-type="dfn" href="#built-in-safe-default-configuration" id="ref-for-built-in-safe-default-configuration">built-in safe default configuration</a>.</p>
+      </ol>
+     <li data-md>
+      <p>Let <var>valid</var> be the return value of <a data-link-type="dfn" href="#sanitizer-set-a-configuration" id="ref-for-sanitizer-set-a-configuration">set a configuration</a> with
+ <var>configuration</var> and true on <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑤">this</a>.</p>
+     <li data-md>
+      <p>If <var>valid</var> is false, then throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror">TypeError</a></code>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="get()" data-algorithm-for="Sanitizer">
+    
+The <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer" data-dfn-type="method" data-export id="dom-sanitizer-get"><code>get()</code></dfn> method steps are:
+
+
+    <div class="note" role="note"><span class="marker">Note:</span>
+Outside of the get() method, the order of the Sanitizer’s elements and attributes is unobservable.
+By explicitly sorting the result of this method, we give implementations the opportunity to optimize by, for example, using unordered sets internally.
+</div>
+    <ol>
+     <li data-md>
+      <p>Let <var>config</var> be <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑥">this</a>’s <a data-link-type="dfn" href="#sanitizer-configuration" id="ref-for-sanitizer-configuration">configuration</a>.</p>
+     <li data-md>
+      <p>If <var>config</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements">elements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists">exists</a>:</p>
+      <ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate">For any</a> <var>element</var> of <var>config</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements①">elements</a></code>"]:</p>
+        <ol>
+         <li data-md>
+          <p>If <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes">attributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists①">exists</a>:</p>
+          <ol>
+           <li data-md>
+            <p>Set <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes①">attributes</a></code>"] to the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-sort-in-ascending-order" id="ref-for-list-sort-in-ascending-order">sort in ascending order</a>
+ <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes②">attributes</a></code>"], with <var>attrA</var> being <a data-link-type="dfn" href="#sanitizerconfig-less-than-item" id="ref-for-sanitizerconfig-less-than-item">less than item</a> <var>attrB</var>.</p>
+          </ol>
+         <li data-md>
+          <p>If <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes">removeAttributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists②">exists</a>:</p>
+          <ol>
+           <li data-md>
+            <p>Set <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes①">removeAttributes</a></code>"] to the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-sort-in-ascending-order" id="ref-for-list-sort-in-ascending-order①">sort in ascending order</a>
+ <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes②">removeAttributes</a></code>"], with <var>attrA</var> being <a data-link-type="dfn" href="#sanitizerconfig-less-than-item" id="ref-for-sanitizerconfig-less-than-item①">less than item</a> <var>attrB</var>.</p>
+          </ol>
+        </ol>
+       <li data-md>
+        <p>Set <var>config</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements②">elements</a></code>"] to the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-sort-in-ascending-order" id="ref-for-list-sort-in-ascending-order②">sort in ascending order</a> <var>config</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements③">elements</a></code>"],
+ with <var>elementA</var> being <a data-link-type="dfn" href="#sanitizerconfig-less-than-item" id="ref-for-sanitizerconfig-less-than-item②">less than item</a> <var>elementB</var>.</p>
+      </ol>
+     <li data-md>
+      <p>If <var>config</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements">removeElements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists③">exists</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Set <var>config</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements①">removeElements</a></code>"] to the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-sort-in-ascending-order" id="ref-for-list-sort-in-ascending-order③">sort in ascending order</a> <var>config</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements②">removeElements</a></code>"],
+ with <var>elementA</var> being <a data-link-type="dfn" href="#sanitizerconfig-less-than-item" id="ref-for-sanitizerconfig-less-than-item③">less than item</a> <var>elementB</var>.</p>
+      </ol>
+     <li data-md>
+      <p>If <var>config</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements">replaceWithChildrenElements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists④">exists</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Set <var>config</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements①">replaceWithChildrenElements</a></code>"] to the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-sort-in-ascending-order" id="ref-for-list-sort-in-ascending-order④">sort in ascending order</a> <var>config</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements②">replaceWithChildrenElements</a></code>"],
+ with <var>elementA</var> being <a data-link-type="dfn" href="#sanitizerconfig-less-than-item" id="ref-for-sanitizerconfig-less-than-item④">less than item</a> <var>elementB</var>.</p>
+      </ol>
+     <li data-md>
+      <p>If <var>config</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes">attributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑤">exists</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Set <var>config</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes①">attributes</a></code>"] to the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-sort-in-ascending-order" id="ref-for-list-sort-in-ascending-order⑤">sort in ascending order</a> <var>config</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes②">attributes</a></code>"],
+ with <var>attrA</var> being <a data-link-type="dfn" href="#sanitizerconfig-less-than-item" id="ref-for-sanitizerconfig-less-than-item⑤">less than item</a> <var>attrB</var>.</p>
+      </ol>
+     <li data-md>
+      <p>If <var>config</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes">removeAttributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑥">exists</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Set <var>config</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes①">removeAttributes</a></code>"] to the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-sort-in-ascending-order" id="ref-for-list-sort-in-ascending-order⑥">sort in ascending order</a> <var>config</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes②">removeAttributes</a></code>"],
+ with <var>attrA</var> being <a data-link-type="dfn" href="#sanitizerconfig-less-than-item" id="ref-for-sanitizerconfig-less-than-item⑥">less than item</a> <var>attrB</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>config</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="allowElement(element)" data-algorithm-for="Sanitizer">
+The <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer" data-dfn-type="method" data-export id="dom-sanitizer-allowelement"><code>allowElement(<var>element</var>)</code></dfn> method steps are to <a data-link-type="dfn" href="#sanitizerconfig-allow-an-element" id="ref-for-sanitizerconfig-allow-an-element">allow an element</a> with <var>element</var> and <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑦">this</a>’s <a data-link-type="dfn" href="#sanitizer-configuration" id="ref-for-sanitizer-configuration①">configuration</a>.
+</div>
+   <div class="algorithm" data-algorithm="removeElement(element)" data-algorithm-for="Sanitizer">
+The <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer" data-dfn-type="method" data-export id="dom-sanitizer-removeelement"><code>removeElement(<var>element</var>)</code></dfn> method steps are
+to <a data-link-type="dfn" href="#sanitizer-remove-an-element" id="ref-for-sanitizer-remove-an-element">remove an element</a> with <var>element</var> and <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑧">this</a>’s <a data-link-type="dfn" href="#sanitizer-configuration" id="ref-for-sanitizer-configuration②">configuration</a>.
+</div>
+   <div class="algorithm" data-algorithm="replaceElementWithChildren(element)" data-algorithm-for="Sanitizer">
+The <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer" data-dfn-type="method" data-export id="dom-sanitizer-replaceelementwithchildren"><code>replaceElementWithChildren(<var>element</var>)</code></dfn> method steps are to <a data-link-type="dfn" href="#sanitizer-replace-an-element-with-its-children" id="ref-for-sanitizer-replace-an-element-with-its-children">replace an element with its children</a> with <var>element</var> and <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①⑨">this</a>’s <a data-link-type="dfn" href="#sanitizer-configuration" id="ref-for-sanitizer-configuration③">configuration</a>.
+</div>
+   <div class="algorithm" data-algorithm="allowAttribute(attribute)" data-algorithm-for="Sanitizer">
+The <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer" data-dfn-type="method" data-export id="dom-sanitizer-allowattribute"><code>allowAttribute(<var>attribute</var>)</code></dfn> method steps are to <a data-link-type="dfn" href="#sanitizer-allow-an-attribute" id="ref-for-sanitizer-allow-an-attribute">allow an attribute</a> with <var>attribute</var> and <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⓪">this</a>’s <a data-link-type="dfn" href="#sanitizer-configuration" id="ref-for-sanitizer-configuration④">configuration</a>.
+</div>
+   <div class="algorithm" data-algorithm="removeAttribute(attribute)" data-algorithm-for="Sanitizer">
+The <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer" data-dfn-type="method" data-export id="dom-sanitizer-removeattribute"><code>removeAttribute(<var>attribute</var>)</code></dfn> method steps are to <a data-link-type="dfn" href="#sanitizer-remove-an-attribute" id="ref-for-sanitizer-remove-an-attribute">remove an attribute</a> with <var>attribute</var> and <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②①">this</a>’s <a data-link-type="dfn" href="#sanitizer-configuration" id="ref-for-sanitizer-configuration⑤">configuration</a>.
+</div>
+   <div class="algorithm" data-algorithm="setComments(allow)" data-algorithm-for="Sanitizer">
+The <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer" data-dfn-type="method" data-export id="dom-sanitizer-setcomments"><code>setComments(<var>allow</var>)</code></dfn> method steps to <a data-link-type="dfn" href="#sanitizer-set-comments" id="ref-for-sanitizer-set-comments">set comments</a> with <var>allow</var> and <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②②">this</a>’s <a data-link-type="dfn" href="#sanitizer-configuration" id="ref-for-sanitizer-configuration⑥">configuration</a>.
+</div>
+   <div class="algorithm" data-algorithm="setDataAttributes(allow)" data-algorithm-for="Sanitizer">
+The <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer" data-dfn-type="method" data-export id="dom-sanitizer-setdataattributes"><code>setDataAttributes(<var>allow</var>)</code></dfn> method steps are to <a data-link-type="dfn" href="#sanitizer-set-data-attributes" id="ref-for-sanitizer-set-data-attributes">set data attributes</a> with <var>allow</var> and <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②③">this</a>’s <a data-link-type="dfn" href="#sanitizer-configuration" id="ref-for-sanitizer-configuration⑦">configuration</a>.
+</div>
+   <div class="algorithm" data-algorithm="removeUnsafe()" data-algorithm-for="Sanitizer">
+The <dfn class="dfn-paneled idl-code" data-dfn-for="Sanitizer" data-dfn-type="method" data-export id="dom-sanitizer-removeunsafe"><code>removeUnsafe()</code></dfn> method steps are to
+update <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②④">this</a>’s <a data-link-type="dfn" href="#sanitizer-configuration" id="ref-for-sanitizer-configuration⑧">configuration</a> with the result of calling <a data-link-type="dfn" href="#sanitizerconfig-remove-unsafe" id="ref-for-sanitizerconfig-remove-unsafe">remove unsafe</a>
+on <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②⑤">this</a>’s <a data-link-type="dfn" href="#sanitizer-configuration" id="ref-for-sanitizer-configuration⑨">configuration</a>.
+</div>
+   <h3 class="heading settled" data-level="2.3" id="config"><span class="secno">2.3. </span><span class="content">The Configuration Dictionary</span><a class="self-link" href="#config"></a></h3>
+<pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-sanitizerelementnamespace"><code><c- g>SanitizerElementNamespace</c-></code></dfn> {
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString⑦"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="SanitizerElementNamespace" data-dfn-type="dict-member" data-export data-type="DOMString" id="dom-sanitizerelementnamespace-name"><code><c- g>name</c-></code></dfn>;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString⑧"><c- b>DOMString</c-></a>? <dfn class="dfn-paneled idl-code" data-default="&quot;http://www.w3.org/1999/xhtml&quot;" data-dfn-for="SanitizerElementNamespace" data-dfn-type="dict-member" data-export data-lt="namespace" data-type="DOMString?" id="dom-sanitizerelementnamespace-namespace"><code><c- g>_namespace</c-></code></dfn> = "http://www.w3.org/1999/xhtml";
+};
+
+// Used by "elements"
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-sanitizerelementnamespacewithattributes"><code><c- g>SanitizerElementNamespaceWithAttributes</c-></code></dfn> : <a data-link-type="idl-name" href="#dictdef-sanitizerelementnamespace" id="ref-for-dictdef-sanitizerelementnamespace"><c- n>SanitizerElementNamespace</c-></a> {
+  <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence" id="ref-for-idl-sequence"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#typedefdef-sanitizerattribute" id="ref-for-typedefdef-sanitizerattribute②"><c- n>SanitizerAttribute</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-for="SanitizerElementNamespaceWithAttributes" data-dfn-type="dict-member" data-export data-type="sequence<SanitizerAttribute>" id="dom-sanitizerelementnamespacewithattributes-attributes"><code><c- g>attributes</c-></code></dfn>;
+  <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence" id="ref-for-idl-sequence①"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#typedefdef-sanitizerattribute" id="ref-for-typedefdef-sanitizerattribute③"><c- n>SanitizerAttribute</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-for="SanitizerElementNamespaceWithAttributes" data-dfn-type="dict-member" data-export data-type="sequence<SanitizerAttribute>" id="dom-sanitizerelementnamespacewithattributes-removeattributes"><code><c- g>removeAttributes</c-></code></dfn>;
+};
+
+<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString⑨"><c- b>DOMString</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#dictdef-sanitizerelementnamespace" id="ref-for-dictdef-sanitizerelementnamespace①"><c- n>SanitizerElementNamespace</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-sanitizerelement"><code><c- g>SanitizerElement</c-></code></dfn>;
+<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString①⓪"><c- b>DOMString</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#dictdef-sanitizerelementnamespacewithattributes" id="ref-for-dictdef-sanitizerelementnamespacewithattributes"><c- n>SanitizerElementNamespaceWithAttributes</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-sanitizerelementwithattributes"><code><c- g>SanitizerElementWithAttributes</c-></code></dfn>;
+
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-sanitizerattributenamespace"><code><c- g>SanitizerAttributeNamespace</c-></code></dfn> {
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString①①"><c- b>DOMString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="SanitizerAttributeNamespace" data-dfn-type="dict-member" data-export data-type="DOMString" id="dom-sanitizerattributenamespace-name"><code><c- g>name</c-></code></dfn>;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString①②"><c- b>DOMString</c-></a>? <dfn class="dfn-paneled idl-code" data-default="null" data-dfn-for="SanitizerAttributeNamespace" data-dfn-type="dict-member" data-export data-lt="namespace" data-type="DOMString?" id="dom-sanitizerattributenamespace-namespace"><code><c- g>_namespace</c-></code></dfn> = <c- b>null</c->;
+};
+<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString①③"><c- b>DOMString</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#dictdef-sanitizerattributenamespace" id="ref-for-dictdef-sanitizerattributenamespace"><c- n>SanitizerAttributeNamespace</c-></a>) <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-sanitizerattribute"><code><c- g>SanitizerAttribute</c-></code></dfn>;
+
+<c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-sanitizerconfig"><code><c- g>SanitizerConfig</c-></code></dfn> {
+  <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence" id="ref-for-idl-sequence②"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#typedefdef-sanitizerelementwithattributes" id="ref-for-typedefdef-sanitizerelementwithattributes①"><c- n>SanitizerElementWithAttributes</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-for="SanitizerConfig" data-dfn-type="dict-member" data-export data-type="sequence<SanitizerElementWithAttributes>" id="dom-sanitizerconfig-elements"><code><c- g>elements</c-></code></dfn>;
+  <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence" id="ref-for-idl-sequence③"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#typedefdef-sanitizerelement" id="ref-for-typedefdef-sanitizerelement②"><c- n>SanitizerElement</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-for="SanitizerConfig" data-dfn-type="dict-member" data-export data-type="sequence<SanitizerElement>" id="dom-sanitizerconfig-removeelements"><code><c- g>removeElements</c-></code></dfn>;
+  <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence" id="ref-for-idl-sequence④"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#typedefdef-sanitizerelement" id="ref-for-typedefdef-sanitizerelement③"><c- n>SanitizerElement</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-for="SanitizerConfig" data-dfn-type="dict-member" data-export data-type="sequence<SanitizerElement>" id="dom-sanitizerconfig-replacewithchildrenelements"><code><c- g>replaceWithChildrenElements</c-></code></dfn>;
+
+  <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence" id="ref-for-idl-sequence⑤"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#typedefdef-sanitizerattribute" id="ref-for-typedefdef-sanitizerattribute④"><c- n>SanitizerAttribute</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-for="SanitizerConfig" data-dfn-type="dict-member" data-export data-type="sequence<SanitizerAttribute>" id="dom-sanitizerconfig-attributes"><code><c- g>attributes</c-></code></dfn>;
+  <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence" id="ref-for-idl-sequence⑥"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#typedefdef-sanitizerattribute" id="ref-for-typedefdef-sanitizerattribute⑤"><c- n>SanitizerAttribute</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-for="SanitizerConfig" data-dfn-type="dict-member" data-export data-type="sequence<SanitizerAttribute>" id="dom-sanitizerconfig-removeattributes"><code><c- g>removeAttributes</c-></code></dfn>;
+
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean①⓪"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="SanitizerConfig" data-dfn-type="dict-member" data-export data-type="boolean" id="dom-sanitizerconfig-comments"><code><c- g>comments</c-></code></dfn>;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean" id="ref-for-idl-boolean①①"><c- b>boolean</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="SanitizerConfig" data-dfn-type="dict-member" data-export data-type="boolean" id="dom-sanitizerconfig-dataattributes"><code><c- g>dataAttributes</c-></code></dfn>;
+};
+</pre>
+   <h3 class="heading settled" data-level="2.4" id="invariants"><span class="secno">2.4. </span><span class="content">Configuration Invariants</span><a class="self-link" href="#invariants"></a></h3>
+   <p>Configurations can and ought to be modified by developers to suit their
+purposes. Options are to write a new <a href="#config">configuration dictionary</a> from
+scratch, to modify an existing <code class="idl"><a data-link-type="idl" href="#sanitizer" id="ref-for-sanitizer④">Sanitizer</a></code>’s configuration by using the
+modifier methods, or to <code class="idl"><a data-link-type="idl" href="#dom-sanitizer-get" id="ref-for-dom-sanitizer-get①">get()</a></code> an existing <code class="idl"><a data-link-type="idl" href="#sanitizer" id="ref-for-sanitizer⑤">Sanitizer</a></code>’s
+<a href="#config">configuration</a>  as a dictionary and modify the dictionary and then
+create a new <code class="idl"><a data-link-type="idl" href="#sanitizer" id="ref-for-sanitizer⑥">Sanitizer</a></code> with it.</p>
+   <p>An empty configuration allows everything (when called with the "unsafe" methods like
+<code class="idl"><a data-link-type="idl" href="#dom-element-sethtmlunsafe" id="ref-for-dom-element-sethtmlunsafe②">setHTMLUnsafe</a></code>).
+A configuration <code>"default"</code> contains a <a data-link-type="dfn" href="#built-in-safe-default-configuration" id="ref-for-built-in-safe-default-configuration①">built-in safe default configuration</a>. Note
+that "safe" and "unsafe" sanitizer methods have different defaults.</p>
+   <p>Not all configuration dictionaries are valid. A valid configuration avoids redundancy
+(like specifying the same element to be allowed twice) and contradictions (like specifying an
+element to be both removed and allowed.)</p>
+   <p>Several conditions need to hold for a configuration to be valid:</p>
+   <ul>
+    <li data-md>
+     <p>Mixing global allow- and remove-lists:</p>
+     <ul>
+      <li data-md>
+       <p><code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements④">elements</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements③">removeElements</a></code> can exist,
+but not both.
+If both are missing, this is equivalent to <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements④">removeElements</a></code>
+<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set">set</a> to « ».</p>
+      <li data-md>
+       <p><code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes③">attributes</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes③">removeAttributes</a></code> can exist,
+but not both.
+If both are missing, this is equivalent to <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes④">removeAttributes</a></code>
+<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set①">set</a> to « ».</p>
+      <li data-md>
+       <p><code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes">dataAttributes</a></code> is conceptually an extension of the
+<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes④">attributes</a></code> allow-list. The <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes①">dataAttributes</a></code>
+attribute is only allowed when a <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes⑤">attributes</a></code> list is used.</p>
+     </ul>
+    <li data-md>
+     <p>Duplicate entries between different global lists:</p>
+     <ul>
+      <li data-md>
+       <p>There are no duplicate entries (i.e., no same elements) between
+<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements⑤">elements</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements⑤">removeElements</a></code>, or
+<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements③">replaceWithChildrenElements</a></code>.</p>
+      <li data-md>
+       <p>There are no duplicate entries (i.e., no same attributes) between
+<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes⑥">attributes</a></code> or <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes⑤">removeAttributes</a></code>.</p>
+     </ul>
+    <li data-md>
+     <p>Duplicate entries on the same element:</p>
+     <ul>
+      <li data-md>
+       <p>There are no duplicate entries between <code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes③">attributes</a></code>
+and <code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes③">removeAttributes</a></code> on the same element.</p>
+     </ul>
+   </ul>
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements⑥">elements</a></code> element allow-list can also specify allowing or removing
+attributes for a given element. This is meant to mirror <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>’s structure, which knows
+both <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes" id="ref-for-global-attributes">global attributes</a> as well as local <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-attribute" id="ref-for-concept-attribute">attributes</a> that apply to a
+specific element. Global and local attributes can be mixed, but note that ambiguous
+configurations where a particular attribute would be allowed by one list and forbidden by another,
+are generally invalid.</p>
+   <table class="data">
+    <tbody>
+     <tr>
+      <td>
+      <th>global <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes⑦">attributes</a></code>
+      <th>global <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes⑥">removeAttributes</a></code>
+     <tr>
+      <th>local <code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes④">attributes</a></code>
+      <td class="long">An attribute is allowed if it matches either list. No duplicates are allowed.
+      <td class="long">An attribute is only allowed if it’s in the local allow list.
+   No duplicate entries between global remove and local allow lists are allowed.
+   Note that the global remove list has no function for this particular element, but may well
+   apply to other elements that do not have a local allow list.
+     <tr>
+      <th>local <code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes④">removeAttributes</a></code>
+      <td class="long">An attribute is allowed if it’s in the global allow-list, but not in the local
+   remove-list. Local remove must be a subset of the global allow lists. 
+      <td class="long">An attribute is allowed if it is in neither list.
+   No duplicate entries between global remove and local remove lists are allowed.
+   </table>
+   <p>Please note the asymmetry where mostly no duplicates between global and per-element lists are
+permitted, but in the case of a global allow-list and a per-element remove-list the latter must
+be a subset of the former. An excerpt of the table above, only focusing on duplicates, is as
+follows:</p>
+   <table class="data">
+    <tbody>
+     <tr>
+      <td>
+      <th>global <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes⑧">attributes</a></code>
+      <th>global <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes⑦">removeAttributes</a></code>
+     <tr>
+      <th>local <code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes⑤">attributes</a></code>
+      <td class="long">No duplicates are allowed.
+      <td class="long">No duplicates are allowed.
+
+     <tr>
+      <th>local <code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes⑤">removeAttributes</a></code>
+      <td class="long">Local remove must be a subset of the global allow lists. 
+      <td class="long">No duplicates are allowed.
+   </table>
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes②">dataAttributes</a></code> setting allows <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute" id="ref-for-custom-data-attribute">custom data attributes</a>. The rules
+above easily extends to <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute" id="ref-for-custom-data-attribute①">custom data attributes</a> if one considers
+<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes③">dataAttributes</a></code> to be an allow-list:</p>
+   <table class="data">
+    <tbody>
+     <tr>
+      <td>
+      <th>global <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes⑨">attributes</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes④">dataAttributes</a></code> set
+     <tr>
+      <th>local <code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes⑥">attributes</a></code>
+      <td class="long">All <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute" id="ref-for-custom-data-attribute②">custom data attributes</a> are allowed. No <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute" id="ref-for-custom-data-attribute③">custom data attributes</a> may
+   be listed in any allow-list, as that would mean a duplicate entry.
+     <tr>
+      <th>local <code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes⑥">removeAttributes</a></code>
+      <td class="long">A <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute" id="ref-for-custom-data-attribute④">custom data attribute</a> is allowed, unless it’s listed in the local
+   remove-list.
+   No <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute" id="ref-for-custom-data-attribute⑤">custom data attribute</a> may be listed in the global allow-list, as that would mean a
+   duplicate entry.
+   </table>
+   <p>Putting these rules in words:</p>
+   <ul>
+    <li data-md>
+     <p>Duplicates and interactions between global and local lists:</p>
+     <ul>
+      <li data-md>
+       <p>If a global <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes①⓪">attributes</a></code> allow list exists, then all element’s local lists:</p>
+       <ul>
+        <li data-md>
+         <p>If a local <code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes⑦">attributes</a></code> allow lists exists,
+  there may be no duplicate entries between these lists.</p>
+        <li data-md>
+         <p>If a local <code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes⑦">removeAttributes</a></code> remove lists exists,
+  then all its entries must also be listed in the global <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes①①">attributes</a></code>
+  allow list.</p>
+        <li data-md>
+         <p>If <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes⑤">dataAttributes</a></code> is true, then no <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute" id="ref-for-custom-data-attribute⑥">custom data attributes</a> may be
+  listed in any of the allow-lists.</p>
+       </ul>
+      <li data-md>
+       <p>If a global <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes⑧">removeAttributes</a></code> remove list exists, then:</p>
+       <ul>
+        <li data-md>
+         <p>If a local <code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes⑧">attributes</a></code> allow lists exists,
+  there may be no duplicate entries between these lists.</p>
+        <li data-md>
+         <p>If a local <code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes⑧">removeAttributes</a></code> remove lists exists,
+  there may be no duplicate entries between these lists.</p>
+        <li data-md>
+         <p><code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes⑥">dataAttributes</a></code> must be absent.</p>
+       </ul>
+     </ul>
+   </ul>
+   <div class="algorithm" data-algorithm="valid" data-algorithm-for="SanitizerConfig">
+    
+A <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig⑤">SanitizerConfig</a></code> <var>config</var> is <dfn class="dfn-paneled" data-dfn-for="SanitizerConfig" data-dfn-type="dfn" data-noexport id="sanitizerconfig-valid">valid</dfn> if all of the following
+conditions hold:
+
+
+    <ol>
+     <li data-md>
+      <p>The <var>config</var> has either an <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements⑦">elements</a></code> or a <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements⑥">removeElements</a></code>
+  <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key">key</a>, but not both.</p>
+     <li data-md>
+      <p>The <var>config</var> has either an <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes①②">attributes</a></code> or a <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes⑨">removeAttributes</a></code>
+  <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key①">key</a>, but not both.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert①">Assert</a>: All <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerelementnamespacewithattributes" id="ref-for-dictdef-sanitizerelementnamespacewithattributes①">SanitizerElementNamespaceWithAttributes</a></code>, <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerelementnamespace" id="ref-for-dictdef-sanitizerelementnamespace②">SanitizerElementNamespace</a></code>, and
+  <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerattributenamespace" id="ref-for-dictdef-sanitizerattributenamespace①">SanitizerAttributeNamespace</a></code> items in <var>config</var> are canonical, meaning they have been run
+  through <a data-link-type="dfn" href="#canonicalize-a-sanitizer-element" id="ref-for-canonicalize-a-sanitizer-element">canonicalize a sanitizer element</a> or <a data-link-type="dfn" href="#canonicalize-a-sanitizer-attribute" id="ref-for-canonicalize-a-sanitizer-attribute">canonicalize a sanitizer attribute</a>,
+  as appropriate.</p>
+     <li data-md>
+      <p>None of <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements⑧">elements</a></code>], <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements⑦">removeElements</a></code>],
+  <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements④">replaceWithChildrenElements</a></code>],
+  <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes①③">attributes</a></code>], or
+  <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes①⓪">removeAttributes</a></code>], if they <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑦">exist</a>,
+  <a data-link-type="dfn" href="#sanitizerconfig-has-duplicates" id="ref-for-sanitizerconfig-has-duplicates">has duplicates</a>.</p>
+     <li data-md>
+      <p>If both <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements⑨">elements</a></code>] and
+  <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements⑤">replaceWithChildrenElements</a></code>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑧">exist</a>, then
+  the <a data-link-type="dfn" href="#sanitizerconfig-intersection" id="ref-for-sanitizerconfig-intersection">intersection</a> of <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements①⓪">elements</a></code>] and
+  <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements⑥">replaceWithChildrenElements</a></code>] is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-empty" id="ref-for-list-empty">empty</a>.</p>
+     <li data-md>
+      <p>If both <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements⑧">removeElements</a></code>] and
+  <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements⑦">replaceWithChildrenElements</a></code>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑨">exist</a>, then
+  the <a data-link-type="dfn" href="#sanitizerconfig-intersection" id="ref-for-sanitizerconfig-intersection①">intersection</a> of <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements⑨">removeElements</a></code>] and
+  <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements⑧">replaceWithChildrenElements</a></code>] is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-empty" id="ref-for-list-empty①">empty</a>.</p>
+     <li data-md>
+      <p>If <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes①④">attributes</a></code>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists①⓪">exists</a>:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements①①">elements</a></code>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists①①">exists</a>:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①">For each</a> <var>element</var> of <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements①②">elements</a></code>]:</p>
+          <ol>
+           <li data-md>
+            <p>Neither <var>element</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes⑨">attributes</a></code>] nor
+ <var>element</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes⑨">removeAttributes</a></code>], if they exist, <a data-link-type="dfn" href="#sanitizerconfig-has-duplicates" id="ref-for-sanitizerconfig-has-duplicates①">has duplicates</a>.</p>
+           <li data-md>
+            <p>The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-intersection" id="ref-for-set-intersection">intersection</a> of <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes①⑤">attributes</a></code>] and
+  <var>element</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes①⓪">attributes</a></code>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-with-default" id="ref-for-map-with-default">with default</a>
+  « » is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-empty" id="ref-for-list-empty②">empty</a>.</p>
+           <li data-md>
+            <p><var>element</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes①⓪">removeAttributes</a></code>]
+  <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-with-default" id="ref-for-map-with-default①">with default</a> « » is a
+  <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-subset" id="ref-for-set-subset">subset</a> of <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes①⑥">attributes</a></code>].</p>
+           <li data-md>
+            <p>If <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes⑦">dataAttributes</a></code> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists①②">exists</a> and
+  <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes⑧">dataAttributes</a></code> is true:</p>
+            <ol>
+             <li data-md>
+              <p><var>element</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes①①">attributes</a></code>] does not
+  contain a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute" id="ref-for-custom-data-attribute⑦">custom data attribute</a>.</p>
+            </ol>
+          </ol>
+        </ol>
+       <li data-md>
+        <p>If <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes⑨">dataAttributes</a></code> is true:</p>
+        <ol>
+         <li data-md>
+          <p><var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes①⑦">attributes</a></code>] does not contain
+  a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute" id="ref-for-custom-data-attribute⑧">custom data attribute</a>.</p>
+        </ol>
+      </ol>
+     <li data-md>
+      <p>If <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes①①">removeAttributes</a></code>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists①③">exists</a>:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements①③">elements</a></code>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists①④">exists</a>,
+ then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate②">for each</a> <var>element</var> of <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements①④">elements</a></code>]:</p>
+        <ol>
+         <li data-md>
+          <p>Neither <var>element</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes①②">attributes</a></code>] nor
+ <var>element</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes①①">removeAttributes</a></code>], if they exist, <a data-link-type="dfn" href="#sanitizerconfig-has-duplicates" id="ref-for-sanitizerconfig-has-duplicates②">has duplicates</a>.</p>
+         <li data-md>
+          <p>The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-intersection" id="ref-for-set-intersection①">intersection</a> of <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes①②">removeAttributes</a></code>] and
+  <var>element</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes①③">attributes</a></code>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-with-default" id="ref-for-map-with-default②">with default</a>
+  « » is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-empty" id="ref-for-list-empty③">empty</a>.</p>
+         <li data-md>
+          <p>The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-intersection" id="ref-for-set-intersection②">intersection</a> of <var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes①③">removeAttributes</a></code>] and
+  <var>element</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes①②">removeAttributes</a></code>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-with-default" id="ref-for-map-with-default③">with default</a>
+  « » is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-empty" id="ref-for-list-empty④">empty</a>.</p>
+        </ol>
+       <li data-md>
+        <p><var>config</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes①⓪">dataAttributes</a></code>] does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists①⑤">exist</a>.</p>
+      </ol>
+    </ol>
+   </div>
+   <p class="note" role="note"><span class="marker">Note:</span> <a data-link-type="dfn" href="#sanitizer-set-a-configuration" id="ref-for-sanitizer-set-a-configuration①">Setting a configuration</a> from a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-dictionary" id="ref-for-dfn-dictionary">dictionary</a> will do a bit
+normalization. In particular, if both allow- and remove-lists are missing, it will interpret this
+as an empty remove-list. So <code>{}</code> itself is not a <a data-link-type="dfn" href="#sanitizerconfig-valid" id="ref-for-sanitizerconfig-valid">valid</a> configuration, but it
+will be normalized to <code>{removeElements:[],removeAttributes:[]}</code>, which is. This normalization step
+was chosen in order to have a missing dictionary be consistent with an empty one, i.e., to have
+<code>setHTMLUnsafe(txt)</code> be consistent with <code>setHTMLUnsafe(txt, {sanitizer: {}})</code>.</p>
+   <h2 class="heading settled" data-level="3" id="algorithms"><span class="secno">3. </span><span class="content">Algorithms</span><a class="self-link" href="#algorithms"></a></h2>
+   <div class="algorithm" data-algorithm="set and filter HTML">
+    
+To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="set-and-filter-html">set and filter HTML</dfn>, given an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑥">Element</a></code> or <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentfragment" id="ref-for-documentfragment">DocumentFragment</a></code>
+<var>target</var>, an <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑦">Element</a></code> <var>contextElement</var>, a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string①">string</a> <var>html</var>, and a
+<a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-dictionary" id="ref-for-dfn-dictionary①">dictionary</a> <var>options</var>, and a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#boolean" id="ref-for-boolean">boolean</a> <var>safe</var>:
+
+
+    <ol>
+     <li data-md>
+      <p>If <var>safe</var> and <var>contextElement</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-local-name" id="ref-for-concept-element-local-name">local name</a> is "<code>script</code>" and
+ <var>contextElement</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-namespace" id="ref-for-concept-element-namespace">namespace</a> is the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace" id="ref-for-html-namespace">HTML namespace</a> or the
+ <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#svg-namespace" id="ref-for-svg-namespace">SVG namespace</a>, then return.</p>
+     <li data-md>
+      <p>Let <var>sanitizer</var> be the result of calling <a data-link-type="dfn" href="#sanitizerconfig-get-a-sanitizer-instance-from-options" id="ref-for-sanitizerconfig-get-a-sanitizer-instance-from-options②">get a sanitizer instance from options</a>
+ with <var>options</var> and <var>safe</var>.</p>
+     <li data-md>
+      <p>Let <var>newChildren</var> be the result of the <a data-link-type="dfn" href="https://html.spec.whatwg.org/#html-fragment-parsing-algorithm" id="ref-for-html-fragment-parsing-algorithm">HTML fragment parsing algorithm</a>
+ given <var>contextElement</var>, <var>html</var>, and true.</p>
+     <li data-md>
+      <p>Let <var>fragment</var> be a new <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documentfragment" id="ref-for-documentfragment①">DocumentFragment</a></code> whose <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document">node document</a> is <var>contextElement</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-document" id="ref-for-concept-node-document①">node document</a>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate③">For each</a> <var>node</var> in <var>newChildren</var>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append">append</a> <var>node</var> to <var>fragment</var>.</p>
+     <li data-md>
+      <p>Run <a data-link-type="dfn" href="#sanitize" id="ref-for-sanitize②">sanitize</a> on <var>fragment</var> using <var>sanitizer</var> and <var>safe</var>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-replace-all" id="ref-for-concept-node-replace-all">Replace all</a> with <var>fragment</var> within <var>target</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="get a sanitizer instance from options" data-algorithm-for="SanitizerConfig">
+    
+To <dfn class="dfn-paneled" data-dfn-for="SanitizerConfig" data-dfn-type="dfn" data-noexport id="sanitizerconfig-get-a-sanitizer-instance-from-options">get a sanitizer instance from options</dfn> from
+a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-dictionary" id="ref-for-dfn-dictionary②">dictionary</a> <var>options</var> with a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#boolean" id="ref-for-boolean①">boolean</a> <var>safe</var>:
+
+
+    <p class="note" role="note"><span class="marker">Note:</span> This algorithm works for both <code class="idl"><a data-link-type="idl" href="#dictdef-sethtmloptions" id="ref-for-dictdef-sethtmloptions③">SetHTMLOptions</a></code> and
+    <code class="idl"><a data-link-type="idl" href="#dictdef-sethtmlunsafeoptions" id="ref-for-dictdef-sethtmlunsafeoptions③">SetHTMLUnsafeOptions</a></code>. They only differ in the defaults.</p>
+    <ol>
+     <li data-md>
+      <p>Let <var>sanitizerSpec</var> be "<code class="idl"><a data-link-type="idl" href="#dom-sanitizerpresets-default" id="ref-for-dom-sanitizerpresets-default①">default</a></code>".</p>
+     <li data-md>
+      <p>If <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-sethtmloptions-sanitizer" id="ref-for-dom-sethtmloptions-sanitizer">sanitizer</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists①⑥">exists</a>, then:</p>
+      <ol>
+       <li data-md>
+        <p>Set <var>sanitizerSpec</var> to <var>options</var>["<code class="idl"><a data-link-type="idl" href="#dom-sethtmloptions-sanitizer" id="ref-for-dom-sethtmloptions-sanitizer①">sanitizer</a></code>"]</p>
+      </ol>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert②">Assert</a>: <var>sanitizerSpec</var> is either a <code class="idl"><a data-link-type="idl" href="#sanitizer" id="ref-for-sanitizer⑦">Sanitizer</a></code> instance,
+ a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string②">string</a> which is a <code class="idl"><a data-link-type="idl" href="#enumdef-sanitizerpresets" id="ref-for-enumdef-sanitizerpresets④">SanitizerPresets</a></code> member, or a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-dictionary" id="ref-for-dfn-dictionary③">dictionary</a>.</p>
+     <li data-md>
+      <p>If <var>sanitizerSpec</var> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string" id="ref-for-string③">string</a>:</p>
+      <ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert③">Assert</a>: <var>sanitizerSpec</var> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is" id="ref-for-string-is①">is</a> "<code class="idl"><a data-link-type="idl" href="#dom-sanitizerpresets-default" id="ref-for-dom-sanitizerpresets-default②">default</a></code>"</p>
+       <li data-md>
+        <p>Set <var>sanitizerSpec</var> to the <a data-link-type="dfn" href="#built-in-safe-default-configuration" id="ref-for-built-in-safe-default-configuration②">built-in safe default configuration</a>.</p>
+      </ol>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert④">Assert</a>: <var>sanitizerSpec</var> is either a <code class="idl"><a data-link-type="idl" href="#sanitizer" id="ref-for-sanitizer⑧">Sanitizer</a></code> instance,
+ or a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-dictionary" id="ref-for-dfn-dictionary④">dictionary</a>.</p>
+     <li data-md>
+      <p>If <var>sanitizerSpec</var> is a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-dictionary" id="ref-for-dfn-dictionary⑤">dictionary</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>sanitizer</var> be a new <code class="idl"><a data-link-type="idl" href="#sanitizer" id="ref-for-sanitizer⑨">Sanitizer</a></code> instance.</p>
+       <li data-md>
+        <p>Let <var>setConfigurationResult</var> be the result of <a data-link-type="dfn" href="#sanitizer-set-a-configuration" id="ref-for-sanitizer-set-a-configuration②">set a configuration</a>
+  with <var>sanitizerSpec</var> and <a data-link-type="dfn" href="#boolean-not" id="ref-for-boolean-not">not</a> <var>safe</var> on <var>sanitizer</var>.</p>
+       <li data-md>
+        <p>If <var>setConfigurationResult</var> is false, <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-throw" id="ref-for-dfn-throw">throw</a> a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror①">TypeError</a></code>.</p>
+       <li data-md>
+        <p>Set <var>sanitizerSpec</var> to <var>sanitizer</var>.</p>
+      </ol>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert⑤">Assert</a>: <var>sanitizerSpec</var> is a <code class="idl"><a data-link-type="idl" href="#sanitizer" id="ref-for-sanitizer①⓪">Sanitizer</a></code> instance.</p>
+     <li data-md>
+      <p>Return <var>sanitizerSpec</var>.</p>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="3.1" id="sanitization"><span class="secno">3.1. </span><span class="content">Sanitize</span><a class="self-link" href="#sanitization"></a></h3>
+   <div class="algorithm" data-algorithm="sanitize">
+    
+For the main <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="sanitize">sanitize</dfn> operation, using a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#parentnode" id="ref-for-parentnode">ParentNode</a></code> <var>node</var>, a
+<code class="idl"><a data-link-type="idl" href="#sanitizer" id="ref-for-sanitizer①①">Sanitizer</a></code> <var>sanitizer</var>, and a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#boolean" id="ref-for-boolean②">boolean</a> <var>safe</var>, run these steps:
+
+
+    <ol>
+     <li data-md>
+      <p>Let <var>configuration</var> be the value of <var>sanitizer</var>’s <a data-link-type="dfn" href="#sanitizer-configuration" id="ref-for-sanitizer-configuration①⓪">configuration</a>.</p>
+     <li data-md>
+      <p>If <var>safe</var> is true, then set <var>configuration</var> to the result of calling <a data-link-type="dfn" href="#sanitizerconfig-remove-unsafe" id="ref-for-sanitizerconfig-remove-unsafe①">remove unsafe</a> on <var>configuration</var>.</p>
+     <li data-md>
+      <p>Call <a data-link-type="dfn" href="#sanitize-core" id="ref-for-sanitize-core">sanitize core</a> on <var>node</var>, <var>configuration</var>, and with <a data-link-type="dfn" href="#handlejavascriptnavigationurls" id="ref-for-handlejavascriptnavigationurls">handleJavascriptNavigationUrls</a> set to <var>safe</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="sanitize core">
+    
+The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="sanitize-core">sanitize core</dfn> operation,
+using a <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#parentnode" id="ref-for-parentnode①">ParentNode</a></code> <var>node</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig⑥">SanitizerConfig</a></code> <var>configuration</var>, and a
+<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#boolean" id="ref-for-boolean③">boolean</a> <var><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="handlejavascriptnavigationurls">handleJavascriptNavigationUrls</dfn></var>, recurses over the DOM tree
+beginning with <var>node</var>. It consistes of these steps:
+
+
+    <ol>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate④">For each</a> <var>child</var> of <var>node</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-child" id="ref-for-concept-tree-child">children</a>:</p>
+      <ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert⑥">Assert</a>: <var>child</var> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#implements" id="ref-for-implements">implements</a> <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text">Text</a></code>, <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#comment" id="ref-for-comment">Comment</a></code>, <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element" id="ref-for-element⑧">Element</a></code>,
+  or <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documenttype" id="ref-for-documenttype">DocumentType</a></code>.</p>
+        <p class="note" role="note"><span class="marker">Note:</span> Currently, this algorithm is only called on output of the HTML
+       parser for which this assertion should hold. <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documenttype" id="ref-for-documenttype①">DocumentType</a></code> should
+       only occur for <code class="idl"><a data-link-type="idl" href="#dom-document-parsehtml" id="ref-for-dom-document-parsehtml①">parseHTML</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-document-parsehtmlunsafe" id="ref-for-dom-document-parsehtmlunsafe①">parseHTMLUnsafe</a></code>.
+       If in the future this algorithm will be used in different contexts,
+       this assumption needs to be re-examined.</p>
+       <li data-md>
+        <p>If <var>child</var> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#implements" id="ref-for-implements①">implements</a> <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#documenttype" id="ref-for-documenttype②">DocumentType</a></code>, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue">continue</a>.</p>
+       <li data-md>
+        <p>If <var>child</var> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#implements" id="ref-for-implements②">implements</a> <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#text" id="ref-for-text①">Text</a></code>, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue①">continue</a>.</p>
+       <li data-md>
+        <p>If <var>child</var> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#implements" id="ref-for-implements③">implements</a> <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#comment" id="ref-for-comment①">Comment</a></code>:</p>
+        <ol>
+         <li data-md>
+          <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-comments" id="ref-for-dom-sanitizerconfig-comments">comments</a></code>"] is not true,
+ then <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-remove" id="ref-for-concept-node-remove">remove</a> <var>child</var>.</p>
+        </ol>
+       <li data-md>
+        <p>Otherwise:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>elementName</var> be a <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerelementnamespace" id="ref-for-dictdef-sanitizerelementnamespace③">SanitizerElementNamespace</a></code> with <var>child</var>’s
+ <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-local-name" id="ref-for-concept-element-local-name①">local name</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-namespace" id="ref-for-concept-element-namespace①">namespace</a>.</p>
+         <li data-md>
+          <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements⑨">replaceWithChildrenElements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists①⑦">exists</a>
+ and if <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements①⓪">replaceWithChildrenElements</a></code>"]
+ <a data-link-type="dfn" href="#sanitizerconfig-contains" id="ref-for-sanitizerconfig-contains">contains</a> <var>elementName</var>:</p>
+          <ol>
+           <li data-md>
+            <p>Call <a data-link-type="dfn" href="#sanitize-core" id="ref-for-sanitize-core①">sanitize core</a> on <var>child</var> with <var>configuration</var> and
+  <var>handleJavascriptNavigationUrls</var>.</p>
+           <li data-md>
+            <p>Call <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-replace-all" id="ref-for-concept-node-replace-all①">replace all</a> with <var>child</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-tree-child" id="ref-for-concept-tree-child①">children</a> within <var>child</var>.</p>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue②">Continue</a>.</p>
+          </ol>
+         <li data-md>
+          <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements①⓪">removeElements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists①⑧">exists</a> and
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements①①">removeElements</a></code>"]  <a data-link-type="dfn" href="#sanitizerconfig-contains" id="ref-for-sanitizerconfig-contains①">contains</a>
+  <var>elementName</var>:</p>
+          <ol>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-remove" id="ref-for-concept-node-remove①">Remove</a> <var>child</var>.</p>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue③">Continue</a>.</p>
+          </ol>
+         <li data-md>
+          <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements①⑤">elements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists①⑨">exists</a> and
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements①⑥">elements</a></code>"] does not
+  <a data-link-type="dfn" href="#sanitizerconfig-contains" id="ref-for-sanitizerconfig-contains②">contain</a> <var>elementName</var>:</p>
+          <ol>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-node-remove" id="ref-for-concept-node-remove②">Remove</a> <var>child</var>.</p>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue④">Continue</a>.</p>
+          </ol>
+         <li data-md>
+          <p>If <var>elementName</var> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is" id="ref-for-string-is②">equals</a> «[ "<code>name</code>" → "<code>template</code>",
+ "<code>namespace</code>" → <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace" id="ref-for-html-namespace①">HTML namespace</a> ]»,
+    then call <a data-link-type="dfn" href="#sanitize-core" id="ref-for-sanitize-core②">sanitize core</a> on <var>child</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/scripting.html#template-contents" id="ref-for-template-contents②">template contents</a> with
+    <var>configuration</var> and <var>handleJavascriptNavigationUrls</var>.</p>
+         <li data-md>
+          <p>If <var>child</var> is a <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#element-shadow-host" id="ref-for-element-shadow-host①">shadow host</a>,
+ then call <a data-link-type="dfn" href="#sanitize-core" id="ref-for-sanitize-core③">sanitize core</a> on <var>child</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-shadow-root" id="ref-for-concept-element-shadow-root">shadow root</a> with
+ <var>configuration</var> and <var>handleJavascriptNavigationUrls</var>.</p>
+         <li data-md>
+          <p>Let <var>elementWithLocalAttributes</var> be « [] ».</p>
+         <li data-md>
+          <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements①⑦">elements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists②⓪">exists</a> and
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements①⑧">elements</a></code>"] <a data-link-type="dfn" href="#sanitizerconfig-contains" id="ref-for-sanitizerconfig-contains③">contains</a>
+  <var>elementName</var>:</p>
+          <ol>
+           <li data-md>
+            <p>Set <var>elementWithLocalAttributes</var> to
+   <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements①⑨">elements</a></code>"][<var>elementName</var>].</p>
+          </ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate⑤">For each</a> <var>attribute</var> in <var>child</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-attribute" id="ref-for-concept-element-attribute">attribute list</a>:</p>
+          <ol>
+           <li data-md>
+            <p>Let <var>attrName</var> be a <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerattributenamespace" id="ref-for-dictdef-sanitizerattributenamespace②">SanitizerAttributeNamespace</a></code> with <var>attribute</var>’s
+ <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-attribute-local-name" id="ref-for-concept-attribute-local-name">local name</a> and <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-attribute-namespace" id="ref-for-concept-attribute-namespace">namespace</a>.</p>
+           <li data-md>
+            <p>If <var>elementWithLocalAttributes</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes①③">removeAttributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-with-default" id="ref-for-map-with-default④">with default</a> « »
+<a data-link-type="dfn" href="#sanitizerconfig-contains" id="ref-for-sanitizerconfig-contains④">contains</a> <var>attrName</var>:</p>
+            <ol>
+             <li data-md>
+              <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-attributes-remove" id="ref-for-concept-element-attributes-remove">Remove</a> <var>attribute</var>.</p>
+            </ol>
+           <li data-md>
+            <p>Otherwise, if <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes①⑧">attributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists②①">exists</a>:</p>
+            <ol>
+             <li data-md>
+              <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes①⑨">attributes</a></code>"] does not
+  <a data-link-type="dfn" href="#sanitizerconfig-contains" id="ref-for-sanitizerconfig-contains⑤">contain</a> <var>attrName</var> and
+  <var>elementWithLocalAttributes</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes①④">attributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-with-default" id="ref-for-map-with-default⑤">with default</a> « »
+  does not <a data-link-type="dfn" href="#sanitizerconfig-contains" id="ref-for-sanitizerconfig-contains⑥">contain</a> <var>attrName</var>, and if
+  "data-" is not a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#code-unit-prefix" id="ref-for-code-unit-prefix">code unit prefix</a> of <var>attribute</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-attribute-local-name" id="ref-for-concept-attribute-local-name①">local name</a> and
+  <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-attribute-namespace" id="ref-for-concept-attribute-namespace①">namespace</a> is not <code>null</code> or
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes①①">dataAttributes</a></code>"] is not true:</p>
+              <ol>
+               <li data-md>
+                <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-attributes-remove" id="ref-for-concept-element-attributes-remove①">Remove</a> <var>attribute</var>.</p>
+              </ol>
+            </ol>
+           <li data-md>
+            <p>Otherwise:</p>
+            <ol>
+             <li data-md>
+              <p>If <var>elementWithLocalAttributes</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes①⑤">attributes</a></code>"]
+<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists②②">exists</a> and <var>elementWithLocalAttributes</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes①⑥">attributes</a></code>"] does not <a data-link-type="dfn" href="#sanitizerconfig-contains" id="ref-for-sanitizerconfig-contains⑦">contain</a> <var>attrName</var>:</p>
+              <ol>
+               <li data-md>
+                <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-attributes-remove" id="ref-for-concept-element-attributes-remove②">Remove</a> <var>attribute</var>.</p>
+              </ol>
+             <li data-md>
+              <p>Otherwise, if <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes①④">removeAttributes</a></code>"] <a data-link-type="dfn" href="#sanitizerconfig-contains" id="ref-for-sanitizerconfig-contains⑧">contains</a> <var>attrName</var>:</p>
+              <ol>
+               <li data-md>
+                <p><a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-attributes-remove" id="ref-for-concept-element-attributes-remove③">Remove</a> <var>attribute</var>.</p>
+              </ol>
+            </ol>
+           <li data-md>
+            <p>If <var>handleJavascriptNavigationUrls</var>:</p>
+            <ol>
+             <li data-md>
+              <p>If «[<var>elementName</var>, <var>attrName</var>]» matches an entry in
+  the <a data-link-type="dfn" href="#built-in-navigating-url-attributes-list" id="ref-for-built-in-navigating-url-attributes-list">built-in navigating URL attributes list</a>, and if <var>attribute</var>
+  <a data-link-type="dfn" href="#contains-a-javascript-url" id="ref-for-contains-a-javascript-url">contains a javascript: URL</a>, then <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-attributes-remove" id="ref-for-concept-element-attributes-remove④">remove</a> <var>attribute</var>.</p>
+             <li data-md>
+              <p>If <var>child</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-namespace" id="ref-for-concept-element-namespace②">namespace</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is" id="ref-for-string-is③">is</a> the
+  <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#mathml-namespace" id="ref-for-mathml-namespace">MathML Namespace</a> and <var>attr</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-attribute-local-name" id="ref-for-concept-attribute-local-name②">local name</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is" id="ref-for-string-is④">is</a>
+  "<code>href</code>" and  <var>attr</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-attribute-namespace" id="ref-for-concept-attribute-namespace②">namespace</a> is <code>null</code> or the
+  <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#xlink-namespace" id="ref-for-xlink-namespace">XLink namespace</a> and <var>attr</var> <a data-link-type="dfn" href="#contains-a-javascript-url" id="ref-for-contains-a-javascript-url①">contains a javascript: URL</a>,
+  then <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-attributes-remove" id="ref-for-concept-element-attributes-remove⑤">remove</a> <var>attribute</var>.</p>
+             <li data-md>
+              <p>If the <a data-link-type="dfn" href="#built-in-animating-url-attributes-list" id="ref-for-built-in-animating-url-attributes-list">built-in animating URL attributes list</a>
+  <a data-link-type="dfn" href="#sanitizerconfig-contains" id="ref-for-sanitizerconfig-contains⑨">contains</a>
+  «[<var>elementName</var>, <var>attrName</var>]» and <var>attr</var>’s
+  <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-attributes-get-value" id="ref-for-concept-element-attributes-get-value">value</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is" id="ref-for-string-is⑤">is</a> "<code>href</code>" or
+  "<code>xlink:href</code>", then <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-attributes-remove" id="ref-for-concept-element-attributes-remove⑥">remove</a> <var>attribute</var>.</p>
+            </ol>
+          </ol>
+         <li data-md>
+          <p>Call <a data-link-type="dfn" href="#sanitize-core" id="ref-for-sanitize-core④">sanitize core</a> on <var>child</var> with <var>configuration</var> and <var>handleJavascriptNavigationUrls</var>.</p>
+        </ol>
+      </ol>
+    </ol>
+   </div>
+   <div class="note" role="note">
+    
+<span class="marker">Note:</span> Current browsers support <code>javascript:</code> URLs
+only when navigating. Since navigation itself is not an XSS threat we handle
+navigation to <code>javascript:</code> URLs, but not navigations in general.
+
+
+    <p>Declarative navigation falls into a handful of categories:</p>
+    <ol>
+     <li data-md>
+      <p>Anchor elements. (<code>&lt;a></code> in HTML and SVG namespaces)</p>
+     <li data-md>
+      <p>Form elements that trigger navigation as part of the form action.</p>
+     <li data-md>
+      <p><a data-link-type="biblio" href="#biblio-mathml" title="Mathematical Markup Language (MathML™) 1.01 Specification">[MathML]</a> allows <a href="https://www.w3.org/TR/MathML3/mathml.html#chapter2_fund.globatt">any element to act as an anchor</a>.</p>
+     <li data-md>
+      <p><a data-link-type="biblio" href="#biblio-svg11" title="Scalable Vector Graphics (SVG) 1.1 (Second Edition)">[SVG11]</a> animation.</p>
+    </ol>
+    <p>The first two are covered by the <a data-link-type="dfn" href="#built-in-navigating-url-attributes-list" id="ref-for-built-in-navigating-url-attributes-list①">built-in navigating URL attributes list</a>.</p>
+    <p>The MathML case is covered by a seperate rule, because there is no formalism
+in this spec to cover a "per-namespace global" rule.</p>
+    <p>The SVG animation case is covered by the
+<a data-link-type="dfn" href="#built-in-animating-url-attributes-list" id="ref-for-built-in-animating-url-attributes-list①">built-in animating URL attributes list</a>. But since the interpretation of SVG animation elements depends on the animation target, and since during sanitization we cannot know what the final target will be, the <a data-link-type="dfn" href="#sanitize" id="ref-for-sanitize③">sanitize</a> algorithm blocks any animation of <code>href</code> attributes.</p>
+   </div>
+   <div class="algorithm" data-algorithm="contains a javascript: URL">
+    
+To determine whether an <var>attribute</var> <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="contains-a-javascript-url">contains a javascript: URL</dfn>:
+
+    <ol>
+     <li data-md>
+      <p>Let <var>url</var> be the result of running the <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-basic-url-parser" id="ref-for-concept-basic-url-parser">basic URL parser</a>
+ on <var>attribute</var>’s <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#concept-element-attributes-get-value" id="ref-for-concept-element-attributes-get-value①">value</a>.</p>
+     <li data-md>
+      <p>If <var>url</var> is <code>failure</code>, then return false.</p>
+     <li data-md>
+      <p>Return whether <var>url</var>’s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is" id="ref-for-string-is⑥">is</a> "<code>javascript</code>".</p>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="3.2" id="configuration-modify"><span class="secno">3.2. </span><span class="content">Modify the Configuration</span><a class="self-link" href="#configuration-modify"></a></h3>
+   <p>The configuration modifier methods are methods on <code class="idl"><a data-link-type="idl" href="#sanitizer" id="ref-for-sanitizer①②">Sanitizer</a></code> that modify its configuration.
+They will maintain the validity criteria.
+They return a boolean which informs the caller whether the configuration was modified or not.</p>
+   <div class="example" id="example-9236066b">
+    <a class="self-link" href="#example-9236066b"></a>
+
+<pre class="language-js highlight"><c- a>let</c-> s <c- o>=</c-> <c- ow>new</c-> Sanitizer<c- p>({</c->elements<c- o>:</c-> <c- p>[</c-><c- u>"div"</c-><c- p>]});</c->
+s<c- p>.</c->allowElement<c- p>(</c-><c- u>"p"</c-><c- p>);</c-> <c- c1>// Returns true.</c->
+div<c- p>.</c->setHTML<c- p>(</c-><c- u>"&lt;div>&lt;p>"</c-><c- p>,</c-> <c- p>{</c->sanitizer<c- o>:</c-> s<c- p>});</c->  <c- c1>// Allows `&lt;div>` and `&lt;p>`.</c->
+</pre>
+   </div>
+   <div class="example" id="example-a63a3c16">
+    <a class="self-link" href="#example-a63a3c16"></a>
+
+<pre class="language-js highlight"><c- a>let</c-> s <c- o>=</c-> <c- ow>new</c-> Sanitizer<c- p>({</c->elements<c- o>:</c-> <c- p>[</c-><c- u>"div"</c-><c- p>]});</c->
+s<c- p>.</c->removeElement<c- p>(</c-><c- u>"p"</c-><c- p>);</c->  <c- c1>// Return false, as &lt;p> was not previously allowed.</c->
+div<c- p>.</c->setHTML<c- p>(</c-><c- u>"&lt;div>&lt;p>"</c-><c- p>,</c-> <c- p>{</c->sanitizer<c- o>:</c-> s<c- p>});</c->  <c- c1>// Allows `&lt;div>`. `&lt;p>` is removed.</c->
+</pre>
+   </div>
+   <div class="algorithm" data-algorithm="allow an element" data-algorithm-for="SanitizerConfig">
+    
+To <dfn class="dfn-paneled" data-dfn-for="SanitizerConfig" data-dfn-type="dfn" data-noexport id="sanitizerconfig-allow-an-element">allow an element</dfn>
+<code class="idl"><a data-link-type="idl" href="#typedefdef-sanitizerelementwithattributes" id="ref-for-typedefdef-sanitizerelementwithattributes②">SanitizerElementWithAttributes</a></code> <var>element</var> with a <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig⑦">SanitizerConfig</a></code> <var>configuration</var>:
+
+
+    <div class="note" role="note">
+     <span class="marker">Note:</span>
+This algorithm is relatively involved, because the element allow list may specifiy per-element
+allow- or remove-lists for attributes. This requires that we distinguish 4 cases:
+
+
+     <ul>
+      <li data-md>
+       <p>Whether we have a global allow- or remove-list, and</p>
+      <li data-md>
+       <p>whether these lists already contain <var>element</var> or not.</p>
+     </ul>
+    </div>
+    <ol>
+     <li data-md>
+      <p>Set <var>element</var> to the result of <a data-link-type="dfn" href="#canonicalize-a-sanitizer-element-with-attributes" id="ref-for-canonicalize-a-sanitizer-element-with-attributes">canonicalize a sanitizer element with attributes</a> with
+  <var>element</var>.</p>
+     <li data-md>
+      <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements②⓪">elements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists②③">exists</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Set <var>modified</var> to the result of <a data-link-type="dfn" href="#sanitizerconfig-remove" id="ref-for-sanitizerconfig-remove">remove</a> <var>element</var> from
+ <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements①①">replaceWithChildrenElements</a></code>"].</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#comment" id="ref-for-comment②">Comment</a>: We need to make sure the per-element attributes do not overlap with global
+  attributes.</p>
+       <li data-md>
+        <p>If <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes①⑦">attributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists②④">exists</a>:</p>
+        <ol>
+         <li data-md>
+          <p>Set <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes①⑧">attributes</a></code>"] to
+ <a data-link-type="dfn" href="#sanitizerconfig-remove-duplicates" id="ref-for-sanitizerconfig-remove-duplicates">remove duplicates</a> from <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes①⑨">attributes</a></code>"].</p>
+         <li data-md>
+          <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes②⓪">attributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists②⑤">exists</a>:</p>
+          <ol>
+           <li data-md>
+            <p>Set <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes②⓪">attributes</a></code>"] to the
+  <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-difference" id="ref-for-set-difference">difference</a> of
+  <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes②①">attributes</a></code>"] and
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes②①">attributes</a></code>"].</p>
+           <li data-md>
+            <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes①②">dataAttributes</a></code>"] is true:</p>
+            <ol>
+             <li data-md>
+              <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove">Remove</a> all items <var>item</var> from
+  <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes②②">attributes</a></code>"]
+  where <var>item</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute" id="ref-for-custom-data-attribute⑨">custom data attribute</a>.</p>
+            </ol>
+          </ol>
+         <li data-md>
+          <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes①⑤">removeAttributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists②⑥">exists</a>:</p>
+          <ol>
+           <li data-md>
+            <p>Set <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes②③">attributes</a></code>"] to the
+  <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-difference" id="ref-for-set-difference①">difference</a> of
+  <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes②④">attributes</a></code>"] and
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes①⑥">removeAttributes</a></code>"].</p>
+          </ol>
+        </ol>
+       <li data-md>
+        <p>If <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes①④">removeAttributes</a></code>"]
+  <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists②⑦">exists</a>:</p>
+        <ol>
+         <li data-md>
+          <p>Set <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes①⑤">removeAttributes</a></code>"] to
+     <a data-link-type="dfn" href="#sanitizerconfig-remove-duplicates" id="ref-for-sanitizerconfig-remove-duplicates①">remove duplicates</a> from <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes①⑥">removeAttributes</a></code>"].</p>
+         <li data-md>
+          <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes②②">attributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists②⑧">exists</a>:</p>
+          <ol>
+           <li data-md>
+            <p>Set <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes①⑦">removeAttributes</a></code>"] to the
+  <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-intersection" id="ref-for-set-intersection③">intersection</a> of
+  <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes①⑧">removeAttributes</a></code>"] and
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes②③">attributes</a></code>"].</p>
+          </ol>
+         <li data-md>
+          <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes①⑦">removeAttributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists②⑨">exists</a>:</p>
+          <ol>
+           <li data-md>
+            <p>Set <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes①⑨">removeAttributes</a></code>"] to the
+  <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-difference" id="ref-for-set-difference②">difference</a> of
+  <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes②⓪">removeAttributes</a></code>"] and
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes①⑧">removeAttributes</a></code>"].</p>
+          </ol>
+        </ol>
+       <li data-md>
+        <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements②①">elements</a></code>"] does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists③⓪">contain</a> <var>element</var>:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="#comment" id="ref-for-comment③">Comment</a>: This is the case with a global allow-list that does not yet contain
+  <var>element</var>.</p>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append①">Append</a> <var>element</var> to <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements②②">elements</a></code>"].</p>
+         <li data-md>
+          <p>Return true.</p>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#comment" id="ref-for-comment④">Comment</a>: This is the case with a global allow-list that already contains <var>element</var>.</p>
+       <li data-md>
+        <p>Let <var>current element</var> be the <var>item</var> in <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements②③">elements</a></code>"]
+  where <var>item</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespace-name" id="ref-for-dom-sanitizerelementnamespace-name">name</a></code>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is" id="ref-for-string-is⑦">equals</a>
+  <var>element</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespace-name" id="ref-for-dom-sanitizerelementnamespace-name①">name</a></code>]
+  and <var>item</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespace-namespace" id="ref-for-dom-sanitizerelementnamespace-namespace">namespace</a></code>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is" id="ref-for-string-is⑧">equals</a>
+  <var>element</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespace-namespace" id="ref-for-dom-sanitizerelementnamespace-namespace①">namespace</a></code>].</p>
+       <li data-md>
+        <p>If <var>element</var> <a data-link-type="dfn" href="#map-equal" id="ref-for-map-equal">equals</a> <var>current element</var> then return <var>modified</var>.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#sanitizerconfig-remove" id="ref-for-sanitizerconfig-remove①">Remove</a> <var>element</var> from <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements②④">elements</a></code>"].</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append②">Append</a> <var>element</var> to <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements②⑤">elements</a></code>"]</p>
+       <li data-md>
+        <p>Return true.</p>
+      </ol>
+     <li data-md>
+      <p>Otherwise:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes②⑤">attributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists③①">exists</a> or
+ <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes②①">removeAttributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-with-default" id="ref-for-map-with-default⑥">with default</a> « »
+ is not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-empty" id="ref-for-list-empty⑤">empty</a>:</p>
+        <ol>
+         <li data-md>
+          <p>The user agent may <a data-link-type="dfn" href="https://console.spec.whatwg.org/#report-a-warning-to-the-console" id="ref-for-report-a-warning-to-the-console">report a warning to the console</a> that this operation is not supported.</p>
+         <li data-md>
+          <p>Return false.</p>
+        </ol>
+       <li data-md>
+        <p>Set <var>modified</var> to the result of <a data-link-type="dfn" href="#sanitizerconfig-remove" id="ref-for-sanitizerconfig-remove②">remove</a> <var>element</var> from
+ <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements①②">replaceWithChildrenElements</a></code>"].</p>
+       <li data-md>
+        <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements①②">removeElements</a></code>"] does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists③②">contain</a> <var>element</var>:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="#comment" id="ref-for-comment⑤">Comment</a>: This is the case with a global remove-list that does not contain <var>element</var>.</p>
+         <li data-md>
+          <p>Return <var>modified</var>.</p>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#comment" id="ref-for-comment⑥">Comment</a>: This is the case with a global remove-list that contains <var>element</var>.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#sanitizerconfig-remove" id="ref-for-sanitizerconfig-remove③">Remove</a> <var>element</var> from
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements①③">removeElements</a></code>"].</p>
+       <li data-md>
+        <p>Return true.</p>
+      </ol>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="remove an element" data-algorithm-for="Sanitizer">
+    
+To <dfn class="dfn-paneled" data-dfn-for="Sanitizer" data-dfn-type="dfn" data-noexport id="sanitizer-remove-an-element">remove an element</dfn> <code class="idl"><a data-link-type="idl" href="#typedefdef-sanitizerelement" id="ref-for-typedefdef-sanitizerelement④">SanitizerElement</a></code> <var>element</var>
+from a <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig⑧">SanitizerConfig</a></code> <var>configuration</var>:
+
+
+    <div class="note" role="note">
+     <span class="marker">Note:</span>
+This method requires that we distinguish 4 cases:
+
+     <ul>
+      <li data-md>
+       <p>Whether we have a global allow- or remove-list,</p>
+      <li data-md>
+       <p>whether they already contain <var>element</var> or not.</p>
+     </ul>
+    </div>
+    <ol>
+     <li data-md>
+      <p>Set <var>element</var> to the result of <a data-link-type="dfn" href="#canonicalize-a-sanitizer-element" id="ref-for-canonicalize-a-sanitizer-element①">canonicalize a sanitizer element</a> with <var>element</var>.</p>
+     <li data-md>
+      <p>Set <var>modified</var> to the result of
+  <a data-link-type="dfn" href="#sanitizerconfig-remove" id="ref-for-sanitizerconfig-remove④">remove</a> <var>element</var> from
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements①③">replaceWithChildrenElements</a></code>"].</p>
+     <li data-md>
+      <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements②⑥">elements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists③③">exists</a>:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements②⑦">elements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists③④">contains</a> <var>element</var>:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="#comment" id="ref-for-comment⑦">Comment</a>: We have a global allow list and it contains <var>element</var>.</p>
+         <li data-md>
+          <p><a data-link-type="dfn" href="#sanitizerconfig-remove" id="ref-for-sanitizerconfig-remove⑤">Remove</a> <var>element</var> from
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements②⑧">elements</a></code>"].</p>
+         <li data-md>
+          <p>Return true.</p>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#comment" id="ref-for-comment⑧">Comment</a>: We have a global allow list and it does not contain <var>element</var>.</p>
+       <li data-md>
+        <p>Return <var>modified</var>.</p>
+      </ol>
+     <li data-md>
+      <p>Otherwise:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements①④">removeElements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists③⑤">contains</a> <var>element</var>:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="#comment" id="ref-for-comment⑨">Comment</a>: We have a global remove list and it already contains <var>element</var>.</p>
+         <li data-md>
+          <p>Return <var>modified</var>.</p>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#comment" id="ref-for-comment①⓪">Comment</a>: We have a global remove list and it does not contain <var>element</var>.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#sanitizerconfig-add" id="ref-for-sanitizerconfig-add">Add</a> <var>element</var> to <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements①⑤">removeElements</a></code>"].</p>
+       <li data-md>
+        <p>Return true.</p>
+      </ol>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="replace an element with its children" data-algorithm-for="Sanitizer">
+    
+To <dfn class="dfn-paneled" data-dfn-for="Sanitizer" data-dfn-type="dfn" data-noexport id="sanitizer-replace-an-element-with-its-children">replace an element with its children</dfn>
+<code class="idl"><a data-link-type="idl" href="#typedefdef-sanitizerelement" id="ref-for-typedefdef-sanitizerelement⑤">SanitizerElement</a></code> <var>element</var> from a <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig⑨">SanitizerConfig</a></code> <var>configuration</var>:
+
+
+    <ol>
+     <li data-md>
+      <p>Set <var>element</var> to the result of <a data-link-type="dfn" href="#canonicalize-a-sanitizer-element" id="ref-for-canonicalize-a-sanitizer-element②">canonicalize a sanitizer element</a> with <var>element</var>.</p>
+     <li data-md>
+      <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements①④">replaceWithChildrenElements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists③⑥">contains</a> <var>element</var>:</p>
+      <ol>
+       <li data-md>
+        <p>Return false.</p>
+      </ol>
+     <li data-md>
+      <p><a data-link-type="dfn" href="#sanitizerconfig-remove" id="ref-for-sanitizerconfig-remove⑥">Remove</a> <var>element</var> from <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements①⑥">removeElements</a></code>"].</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="#sanitizerconfig-remove" id="ref-for-sanitizerconfig-remove⑦">Remove</a> <var>element</var> from <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements②⑨">elements</a></code>"] list.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="#sanitizerconfig-add" id="ref-for-sanitizerconfig-add①">Add</a> <var>element</var> to <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements①⑤">replaceWithChildrenElements</a></code>"].</p>
+     <li data-md>
+      <p>Return true.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="allow an attribute" data-algorithm-for="Sanitizer">
+    
+To <dfn class="dfn-paneled" data-dfn-for="Sanitizer" data-dfn-type="dfn" data-noexport id="sanitizer-allow-an-attribute">allow an attribute</dfn> <code class="idl"><a data-link-type="idl" href="#typedefdef-sanitizerattribute" id="ref-for-typedefdef-sanitizerattribute⑥">SanitizerAttribute</a></code>
+<var>attribute</var> on a <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig①⓪">SanitizerConfig</a></code> <var>configuration</var>:
+
+
+    <p class="note" role="note"><span class="marker">Note:</span> This method distinguishes two cases, namely whether we have a global allow- or a global
+remove-list. If add <var>attribute</var> to a global allow-list, we may need to do additional work to fix
+up per-element allow- or remove-lists to maintain our validity criteria.</p>
+    <ol>
+     <li data-md>
+      <p>Set <var>attribute</var> to the result of <a data-link-type="dfn" href="#canonicalize-a-sanitizer-attribute" id="ref-for-canonicalize-a-sanitizer-attribute①">canonicalize a sanitizer attribute</a> with <var>attribute</var>.</p>
+     <li data-md>
+      <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes②④">attributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists③⑦">exists</a>:</p>
+      <ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#comment" id="ref-for-comment①①">Comment</a>: If we have a global allow-list, we need to add <var>attribute</var>.</p>
+       <li data-md>
+        <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes①③">dataAttributes</a></code>"] is true and <var>attribute</var> is a
+ <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute" id="ref-for-custom-data-attribute①⓪">custom data attribute</a>, then return false.</p>
+       <li data-md>
+        <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes②⑤">attributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain">contains</a> <var>attribute</var>
+  return false.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#comment" id="ref-for-comment①②">Comment</a>: Fix-up per-element allow and remove lists.</p>
+       <li data-md>
+        <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements③⓪">elements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists③⑧">exists</a>:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate⑥">For each</a> <var>element</var> in <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements③①">elements</a></code>"]:</p>
+          <ol>
+           <li data-md>
+            <p>If <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes②⑥">attributes</a></code>"]
+ <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-with-default" id="ref-for-map-with-default⑦">with default</a> « » <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain①">contains</a> <var>attribute</var>:</p>
+            <ol>
+             <li data-md>
+              <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove①">Remove</a> <var>attribute</var> from
+  <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes②⑦">attributes</a></code>"].</p>
+            </ol>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert⑦">Assert</a>: <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes②②">removeAttributes</a></code>"]
+ <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-with-default" id="ref-for-map-with-default⑧">with default</a> « »
+ does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain②">contain</a> <var>attribute</var>.</p>
+          </ol>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append③">Append</a> <var>attribute</var> to <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes②⑥">attributes</a></code>"]</p>
+       <li data-md>
+        <p>Return true.</p>
+      </ol>
+     <li data-md>
+      <p>Otherwise:</p>
+      <ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#comment" id="ref-for-comment①③">Comment</a>: If we have a global remove-list, we need to remove <var>attribute</var>.</p>
+       <li data-md>
+        <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes①⑨">removeAttributes</a></code>"] does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain③">contain</a>
+  <var>attribute</var>:</p>
+        <ol>
+         <li data-md>
+          <p>Return false.</p>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove②">Remove</a> <var>attribute</var> from <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes②⓪">removeAttributes</a></code>"].</p>
+       <li data-md>
+        <p>Return true.</p>
+      </ol>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="remove an attribute" data-algorithm-for="Sanitizer">
+    
+To <dfn class="dfn-paneled" data-dfn-for="Sanitizer" data-dfn-type="dfn" data-noexport id="sanitizer-remove-an-attribute">remove an attribute</dfn> SanitizerAttribute<var>attribute</var>
+from a <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig①①">SanitizerConfig</a></code> <var>configuration</var>:
+
+
+    <p class="note" role="note"><span class="marker">Note:</span> This method distinguishes two cases, namely whether we have a global allow- or a global
+remove-list. If we add <var>attribute</var> to the global remove-list, we may need to do additional work
+to fix up per-element allow- or remove-lists to maintain our validity criteria. If we remove
+<var>attribute</var> from a global allow-list, we may also have to remove it from local remove-lists.</p>
+    <ol>
+     <li data-md>
+      <p>Set <var>attribute</var> to the result of <a data-link-type="dfn" href="#canonicalize-a-sanitizer-attribute" id="ref-for-canonicalize-a-sanitizer-attribute②">canonicalize a sanitizer attribute</a> with <var>attribute</var>.</p>
+     <li data-md>
+      <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes②⑦">attributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists③⑨">exists</a>:</p>
+      <ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#comment" id="ref-for-comment①④">Comment</a>: If we have a global allow-list, we need to add <var>attribute</var>.</p>
+       <li data-md>
+        <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes②⑧">attributes</a></code>"] does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain④">contain</a> <var>attribute</var>:</p>
+        <ol>
+         <li data-md>
+          <p>Return false.</p>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#comment" id="ref-for-comment①⑤">Comment</a>: Fix-up per-element allow and remove lists.</p>
+       <li data-md>
+        <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements③②">elements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists④⓪">exists</a>:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate⑦">For each</a> <var>element</var> in <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements③③">elements</a></code>"]:</p>
+          <ol>
+           <li data-md>
+            <p>If <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes②③">removeAttributes</a></code>"]
+ <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-with-default" id="ref-for-map-with-default⑨">with default</a> « » <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain⑤">contains</a> <var>attribute</var>:</p>
+            <ol>
+             <li data-md>
+              <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove③">Remove</a> <var>attribute</var> from
+  <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes②④">removeAttributes</a></code>"].</p>
+            </ol>
+          </ol>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove④">Remove</a> <var>attribute</var> from <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes②⑨">attributes</a></code>"].</p>
+       <li data-md>
+        <p>Return true.</p>
+      </ol>
+     <li data-md>
+      <p>Otherwise:</p>
+      <ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#comment" id="ref-for-comment①⑥">Comment</a>: If we have a global remove-list, we need to add <var>attribute</var>.</p>
+       <li data-md>
+        <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes②①">removeAttributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain⑥">contains</a> <var>attribute</var>
+  return false.</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="#comment" id="ref-for-comment①⑦">Comment</a>: Fix-up per-element allow and remove lists.</p>
+       <li data-md>
+        <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements③④">elements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists④①">exists</a>:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate⑧">For each</a> <var>element</var> in <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements③⑤">elements</a></code>"]:</p>
+          <ol>
+           <li data-md>
+            <p>If <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes②⑧">attributes</a></code>"]
+ <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-with-default" id="ref-for-map-with-default①⓪">with default</a> « » <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain⑦">contains</a> <var>attribute</var>:</p>
+            <ol>
+             <li data-md>
+              <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove⑤">Remove</a> <var>attribute</var> from
+  <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes②⑨">attributes</a></code>"].</p>
+            </ol>
+           <li data-md>
+            <p>If <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes②⑤">removeAttributes</a></code>"]
+ <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-with-default" id="ref-for-map-with-default①①">with default</a> « » <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain⑧">contains</a> <var>attribute</var>:</p>
+            <ol>
+             <li data-md>
+              <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove⑥">Remove</a> <var>attribute</var> from
+  <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes②⑥">removeAttributes</a></code>"].</p>
+            </ol>
+          </ol>
+        </ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append④">Append</a> <var>attribute</var> to <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes②②">removeAttributes</a></code>"]</p>
+       <li data-md>
+        <p>Return true.</p>
+      </ol>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="set comments" data-algorithm-for="Sanitizer">
+    
+To <dfn class="dfn-paneled" data-dfn-for="Sanitizer" data-dfn-type="dfn" data-noexport id="sanitizer-set-comments">set comments</dfn> with a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#boolean" id="ref-for-boolean④">boolean</a> <var>allow</var> on a
+<code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig①②">SanitizerConfig</a></code> <var>configuration</var>:
+
+
+    <ol>
+     <li data-md>
+      <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-comments" id="ref-for-dom-sanitizerconfig-comments①">comments</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists④②">exists</a> and
+ <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-comments" id="ref-for-dom-sanitizerconfig-comments②">comments</a></code>"] equals <var>allow</var>, then return false;</p>
+     <li data-md>
+      <p>Set <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-comments" id="ref-for-dom-sanitizerconfig-comments③">comments</a></code>"] to <var>allow</var>.</p>
+     <li data-md>
+      <p>Return true.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="set data attributes" data-algorithm-for="Sanitizer">
+    
+To <dfn class="dfn-paneled" data-dfn-for="Sanitizer" data-dfn-type="dfn" data-noexport id="sanitizer-set-data-attributes">set data attributes</dfn> with a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#boolean" id="ref-for-boolean⑤">boolean</a> <var>allow</var>
+on a <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig①③">SanitizerConfig</a></code> <var>configuration</var>:
+
+
+    <ol>
+     <li data-md>
+      <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes③⓪">attributes</a></code>"] does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists④③">exist</a>, then return false.</p>
+     <li data-md>
+      <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes①④">dataAttributes</a></code>"] equals <var>allow</var>, then return false.</p>
+     <li data-md>
+      <p>If <var>allow</var> is true:</p>
+      <ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove⑦">Remove</a> any items <var>attr</var> from <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes③①">attributes</a></code>"]
+   where <var>attr</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute" id="ref-for-custom-data-attribute①①">custom data attribute</a>.</p>
+       <li data-md>
+        <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements③⑥">elements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists④④">exists</a>:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate⑨">For each</a> <var>element</var> in <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements③⑦">elements</a></code>"]:</p>
+          <ol>
+           <li data-md>
+            <p>If <var>element</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes③⓪">attributes</a></code>] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists④⑤">exists</a>:</p>
+            <ol>
+             <li data-md>
+              <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove⑧">Remove</a> any items <var>attr</var> from
+   <var>element</var>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes③①">attributes</a></code>]
+   where <var>attr</var> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute" id="ref-for-custom-data-attribute①②">custom data attribute</a>.</p>
+            </ol>
+          </ol>
+        </ol>
+      </ol>
+     <li data-md>
+      <p>Set <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes①⑤">dataAttributes</a></code>"] to <var>allow</var>.</p>
+     <li data-md>
+      <p>Return true.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="remove unsafe" data-algorithm-for="SanitizerConfig">
+    
+To <dfn class="dfn-paneled" data-dfn-for="SanitizerConfig" data-dfn-type="dfn" data-noexport id="sanitizerconfig-remove-unsafe">remove unsafe</dfn> from a <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig①④">SanitizerConfig</a></code> <var>configuration</var>,
+do this:
+
+
+    <p class="note" role="note"><span class="marker">Note:</span> While this algorithm is called <a data-link-type="dfn" href="#sanitizerconfig-remove-unsafe" id="ref-for-sanitizerconfig-remove-unsafe②">remove unsafe</a>, we use
+    <a href="#security-considerations">the term "unsafe" strictly in the sense
+    of this spec</a>, to denote content that will
+    execute JavaScript when inserted into the document. In other words, this
+    method will remove oportunities for XSS.</p>
+    <ol>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert⑧">Assert</a>: The <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-getting-the-keys" id="ref-for-map-getting-the-keys">key set</a> of <a data-link-type="dfn" href="#built-in-safe-baseline-configuration" id="ref-for-built-in-safe-baseline-configuration">built-in safe baseline configuration</a>
+ <a data-link-type="dfn" href="#set-equal" id="ref-for-set-equal">equals</a>
+ «[ "<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements①⑦">removeElements</a></code>", "<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes②③">removeAttributes</a></code>" ] ».</p>
+     <li data-md>
+      <p>Let <var>result</var> be false.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①⓪">For each</a> <var>element</var> in
+ <a data-link-type="dfn" href="#built-in-safe-baseline-configuration" id="ref-for-built-in-safe-baseline-configuration①">built-in safe baseline configuration</a>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements①⑧">removeElements</a></code>]:</p>
+      <ol>
+       <li data-md>
+        <p>Call <a data-link-type="dfn" href="#sanitizer-remove-an-element" id="ref-for-sanitizer-remove-an-element①">remove an element</a> <var>element</var> from <var>configuration</var>.</p>
+       <li data-md>
+        <p>If the call returned true, set <var>result</var> to true.</p>
+      </ol>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①①">For each</a> <var>attribute</var> in
+ <a data-link-type="dfn" href="#built-in-safe-baseline-configuration" id="ref-for-built-in-safe-baseline-configuration②">built-in safe baseline configuration</a>[<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes②④">removeAttributes</a></code>]:</p>
+      <ol>
+       <li data-md>
+        <p>Call <a data-link-type="dfn" href="#sanitizer-remove-an-attribute" id="ref-for-sanitizer-remove-an-attribute①">remove an attribute</a> <var>attribute</var> from <var>configuration</var>.</p>
+       <li data-md>
+        <p>If the call returned true, set <var>result</var> to true.</p>
+      </ol>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①②">For each</a> <var>attribute</var> listed in <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes" id="ref-for-event-handler-content-attributes">event handler content attributes</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Call <a data-link-type="dfn" href="#sanitizer-remove-an-attribute" id="ref-for-sanitizer-remove-an-attribute②">remove an attribute</a> <var>attribute</var> from <var>configuration</var>.</p>
+       <li data-md>
+        <p>If the call returned true, set <var>result</var> to true.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="3.3" id="configuration-set"><span class="secno">3.3. </span><span class="content">Set the Configuration</span><a class="self-link" href="#configuration-set"></a></h3>
+   <div class="algorithm" data-algorithm="set a configuration" data-algorithm-for="Sanitizer">
+    
+To <dfn class="dfn-paneled" data-dfn-for="Sanitizer" data-dfn-type="dfn" data-noexport id="sanitizer-set-a-configuration">set a configuration</dfn>, given a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-dictionary" id="ref-for-dfn-dictionary⑥">dictionary</a> <var>configuration</var>,
+a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#boolean" id="ref-for-boolean⑥">boolean</a> <var>allowCommentsAndDataAttributes</var>, and a <code class="idl"><a data-link-type="idl" href="#sanitizer" id="ref-for-sanitizer①③">Sanitizer</a></code> <var>sanitizer</var>:
+
+
+    <ol>
+     <li data-md>
+      <p><a data-link-type="dfn" href="#sanitizer-canonicalize-the-configuration" id="ref-for-sanitizer-canonicalize-the-configuration">Canonicalize</a> <var>configuration</var> with
+  <var>allowCommentsAndDataAttributes</var>.</p>
+     <li data-md>
+      <p>If <var>configuration</var> is not <a data-link-type="dfn" href="#sanitizerconfig-valid" id="ref-for-sanitizerconfig-valid①">valid</a>, then return false.</p>
+     <li data-md>
+      <p>Set <var>sanitizer</var>’s <a data-link-type="dfn" href="#sanitizer-configuration" id="ref-for-sanitizer-configuration①①">configuration</a> to <var>configuration</var>.</p>
+     <li data-md>
+      <p>Return true.</p>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="3.4" id="configuration-canonicalize"><span class="secno">3.4. </span><span class="content">Canonicalize the Configuration</span><a class="self-link" href="#configuration-canonicalize"></a></h3>
+   <p>The <code class="idl"><a data-link-type="idl" href="#sanitizer" id="ref-for-sanitizer①④">Sanitizer</a></code> stores the <a data-link-type="dfn" href="#sanitizer-configuration" id="ref-for-sanitizer-configuration①②">configuration</a> in a canonical form, as this makes
+a number of processing steps easier.</p>
+   <div class="example" id="example-6e3e9dcc"><a class="self-link" href="#example-6e3e9dcc"></a>An <code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements③⑧">elements</a></code> list <code>{elements: ["div"]}</code> gets stored as
+<code>{elements: [{name: "div", namespace: "http://www.w3.org/1999/xhtml"}]</code>).
+</div>
+   <div class="algorithm" data-algorithm="canonicalize the configuration" data-algorithm-for="Sanitizer">
+    
+To <dfn class="dfn-paneled" data-dfn-for="Sanitizer" data-dfn-type="dfn" data-noexport id="sanitizer-canonicalize-the-configuration">canonicalize the configuration</dfn> <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig①⑤">SanitizerConfig</a></code> <var>configuration</var>
+with a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#boolean" id="ref-for-boolean⑦">boolean</a> <var>allowCommentsAndDataAttributes</var>:
+
+
+    <p class="note" role="note"><span class="marker">Note:</span> We assume that <var>configuration</var> is the result of <a data-link-type="biblio" href="#biblio-webidl" title="Web IDL Standard">[WebIDL]</a> converting a JavaScript
+value to a <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerconfig" id="ref-for-dictdef-sanitizerconfig①⑥">SanitizerConfig</a></code>.</p>
+    <ol>
+     <li data-md>
+      <p>If neither <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements③⑨">elements</a></code>"] nor
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements①⑨">removeElements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists④⑥">exist</a>, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set②">set</a>
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements②⓪">removeElements</a></code>"] to « ».</p>
+     <li data-md>
+      <p>If neither <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes③②">attributes</a></code>"] nor
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes②⑤">removeAttributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists④⑦">exist</a>, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set③">set</a>
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes②⑥">removeAttributes</a></code>"] to « ».</p>
+     <li data-md>
+      <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements④⓪">elements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists④⑧">exists</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>elements</var> be « ».</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①③">For each</a> <var>element</var> of <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements④①">elements</a></code>"] do:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append⑤">Append</a> the result of <a data-link-type="dfn" href="#canonicalize-a-sanitizer-element-with-attributes" id="ref-for-canonicalize-a-sanitizer-element-with-attributes①">canonicalize a sanitizer element with attributes</a>
+  <var>element</var> to <var>elements</var>.</p>
+        </ol>
+       <li data-md>
+        <p>Set <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-elements" id="ref-for-dom-sanitizerconfig-elements④②">elements</a></code>"] to <var>elements</var>.</p>
+      </ol>
+     <li data-md>
+      <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements②①">removeElements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists④⑨">exists</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>elements</var> be « ».</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①④">For each</a> <var>element</var> of <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements②②">removeElements</a></code>"] do:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append⑥">Append</a> the result of <a data-link-type="dfn" href="#canonicalize-a-sanitizer-element" id="ref-for-canonicalize-a-sanitizer-element③">canonicalize a sanitizer element</a> <var>element</var> to
+  <var>elements</var>.</p>
+        </ol>
+       <li data-md>
+        <p>Set <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeelements" id="ref-for-dom-sanitizerconfig-removeelements②③">removeElements</a></code>"] to <var>elements</var>.</p>
+      </ol>
+     <li data-md>
+      <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements①⑥">replaceWithChildrenElements</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑤⓪">exists</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>elements</var> be « ».</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①⑤">For each</a> <var>element</var> of <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements①⑦">replaceWithChildrenElements</a></code>"] do:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append⑦">Append</a> the result of <a data-link-type="dfn" href="#canonicalize-a-sanitizer-element" id="ref-for-canonicalize-a-sanitizer-element④">canonicalize a sanitizer element</a> <var>element</var> to <var>elements</var>.</p>
+        </ol>
+       <li data-md>
+        <p>Set <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-replacewithchildrenelements" id="ref-for-dom-sanitizerconfig-replacewithchildrenelements①⑧">replaceWithChildrenElements</a></code>"] to <var>elements</var>.</p>
+      </ol>
+     <li data-md>
+      <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes③③">attributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑤①">exists</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>attributes</var> be « ».</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①⑥">For each</a> <var>attribute</var> of <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes③④">attributes</a></code>"] do:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append⑧">Append</a> the result of <a data-link-type="dfn" href="#canonicalize-a-sanitizer-attribute" id="ref-for-canonicalize-a-sanitizer-attribute③">canonicalize a sanitizer attribute</a> <var>attribute</var> to
+  <var>attributes</var>.</p>
+        </ol>
+       <li data-md>
+        <p>Set <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes③⑤">attributes</a></code>"] to <var>attributes</var>.</p>
+      </ol>
+     <li data-md>
+      <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes②⑦">removeAttributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑤②">exists</a>:</p>
+      <ol>
+       <li data-md>
+        <p>Let <var>attributes</var> be « ».</p>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①⑦">For each</a> <var>attribute</var> of <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes②⑧">removeAttributes</a></code>"] do:</p>
+        <ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append⑨">Append</a> the result of <a data-link-type="dfn" href="#canonicalize-a-sanitizer-attribute" id="ref-for-canonicalize-a-sanitizer-attribute④">canonicalize a sanitizer attribute</a> <var>attribute</var> to
+  <var>attributes</var>.</p>
+        </ol>
+       <li data-md>
+        <p>Set <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-removeattributes" id="ref-for-dom-sanitizerconfig-removeattributes②⑨">removeAttributes</a></code>"] to <var>attributes</var>.</p>
+      </ol>
+     <li data-md>
+      <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-comments" id="ref-for-dom-sanitizerconfig-comments④">comments</a></code>"] does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑤③">exist</a>, then <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set④">set</a>
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-comments" id="ref-for-dom-sanitizerconfig-comments⑤">comments</a></code>"] to <var>allowCommentsAndDataAttributes</var>.</p>
+     <li data-md>
+      <p>If <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-attributes" id="ref-for-dom-sanitizerconfig-attributes③⑥">attributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑤④">exists</a> and
+  <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes①⑥">dataAttributes</a></code>"] does not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑤⑤">exist</a>, then
+  <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set⑤">set</a> <var>configuration</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerconfig-dataattributes" id="ref-for-dom-sanitizerconfig-dataattributes①⑦">dataAttributes</a></code>"] to
+  <var>allowCommentsAndDataAttributes</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="canonicalize a sanitizer element with attributes">
+    
+To <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="canonicalize-a-sanitizer-element-with-attributes">canonicalize a sanitizer element with attributes</dfn> a <code class="idl"><a data-link-type="idl" href="#typedefdef-sanitizerelementwithattributes" id="ref-for-typedefdef-sanitizerelementwithattributes③">SanitizerElementWithAttributes</a></code> <var>element</var>:
+
+
+    <ol>
+     <li data-md>
+      <p>Let <var>result</var> be the result of <a data-link-type="dfn" href="#canonicalize-a-sanitizer-element" id="ref-for-canonicalize-a-sanitizer-element⑤">canonicalize a sanitizer element</a> with <var>element</var>.</p>
+     <li data-md>
+      <p>If <var>element</var> is a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-dictionary" id="ref-for-dfn-dictionary⑦">dictionary</a>:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes③②">attributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑤⑥">exists</a>:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>attributes</var> be « ».</p>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①⑧">For each</a> <var>attribute</var> of <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes③③">attributes</a></code>"]:</p>
+          <ol>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append①⓪">Append</a> the result of <a data-link-type="dfn" href="#canonicalize-a-sanitizer-attribute" id="ref-for-canonicalize-a-sanitizer-attribute⑤">canonicalize a sanitizer attribute</a> with <var>attribute</var> to <var>attributes</var>.</p>
+          </ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set⑥">Set</a> <var>result</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes③④">attributes</a></code>"] to <var>attributes</var>.</p>
+        </ol>
+       <li data-md>
+        <p>If <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes②⑦">removeAttributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑤⑦">exists</a>:</p>
+        <ol>
+         <li data-md>
+          <p>Let <var>attributes</var> be « ».</p>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate①⑨">For each</a> <var>attribute</var> of <var>element</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes②⑧">removeAttributes</a></code>"]:</p>
+          <ol>
+           <li data-md>
+            <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append①①">Append</a> the result of <a data-link-type="dfn" href="#canonicalize-a-sanitizer-attribute" id="ref-for-canonicalize-a-sanitizer-attribute⑥">canonicalize a sanitizer attribute</a> with <var>attribute</var> to <var>attributes</var>.</p>
+          </ol>
+         <li data-md>
+          <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set⑦">Set</a> <var>result</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes②⑨">removeAttributes</a></code>"] to <var>attributes</var>.</p>
+        </ol>
+      </ol>
+     <li data-md>
+      <p>If neither <var>result</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-attributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-attributes③⑤">attributes</a></code>"] nor
+ <var>result</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes③⓪">removeAttributes</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑤⑧">exist</a>:</p>
+      <ol>
+       <li data-md>
+        <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-set" id="ref-for-map-set⑧">Set</a> <var>result</var>["<code class="idl"><a data-link-type="idl" href="#dom-sanitizerelementnamespacewithattributes-removeattributes" id="ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes③①">removeAttributes</a></code>"] to « ».</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="canonicalize a sanitizer element">
+In order to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="canonicalize-a-sanitizer-element">canonicalize a sanitizer element</dfn> a
+<code class="idl"><a data-link-type="idl" href="#typedefdef-sanitizerelement" id="ref-for-typedefdef-sanitizerelement⑥">SanitizerElement</a></code> <var>element</var>,
+return the result of <a data-link-type="dfn" href="#canonicalize-a-sanitizer-name" id="ref-for-canonicalize-a-sanitizer-name">canonicalize a sanitizer name</a> with <var>element</var> and the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace" id="ref-for-html-namespace②">HTML namespace</a> as the default namespace.
+</div>
+   <div class="algorithm" data-algorithm="canonicalize a sanitizer attribute">
+In order to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="canonicalize-a-sanitizer-attribute">canonicalize a sanitizer attribute</dfn> a
+<code class="idl"><a data-link-type="idl" href="#typedefdef-sanitizerattribute" id="ref-for-typedefdef-sanitizerattribute⑦">SanitizerAttribute</a></code> <var>attribute</var>,
+return the result of <a data-link-type="dfn" href="#canonicalize-a-sanitizer-name" id="ref-for-canonicalize-a-sanitizer-name①">canonicalize a sanitizer name</a> with <var>attribute</var> and null as the default namespace.
+</div>
+   <div class="algorithm" data-algorithm="canonicalize a sanitizer name">
+    
+In order to <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="canonicalize-a-sanitizer-name">canonicalize a sanitizer name</dfn> <var>name</var>, with a default
+namespace <var>defaultNamespace</var>, run the following steps:
+
+
+    <ol>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert⑨">Assert</a>: <var>name</var> is either a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString①④">DOMString</a></code> or a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-dictionary" id="ref-for-dfn-dictionary⑧">dictionary</a>.</p>
+     <li data-md>
+      <p>If <var>name</var> is a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString①⑤">DOMString</a></code>, then return «[ "<code>name</code>" → <var>name</var>, "<code>namespace</code>" → <var>defaultNamespace</var>]».</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#assert" id="ref-for-assert①⓪">Assert</a>: <var>name</var> is a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#dfn-dictionary" id="ref-for-dfn-dictionary⑨">dictionary</a> and both <var>name</var>["name"] and <var>name</var>["namespace"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists⑤⑨">exist</a>.</p>
+     <li data-md>
+      <p>If <var>name</var>["namespace"] is the empty string, then set it to null.</p>
+     <li data-md>
+      <p>Return «[ <br>
+"<code>name</code>" → <var>name</var>["name"], <br>
+"<code>namespace</code>" → <var>name</var>["namespace"] <br>
+]».</p>
+    </ol>
+   </div>
+   <h3 class="heading settled" data-level="3.5" id="alg-support"><span class="secno">3.5. </span><span class="content">Supporting Algorithms</span><a class="self-link" href="#alg-support"></a></h3>
+   <p>For the <a data-link-type="dfn" href="#canonicalize-a-sanitizer-name" id="ref-for-canonicalize-a-sanitizer-name②">canonicalized</a>
+<code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerelementnamespace" id="ref-for-dictdef-sanitizerelementnamespace④">element</a></code> and <code class="idl"><a data-link-type="idl" href="#dictdef-sanitizerattributenamespace" id="ref-for-dictdef-sanitizerattributenamespace③">attribute name</a></code> lists
+used in this spec, list membership is based on matching both "<code>name</code>" and "<code>namespace</code>"
+entries:</p>
+   <div class="algorithm" data-algorithm="contains" data-algorithm-for="SanitizerConfig">
+A Sanitizer name <var>list</var> <dfn class="dfn-paneled" data-dfn-for="SanitizerConfig" data-dfn-type="dfn" data-noexport id="sanitizerconfig-contains">contains</dfn> an <var>item</var>
+if there exists an <var>entry</var> of <var>list</var> that is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map">ordered map</a>, and where
+<var>item</var>["name"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is" id="ref-for-string-is⑨">equals</a> <var>entry</var>["name"] and
+<var>item</var>["namespace"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is" id="ref-for-string-is①⓪">equals</a> <var>entry</var>["namespace"].
+</div>
+   <div class="algorithm" data-algorithm="remove" data-algorithm-for="SanitizerConfig">
+To <dfn class="dfn-paneled" data-dfn-for="SanitizerConfig" data-dfn-type="dfn" data-noexport id="sanitizerconfig-remove">remove</dfn> an <var>item</var> from a <var>list</var> that is an
+<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map①">ordered map</a>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-remove" id="ref-for-list-remove⑨">remove</a> all <var>entry</var> from <var>list</var>
+where <var>item</var>["name"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is" id="ref-for-string-is①①">equals</a> <var>entry</var>["name"] and
+<var>item</var>["namespace"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is" id="ref-for-string-is①②">equals</a> <var>entry</var>["namespace"].
+</div>
+   <div class="algorithm" data-algorithm="add" data-algorithm-for="SanitizerConfig">
+    
+To <dfn class="dfn-paneled" data-dfn-for="SanitizerConfig" data-dfn-type="dfn" data-noexport id="sanitizerconfig-add">add</dfn> a <var>name</var> to a <var>list</var>, where <var>name</var> is
+<a data-link-type="dfn" href="#canonicalize-a-sanitizer-name" id="ref-for-canonicalize-a-sanitizer-name③">canonicalized</a> and <var>list</var> is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map②">ordered map</a>:
+
+
+    <ol>
+     <li data-md>
+      <p>If <var>list</var> <a data-link-type="dfn" href="#sanitizerconfig-contains" id="ref-for-sanitizerconfig-contains①⓪">contains</a> <var>name</var>, then return.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-append" id="ref-for-list-append①②">Append</a> <var>name</var> to <var>list</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="less than item" data-algorithm-for="SanitizerConfig">
+    
+An item <var>itemA</var> is <dfn class="dfn-paneled" data-dfn-for="SanitizerConfig" data-dfn-type="dfn" data-noexport id="sanitizerconfig-less-than-item">less than item</dfn> <var>itemB</var> if:
+
+
+    <ol>
+     <li data-md>
+      <p>If <var>itemA</var>["namespace"] is null:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>itemB</var>["namespace"] is not null, return true.</p>
+      </ol>
+     <li data-md>
+      <p>Otherwise:</p>
+      <ol>
+       <li data-md>
+        <p>If <var>itemB</var>["namespace"] is null, return false.</p>
+       <li data-md>
+        <p>If <var>itemA</var>["namespace"] is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#code-unit-less-than" id="ref-for-code-unit-less-than">code unit less than</a> <var>itemB</var>["namespace"], return true.</p>
+       <li data-md>
+        <p>If <var>itemA</var>["namespace"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#string-is" id="ref-for-string-is①③">is</a> not <var>itemB</var>["namespace"], return false.</p>
+      </ol>
+     <li data-md>
+      <p>Return <var>itemA</var>["name"] is <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#code-unit-less-than" id="ref-for-code-unit-less-than①">code unit less than</a><var>itemB</var>["name"].</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="equal" data-algorithm-for="set">
+Equality for <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set">ordered sets</a> is equality of its members, but without
+regard to order:
+<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set①">Ordered sets</a> <var>A</var> and <var>B</var> are <dfn class="dfn-paneled" data-dfn-for="set" data-dfn-type="dfn" data-noexport id="set-equal">equal</dfn> if both <var>A</var> is a
+<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-superset" id="ref-for-set-superset">superset</a> of <var>B</var> and <var>B</var> is a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-superset" id="ref-for-set-superset①">superset</a> of <var>A</var>.
+</div>
+   <div class="algorithm" data-algorithm="equal" data-algorithm-for="map">
+An  <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map③">ordered map</a> is a sequence of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key②">key</a> and <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value">value</a> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#tuple" id="ref-for-tuple">tuples</a>.
+Equality of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map④">ordered maps</a> is equality of this sequence of tuples, when treated as an ordered
+set.
+<a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-map" id="ref-for-ordered-map⑤">Ordered maps</a> <var>A</var> and <var>B</var> are <dfn class="dfn-paneled" data-dfn-for="map" data-dfn-type="dfn" data-noexport id="map-equal">equal</dfn> if the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set②">ordered set</a> consisting
+of <var>A</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry">entries</a> and the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set③">ordered set</a> of <var>B</var>’s <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry①">entries</a> are <a data-link-type="dfn" href="#set-equal" id="ref-for-set-equal①">equal</a>.
+</div>
+   <div class="algorithm" data-algorithm="has duplicates" data-algorithm-for="SanitizerConfig">
+A <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list">list</a> <var>list</var> <dfn class="dfn-paneled" data-dfn-for="SanitizerConfig" data-dfn-type="dfn" data-noexport id="sanitizerconfig-has-duplicates">has duplicates</dfn>,
+if <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate②⓪">for any</a> <var>item</var> of <var>list</var>,
+there is more than one <var>entry</var> in <var>list</var> where
+<var>item</var>["name"] is <var>entry</var>["name"] and
+<var>item</var>["namespace"] is <var>entry</var>["namespace"].
+</div>
+   <div class="algorithm" data-algorithm="remove duplicates" data-algorithm-for="SanitizerConfig">
+    
+To <dfn class="dfn-paneled" data-dfn-for="SanitizerConfig" data-dfn-type="dfn" data-noexport id="sanitizerconfig-remove-duplicates">remove duplicates</dfn> from a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list①">list</a> <var>list</var>,
+
+
+    <ol>
+     <li data-md>
+      <p>Let <var>result</var> be « ».</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate②①">For each</a> <var>entry</var> of <var>list</var>, <a data-link-type="dfn" href="#sanitizerconfig-add" id="ref-for-sanitizerconfig-add②">add</a> <var>entry</var> to <var>result</var>.</p>
+     <li data-md>
+      <p>Return <var>result</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="intersection" data-algorithm-for="SanitizerConfig">
+    
+The <dfn class="dfn-paneled" data-dfn-for="SanitizerConfig" data-dfn-type="dfn" data-noexport id="sanitizerconfig-intersection">intersection</dfn> of two <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list" id="ref-for-list②">lists</a> <var>A</var> and <var>B</var>
+containing <code class="idl"><a data-link-type="idl" href="#typedefdef-sanitizerelement" id="ref-for-typedefdef-sanitizerelement⑦">SanitizerElement</a></code> is the same as <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-intersection" id="ref-for-set-intersection④">set intersection</a>,
+but with the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ordered-set" id="ref-for-ordered-set④">set</a> entries previously <a data-link-type="dfn" href="#canonicalize-a-sanitizer-name" id="ref-for-canonicalize-a-sanitizer-name④">canonicalized</a>:
+
+
+    <ol>
+     <li data-md>
+      <p>Let <var>set A</var> be « [] »</p>
+     <li data-md>
+      <p>Let <var>set B</var> be « [] »</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate②②">For each</a> <var>entry</var> of <var>A</var>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append">append</a> the result of
+  <a data-link-type="dfn" href="#canonicalize-a-sanitizer-name" id="ref-for-canonicalize-a-sanitizer-name⑤">canonicalize a sanitizer name</a> <var>entry</var> to <var>set A</var>.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-iterate" id="ref-for-list-iterate②③">For each</a> <var>entry</var> of <var>B</var>, <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-append" id="ref-for-set-append①">append</a> the result of
+  <a data-link-type="dfn" href="#canonicalize-a-sanitizer-name" id="ref-for-canonicalize-a-sanitizer-name⑥">canonicalize a sanitizer name</a> <var>entry</var> to <var>set B</var>.</p>
+     <li data-md>
+      <p>Retrun the <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#set-intersection" id="ref-for-set-intersection⑤">intersection</a> of <var>set A</var> and <var>set B</var>.</p>
+    </ol>
+   </div>
+   <div class="algorithm" data-algorithm="not" data-algorithm-for="boolean">
+To determine <dfn class="dfn-paneled" data-dfn-for="boolean" data-dfn-type="dfn" data-noexport id="boolean-not">not</dfn> of a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#boolean" id="ref-for-boolean⑧">boolean</a> <var>bool</var>,
+return false if <var>bool</var> is true, and return true otherwise.
+</div>
+   <div>
+A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="comment">Comment</dfn> contains an explanatory text that applies to a particular
+point within an algorithm.
+</div>
+   <h3 class="heading settled" data-level="3.6" id="sanitization-defaults"><span class="secno">3.6. </span><span class="content">Builtins</span><a class="self-link" href="#sanitization-defaults"></a></h3>
+   <p>There are four builtins:</p>
+   <ul>
+    <li data-md>
+     <p>The <a data-link-type="dfn" href="#built-in-safe-default-configuration" id="ref-for-built-in-safe-default-configuration③">built-in safe default configuration</a>,</p>
+    <li data-md>
+     <p>the <a data-link-type="dfn" href="#built-in-safe-baseline-configuration" id="ref-for-built-in-safe-baseline-configuration③">built-in safe baseline configuration</a>, and</p>
+    <li data-md>
+     <p>the <a data-link-type="dfn" href="#built-in-navigating-url-attributes-list" id="ref-for-built-in-navigating-url-attributes-list②">built-in navigating URL attributes list</a>, and</p>
+    <li data-md>
+     <p>the <a data-link-type="dfn" href="#built-in-animating-url-attributes-list" id="ref-for-built-in-animating-url-attributes-list②">built-in animating URL attributes list</a>.</p>
+   </ul>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="built-in-safe-default-configuration">built-in safe default configuration</dfn> is as follows:</p>
+<pre class="include-code highlight"><c- p>{</c->
+  <c- f>"elements"</c-><c- p>:</c-> <c- p>[</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"math"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"merror"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mfrac"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mi"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mmultiscripts"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mn"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mo"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"fence"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"form"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"largeop"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"lspace"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"maxsize"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"minsize"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"movablelimits"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"rspace"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"separator"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"stretchy"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"symmetric"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mover"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"accent"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mpadded"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"depth"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"height"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"lspace"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"voffset"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"width"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mphantom"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mprescripts"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mroot"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mrow"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"ms"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mspace"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"depth"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"height"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"width"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"msqrt"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mstyle"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"msub"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"msubsup"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"msup"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mtable"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mtd"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"columnspan"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"rowspan"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mtext"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mtr"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"munder"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"accentunder"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"munderover"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"accent"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"accentunder"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"semantics"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1998/Math/MathML"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"a"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"href"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"hreflang"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"rel"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"type"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"abbr"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"address"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"article"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"aside"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"b"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"bdi"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"bdo"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"blockquote"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"cite"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"body"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"br"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"caption"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"cite"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"code"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"col"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"span"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"colgroup"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"span"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"data"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"value"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"dd"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"del"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"cite"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"datetime"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"dfn"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"div"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"dl"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"dt"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"em"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"figcaption"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"figure"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"footer"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"h1"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"h2"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"h3"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"h4"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"h5"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"h6"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"head"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"header"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"hgroup"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"hr"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"html"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"i"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"ins"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"cite"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"datetime"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"kbd"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"li"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"value"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"main"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mark"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"menu"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"nav"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"ol"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"reversed"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"start"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"type"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"p"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"pre"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"q"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"rp"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"rt"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"ruby"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"s"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"samp"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"search"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"section"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"small"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"span"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"strong"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"sub"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"sup"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"table"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"tbody"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"td"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"colspan"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"headers"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"rowspan"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"tfoot"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"th"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"abbr"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"colspan"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"headers"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"rowspan"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"scope"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"thead"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"time"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"datetime"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"title"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"tr"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"u"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"ul"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"var"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"wbr"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"circle"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"cx"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"cy"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"pathLength"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"r"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"defs"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"desc"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"ellipse"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"cx"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"cy"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"pathLength"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"rx"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"ry"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"foreignObject"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"height"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"width"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"x"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"y"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"g"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"line"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"pathLength"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"x1"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"x2"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"y1"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"y2"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"marker"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"markerHeight"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"markerUnits"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"markerWidth"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"orient"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"preserveAspectRatio"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"refX"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"refY"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"viewBox"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"metadata"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"path"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"d"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"pathLength"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"polygon"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"pathLength"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"points"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"polyline"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"pathLength"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"points"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"rect"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"height"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"pathLength"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"rx"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"ry"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"width"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"x"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"y"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"svg"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"height"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"preserveAspectRatio"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"viewBox"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"width"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"x"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"y"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"text"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"dx"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"dy"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"lengthAdjust"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"rotate"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"textLength"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"x"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"y"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"textPath"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"lengthAdjust"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"method"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"path"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"side"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"spacing"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"startOffset"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"textLength"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"title"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[]</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"tspan"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"dx"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"dy"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"lengthAdjust"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"rotate"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"textLength"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"x"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>},</c->
+        <c- p>{</c->
+          <c- f>"name"</c-><c- p>:</c-> <c- u>"y"</c-><c- p>,</c->
+          <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+        <c- p>}</c->
+      <c- p>]</c->
+    <c- p>}</c->
+  <c- p>],</c->
+  <c- f>"attributes"</c-><c- p>:</c-> <c- p>[</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"alignment-baseline"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"baseline-shift"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"clip-path"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"clip-rule"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"color"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"color-interpolation"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"cursor"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"dir"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"direction"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"display"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"displaystyle"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"dominant-baseline"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"fill"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"fill-opacity"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"fill-rule"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"font-family"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"font-size"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"font-size-adjust"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"font-stretch"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"font-style"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"font-variant"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"font-weight"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"lang"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"letter-spacing"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"marker-end"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"marker-mid"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"marker-start"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mathbackground"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mathcolor"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"mathsize"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"opacity"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"paint-order"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"pointer-events"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"scriptlevel"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"shape-rendering"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"stop-color"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"stop-opacity"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"stroke"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"stroke-dasharray"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"stroke-dashoffset"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"stroke-linecap"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"stroke-linejoin"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"stroke-miterlimit"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"stroke-opacity"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"stroke-width"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"text-anchor"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"text-decoration"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"text-overflow"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"text-rendering"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"title"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"transform"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"transform-origin"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"unicode-bidi"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"vector-effect"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"visibility"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"white-space"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"word-spacing"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"writing-mode"</c-><c- p>,</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- kc>null</c->
+    <c- p>}</c->
+  <c- p>],</c->
+  <c- f>"comments"</c-><c- p>:</c-> <c- kc>false</c-><c- p>,</c->
+  <c- f>"dataAttributes"</c-><c- p>:</c-> <c- kc>false</c->
+<c- p>}</c-></pre>
+   <p class="note" role="note"><span class="marker">Note:</span> Included <a data-link-type="biblio" href="#biblio-mathml" title="Mathematical Markup Language (MathML™) 1.01 Specification">[MathML]</a> markup is based on <a data-link-type="biblio" href="#biblio-safemathml" title="MathML Safe List">[SafeMathML]</a>.</p>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="built-in-safe-baseline-configuration">built-in safe baseline configuration</dfn> is meant to block only
+script-content. It is as follows:</p>
+<pre class="include-code highlight"><c- p>{</c->
+  <c- f>"removeElements"</c-><c- p>:</c-> <c- p>[</c->
+    <c- p>{</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"embed"</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"frame"</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"iframe"</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"object"</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"script"</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"script"</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"use"</c->
+    <c- p>}</c->
+  <c- p>],</c->
+  <c- f>"removeAttributes"</c-><c- p>:</c-> <c- p>[]</c->
+<c- p>}</c->
+</pre>
+   <div class="advisement">
+    <p><strong class="marker">Warning:</strong> The <a data-link-type="dfn" href="#sanitizerconfig-remove-unsafe" id="ref-for-sanitizerconfig-remove-unsafe③">remove unsafe</a> algorithm specifies
+to additionally remove any <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes" id="ref-for-event-handler-content-attributes①">event handler content attributes</a>, as defined
+in <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a>.
+If a <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#user-agent" id="ref-for-user-agent">user agent</a> defines extensions to the <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a> spec with additional
+<a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes" id="ref-for-event-handler-content-attributes②">event handler content attributes</a>, it is its responsibility to decide how
+to handle them. Using the current <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes" id="ref-for-event-handler-content-attributes③">event handler content attributes</a> list,
+the safe baseline configuration looks effectively like so:</p>
+<pre class="include-code highlight"><c- p>{</c->
+  <c- f>"removeElements"</c-><c- p>:</c-> <c- p>[</c->
+    <c- p>{</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"embed"</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"frame"</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"iframe"</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"object"</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/1999/xhtml"</c-><c- p>,</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"script"</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"script"</c->
+    <c- p>},</c->
+    <c- p>{</c->
+      <c- f>"namespace"</c-><c- p>:</c-> <c- u>"http://www.w3.org/2000/svg"</c-><c- p>,</c->
+      <c- f>"name"</c-><c- p>:</c-> <c- u>"use"</c->
+    <c- p>}</c->
+  <c- p>],</c->
+  <c- f>"removeAttributes"</c-><c- p>:</c-> <c- p>[</c->
+    <c- u>"onafterprint"</c-><c- p>,</c->
+    <c- u>"onauxclick"</c-><c- p>,</c->
+    <c- u>"onbeforeinput"</c-><c- p>,</c->
+    <c- u>"onbeforematch"</c-><c- p>,</c->
+    <c- u>"onbeforeprint"</c-><c- p>,</c->
+    <c- u>"onbeforeunload"</c-><c- p>,</c->
+    <c- u>"onbeforetoggle"</c-><c- p>,</c->
+    <c- u>"onblur"</c-><c- p>,</c->
+    <c- u>"oncancel"</c-><c- p>,</c->
+    <c- u>"oncanplay"</c-><c- p>,</c->
+    <c- u>"oncanplaythrough"</c-><c- p>,</c->
+    <c- u>"onchange"</c-><c- p>,</c->
+    <c- u>"onclick"</c-><c- p>,</c->
+    <c- u>"onclose"</c-><c- p>,</c->
+    <c- u>"oncontextlost"</c-><c- p>,</c->
+    <c- u>"oncontextmenu"</c-><c- p>,</c->
+    <c- u>"oncontextrestored"</c-><c- p>,</c->
+    <c- u>"oncopy"</c-><c- p>,</c->
+    <c- u>"oncuechange"</c-><c- p>,</c->
+    <c- u>"oncut"</c-><c- p>,</c->
+    <c- u>"ondblclick"</c-><c- p>,</c->
+    <c- u>"ondrag"</c-><c- p>,</c->
+    <c- u>"ondragend"</c-><c- p>,</c->
+    <c- u>"ondragenter"</c-><c- p>,</c->
+    <c- u>"ondragleave"</c-><c- p>,</c->
+    <c- u>"ondragover"</c-><c- p>,</c->
+    <c- u>"ondragstart"</c-><c- p>,</c->
+    <c- u>"ondrop"</c-><c- p>,</c->
+    <c- u>"ondurationchange"</c-><c- p>,</c->
+    <c- u>"onemptied"</c-><c- p>,</c->
+    <c- u>"onended"</c-><c- p>,</c->
+    <c- u>"onerror"</c-><c- p>,</c->
+    <c- u>"onfocus"</c-><c- p>,</c->
+    <c- u>"onformdata"</c-><c- p>,</c->
+    <c- u>"onhashchange"</c-><c- p>,</c->
+    <c- u>"oninput"</c-><c- p>,</c->
+    <c- u>"oninvalid"</c-><c- p>,</c->
+    <c- u>"onkeydown"</c-><c- p>,</c->
+    <c- u>"onkeypress"</c-><c- p>,</c->
+    <c- u>"onkeyup"</c-><c- p>,</c->
+    <c- u>"onlanguagechange"</c-><c- p>,</c->
+    <c- u>"onload"</c-><c- p>,</c->
+    <c- u>"onloadeddata"</c-><c- p>,</c->
+    <c- u>"onloadedmetadata"</c-><c- p>,</c->
+    <c- u>"onloadstart"</c-><c- p>,</c->
+    <c- u>"onmessage"</c-><c- p>,</c->
+    <c- u>"onmessageerror"</c-><c- p>,</c->
+    <c- u>"onmousedown"</c-><c- p>,</c->
+    <c- u>"onmouseenter"</c-><c- p>,</c->
+    <c- u>"onmouseleave"</c-><c- p>,</c->
+    <c- u>"onmousemove"</c-><c- p>,</c->
+    <c- u>"onmouseout"</c-><c- p>,</c->
+    <c- u>"onmouseover"</c-><c- p>,</c->
+    <c- u>"onmouseup"</c-><c- p>,</c->
+    <c- u>"onoffline"</c-><c- p>,</c->
+    <c- u>"ononline"</c-><c- p>,</c->
+    <c- u>"onpagehide"</c-><c- p>,</c->
+    <c- u>"onpagereveal"</c-><c- p>,</c->
+    <c- u>"onpageshow"</c-><c- p>,</c->
+    <c- u>"onpageswap"</c-><c- p>,</c->
+    <c- u>"onpaste"</c-><c- p>,</c->
+    <c- u>"onpause"</c-><c- p>,</c->
+    <c- u>"onplay"</c-><c- p>,</c->
+    <c- u>"onplaying"</c-><c- p>,</c->
+    <c- u>"onpopstate"</c-><c- p>,</c->
+    <c- u>"onprogress"</c-><c- p>,</c->
+    <c- u>"onratechange"</c-><c- p>,</c->
+    <c- u>"onreset"</c-><c- p>,</c->
+    <c- u>"onresize"</c-><c- p>,</c->
+    <c- u>"onrejectionhandled"</c-><c- p>,</c->
+    <c- u>"onscroll"</c-><c- p>,</c->
+    <c- u>"onscrollend"</c-><c- p>,</c->
+    <c- u>"onsecuritypolicyviolation"</c-><c- p>,</c->
+    <c- u>"onseeked"</c-><c- p>,</c->
+    <c- u>"onseeking"</c-><c- p>,</c->
+    <c- u>"onselect"</c-><c- p>,</c->
+    <c- u>"onslotchange"</c-><c- p>,</c->
+    <c- u>"onstalled"</c-><c- p>,</c->
+    <c- u>"onstorage"</c-><c- p>,</c->
+    <c- u>"onsubmit"</c-><c- p>,</c->
+    <c- u>"onsuspend"</c-><c- p>,</c->
+    <c- u>"ontimeupdate"</c-><c- p>,</c->
+    <c- u>"ontoggle"</c-><c- p>,</c->
+    <c- u>"onunhandledrejection"</c-><c- p>,</c->
+    <c- u>"onunload"</c-><c- p>,</c->
+    <c- u>"onvolumechange"</c-><c- p>,</c->
+    <c- u>"onwaiting"</c-><c- p>,</c->
+    <c- u>"onwheel"</c->
+  <c- p>]</c->
+<c- p>}</c-></pre>
+   </div>
+   <div>
+    
+The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="built-in-navigating-url-attributes-list">built-in navigating URL attributes list</dfn>, for which "<code>javascript:</code>"
+navigations are "unsafe", are as follows:
+
+
+    <p>«[
+  <br>
+  [
+    { "<code>name</code>" → "<code>a</code>", "<code>namespace</code>" → <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace" id="ref-for-html-namespace③">HTML namespace</a> },
+    { "<code>name</code>" → "<code>href</code>", "<code>namespace</code>" → <code>null</code> }
+  ],
+  <br>
+  [
+    { "<code>name</code>" → "<code>area</code>", "<code>namespace</code>" → <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace" id="ref-for-html-namespace④">HTML namespace</a> },
+    { "<code>name</code>" → "<code>href</code>", "<code>namespace</code>" → <code>null</code> }
+  ],
+  <br>
+  [
+    { "<code>name</code>" → "<code>base</code>", "<code>namespace</code>" → <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace" id="ref-for-html-namespace⑤">HTML namespace</a> },
+    { "<code>name</code>" → "<code>href</code>", "<code>namespace</code>" → <code>null</code> }
+  ],
+  <br>
+  [
+    { "<code>name</code>" → "<code>button</code>", "<code>namespace</code>" → <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace" id="ref-for-html-namespace⑥">HTML namespace</a> },
+    { "<code>name</code>" → "<code>formaction</code>", "<code>namespace</code>" → <code>null</code> }
+  ],
+  <br>
+  [
+    { "<code>name</code>" → "<code>form</code>", "<code>namespace</code>" → <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace" id="ref-for-html-namespace⑦">HTML namespace</a> },
+    { "<code>name</code>" → "<code>action</code>", "<code>namespace</code>" → <code>null</code> }
+  ],
+  <br>
+  [
+    { "<code>name</code>" → "<code>iframe</code>", "<code>namespace</code>" → <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace" id="ref-for-html-namespace⑧">HTML namespace</a> },
+    { "<code>name</code>" → "<code>src</code>", "<code>namespace</code>" → <code>null</code> }
+  ],
+  <br>
+  [
+    { "<code>name</code>" → "<code>input</code>", "<code>namespace</code>" → <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#html-namespace" id="ref-for-html-namespace⑨">HTML namespace</a> },
+    { "<code>name</code>" → "<code>formaction</code>", "<code>namespace</code>" → <code>null</code> }
+  ],
+  <br>
+  [
+    { "<code>name</code>" → "<code>a</code>", "<code>namespace</code>" → <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#svg-namespace" id="ref-for-svg-namespace①">SVG namespace</a> },
+    { "<code>name</code>" → "<code>href</code>", "<code>namespace</code>" → <code>null</code> }
+  ],
+  <br>
+  [
+    { "<code>name</code>" → "<code>a</code>", "<code>namespace</code>" → <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#svg-namespace" id="ref-for-svg-namespace②">SVG namespace</a> },
+    { "<code>name</code>" → "<code>href</code>", "<code>namespace</code>" → <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#xlink-namespace" id="ref-for-xlink-namespace①">XLink namespace</a> }
+  ],
+  <br>
+]»</p>
+   </div>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="built-in-animating-url-attributes-list">built-in animating URL attributes list</dfn>, which can be used in
+<a data-link-type="biblio" href="#biblio-svg11" title="Scalable Vector Graphics (SVG) 1.1 (Second Edition)">[SVG11]</a> to declaratively modify navigation elements to use "<code>javascript:</code>"
+URLs, is as follows:</p>
+   <p>«[
+  <br>
+  [
+    { "<code>name</code>" → "<code>animate</code>", "<code>namespace</code>" → <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#svg-namespace" id="ref-for-svg-namespace③">SVG namespace</a> },
+    { "<code>name</code>" → "<code>attributeName</code>", "<code>namespace</code>" → <code>null</code>] }
+  ],
+  <br>
+  [
+    { "<code>name</code>" → "<code>animateMotion</code>", "<code>namespace</code>" → <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#svg-namespace" id="ref-for-svg-namespace④">SVG namespace</a> },
+    { "<code>name</code>" → "<code>attributeName</code>", "<code>namespace</code>" → <code>null</code> }
+  ],
+  <br>
+  [
+    { "<code>name</code>" → "<code>animateTransform</code>", "<code>namespace</code>" → <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#svg-namespace" id="ref-for-svg-namespace⑤">SVG namespace</a> },
+    { "<code>name</code>" → "<code>attributeName</code>", "<code>namespace</code>" → <code>null</code> }
+  ],
+  <br>
+  [
+    { "<code>name</code>" → "<code>set</code>", "<code>namespace</code>" → <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#svg-namespace" id="ref-for-svg-namespace⑥">SVG namespace</a> },
+    { "<code>name</code>" → "<code>attributeName</code>", "<code>namespace</code>" → <code>null</code> }
+  ],
+  <br>
+]»</p>
+   <h2 class="heading settled" data-level="4" id="security-considerations"><span class="secno">4. </span><span class="content">Security Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
+   <p>The Sanitizer API is intended to prevent DOM-based Cross-Site Scripting
+by traversing a supplied HTML content and removing elements and attributes
+according to a configuration. The specified API must not support
+the construction of a Sanitizer object that leaves script-capable markup in
+and doing so would be a bug in the threat model.</p>
+   <p>That being said, there are security issues which the correct usage of the
+Sanitizer API will not be able to protect against and the scenarios will be
+laid out in the following sections.</p>
+   <h3 class="heading settled" data-level="4.1" id="server-side-xss"><span class="secno">4.1. </span><span class="content">Server-Side Reflected and Stored XSS</span><a class="self-link" href="#server-side-xss"></a></h3>
+   <p><em>This section is not normative.</em></p>
+   <p>The Sanitizer API operates solely in the DOM and adds a capability to traverse
+and filter an existing DocumentFragment. The Sanitizer does not address
+server-side reflected or stored XSS.</p>
+   <h3 class="heading settled" data-level="4.2" id="dom-clobbering"><span class="secno">4.2. </span><span class="content">DOM clobbering</span><a class="self-link" href="#dom-clobbering"></a></h3>
+   <p><em>This section is not normative.</em></p>
+   <p>DOM clobbering describes an attack in which malicious HTML confuses an
+application by naming elements through <code>id</code> or <code>name</code> attributes such that
+properties like <code>children</code> of an HTML element in the DOM are overshadowed by
+the malicious content.</p>
+   <p>The Sanitizer API does not protect DOM clobbering attacks in its
+default state, but can be configured to remove <code>id</code> and <code>name</code> attributes.</p>
+   <h3 class="heading settled" data-level="4.3" id="script-gadgets"><span class="secno">4.3. </span><span class="content">XSS with Script gadgets</span><a class="self-link" href="#script-gadgets"></a></h3>
+   <p><em>This section is not normative.</em></p>
+   <p>Script gadgets are a technique in which an attacker uses existing application
+code from popular JavaScript libraries to cause their own code to execute.
+This is often done by injecting innocent-looking code or seemingly inert
+DOM nodes that is only parsed and interpreted by a framework which then
+performs the execution of JavaScript based on that input.</p>
+   <p>The Sanitizer API can not prevent these attacks, but requires page authors to
+explicitly allow unknown elements in general, and authors must additionally
+explicitly configure unknown attributes and elements and markup that is known
+to be widely used for templating and framework-specific code,
+like <code>data-</code> and <code>slot</code> attributes and elements like <code>&lt;slot></code> and <code>&lt;template></code>.
+We believe that these restrictions are not exhaustive and encourage page
+authors to examine their third party libraries for this behavior.</p>
+   <h3 class="heading settled" data-level="4.4" id="mutated-xss"><span class="secno">4.4. </span><span class="content">Mutated XSS</span><a class="self-link" href="#mutated-xss"></a></h3>
+   <p><em>This section is not normative.</em></p>
+   <p>Mutated XSS or mXSS describes an attack based on parser context mismatches
+when parsing an HTML snippet without the correct context. In particular,
+when a parsed HTML fragment has been serialized to a string, the string is
+not guaranteed to be parsed and interpreted exactly the same when inserted
+into a different parent element. An example for carrying out such an attack
+is by relying on the change of parsing behavior for foreign content or
+mis-nested tags.</p>
+   <p>The Sanitizer API offers only functions that turn a string into a node tree.
+The context is supplied implicitly by all sanitizer functions:
+<code>Element.setHTML()</code> uses the current element; <code>Document.parseHTML()</code> creates a
+new document. Therefore Sanitizer API is not directly affected by mutated XSS.</p>
+   <p>If a developer were to retrieve a sanitized node tree as a string, e.g. via
+<code>.innerHTML</code>, and to then parse it again then mutated XSS may occur.
+We discourage this practice. If processing or passing of HTML as a
+string should be necessary after all, then any string should be considered
+untrusted and should be sanitized (again) when inserting it into the DOM. In
+other words, a sanitized and then serialized HTML tree can no
+longer be considered as sanitized.</p>
+   <p>A more complete treatment of mXSS can be found in <a data-link-type="biblio" href="#biblio-mxss" title="mXSS Attacks: Attacking well-secured Web-Applications by using innerHTML Mutations">[MXSS]</a>.</p>
+   <h2 class="heading settled" data-level="5" id="ack"><span class="secno">5. </span><span class="content">Acknowledgements</span><a class="self-link" href="#ack"></a></h2>
+   <p>This work is informed and inspired by <a data-link-type="biblio" href="#biblio-dompurify" title="DOMPurify">[DOMPURIFY]</a> from cure53,
+Internet Explorer’s <code class="idl"><a data-link-type="idl" href="https://msdn.microsoft.com/en-us/library/cc848922(v=vs.85).aspx" id="ref-for-something">window.toStaticHTML()</a></code> as well as the original
+<a data-link-type="biblio" href="#biblio-htmlsanitizer" title="HTML Sanitizer">[HTMLSanitizer]</a> from Ben Bucksch.
+Anne van Kesteren, Krzysztof Kotowicz, Tom Schuster, Luke Warlow,
+Guillaume Weghsteen, and Mike West for their valuable feedback.</p>
+  </main>
+  <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
+  <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
+  <ul class="index">
+   <li><a href="#sanitizerconfig-add">add</a><span>, in § 3.5</span>
+   <li><a href="#sanitizer-allow-an-attribute">allow an attribute</a><span>, in § 3.2</span>
+   <li><a href="#sanitizerconfig-allow-an-element">allow an element</a><span>, in § 3.2</span>
+   <li><a href="#dom-sanitizer-allowattribute">allowAttribute(attribute)</a><span>, in § 2.2</span>
+   <li><a href="#dom-sanitizer-allowelement">allowElement(element)</a><span>, in § 2.2</span>
+   <li>
+    attributes
+    <ul>
+     <li><a href="#dom-sanitizerconfig-attributes">dict-member for SanitizerConfig</a><span>, in § 2.3</span>
+     <li><a href="#dom-sanitizerelementnamespacewithattributes-attributes">dict-member for SanitizerElementNamespaceWithAttributes</a><span>, in § 2.3</span>
+    </ul>
+   <li><a href="#built-in-animating-url-attributes-list">built-in animating URL attributes list</a><span>, in § 3.6</span>
+   <li><a href="#built-in-navigating-url-attributes-list">built-in navigating URL attributes list</a><span>, in § 3.6</span>
+   <li><a href="#built-in-safe-baseline-configuration">built-in safe baseline configuration</a><span>, in § 3.6</span>
+   <li><a href="#built-in-safe-default-configuration">built-in safe default configuration</a><span>, in § 3.6</span>
+   <li><a href="#canonicalize-a-sanitizer-attribute">canonicalize a sanitizer attribute</a><span>, in § 3.4</span>
+   <li><a href="#canonicalize-a-sanitizer-element">canonicalize a sanitizer element</a><span>, in § 3.4</span>
+   <li><a href="#canonicalize-a-sanitizer-element-with-attributes">canonicalize a sanitizer element with attributes</a><span>, in § 3.4</span>
+   <li><a href="#canonicalize-a-sanitizer-name">canonicalize a sanitizer name</a><span>, in § 3.4</span>
+   <li><a href="#sanitizer-canonicalize-the-configuration">canonicalize the configuration</a><span>, in § 3.4</span>
+   <li><a href="#comment">Comment</a><span>, in § 3.5</span>
+   <li><a href="#dom-sanitizerconfig-comments">comments</a><span>, in § 2.3</span>
+   <li><a href="#sanitizer-configuration">configuration</a><span>, in § 2.2</span>
+   <li><a href="#dom-sanitizer-constructor">constructor()</a><span>, in § 2.2</span>
+   <li><a href="#dom-sanitizer-constructor">constructor(configuration)</a><span>, in § 2.2</span>
+   <li><a href="#sanitizerconfig-contains">contains</a><span>, in § 3.5</span>
+   <li><a href="#contains-a-javascript-url">contains a javascript: URL</a><span>, in § 3.1</span>
+   <li><a href="#dom-sanitizerconfig-dataattributes">dataAttributes</a><span>, in § 2.3</span>
+   <li><a href="#dom-sanitizerpresets-default">"default"</a><span>, in § 2.2</span>
+   <li><a href="#dom-sanitizerconfig-elements">elements</a><span>, in § 2.3</span>
+   <li>
+    equal
+    <ul>
+     <li><a href="#map-equal">dfn for map</a><span>, in § 3.5</span>
+     <li><a href="#set-equal">dfn for set</a><span>, in § 3.5</span>
+    </ul>
+   <li><a href="#dom-sanitizer-get">get()</a><span>, in § 2.2</span>
+   <li><a href="#sanitizerconfig-get-a-sanitizer-instance-from-options">get a sanitizer instance from options</a><span>, in § 3</span>
+   <li><a href="#handlejavascriptnavigationurls">handleJavascriptNavigationUrls</a><span>, in § 3.1</span>
+   <li><a href="#sanitizerconfig-has-duplicates">has duplicates</a><span>, in § 3.5</span>
+   <li><a href="#sanitizerconfig-intersection">intersection</a><span>, in § 3.5</span>
+   <li><a href="#sanitizerconfig-less-than-item">less than item</a><span>, in § 3.5</span>
+   <li>
+    name
+    <ul>
+     <li><a href="#dom-sanitizerattributenamespace-name">dict-member for SanitizerAttributeNamespace</a><span>, in § 2.3</span>
+     <li><a href="#dom-sanitizerelementnamespace-name">dict-member for SanitizerElementNamespace</a><span>, in § 2.3</span>
+    </ul>
+   <li>
+    namespace
+    <ul>
+     <li><a href="#dom-sanitizerattributenamespace-namespace">dict-member for SanitizerAttributeNamespace</a><span>, in § 2.3</span>
+     <li><a href="#dom-sanitizerelementnamespace-namespace">dict-member for SanitizerElementNamespace</a><span>, in § 2.3</span>
+    </ul>
+   <li><a href="#boolean-not">not</a><span>, in § 3.5</span>
+   <li><a href="#dom-document-parsehtml">parseHTML(html)</a><span>, in § 2.1</span>
+   <li><a href="#dom-document-parsehtml">parseHTML(html, options)</a><span>, in § 2.1</span>
+   <li><a href="#dom-document-parsehtmlunsafe">parseHTMLUnsafe(html)</a><span>, in § 2.1</span>
+   <li><a href="#dom-document-parsehtmlunsafe">parseHTMLUnsafe(html, options)</a><span>, in § 2.1</span>
+   <li><a href="#sanitizerconfig-remove">remove</a><span>, in § 3.5</span>
+   <li><a href="#sanitizer-remove-an-attribute">remove an attribute</a><span>, in § 3.2</span>
+   <li><a href="#sanitizer-remove-an-element">remove an element</a><span>, in § 3.2</span>
+   <li><a href="#dom-sanitizer-removeattribute">removeAttribute(attribute)</a><span>, in § 2.2</span>
+   <li>
+    removeAttributes
+    <ul>
+     <li><a href="#dom-sanitizerconfig-removeattributes">dict-member for SanitizerConfig</a><span>, in § 2.3</span>
+     <li><a href="#dom-sanitizerelementnamespacewithattributes-removeattributes">dict-member for SanitizerElementNamespaceWithAttributes</a><span>, in § 2.3</span>
+    </ul>
+   <li><a href="#sanitizerconfig-remove-duplicates">remove duplicates</a><span>, in § 3.5</span>
+   <li><a href="#dom-sanitizer-removeelement">removeElement(element)</a><span>, in § 2.2</span>
+   <li><a href="#dom-sanitizerconfig-removeelements">removeElements</a><span>, in § 2.3</span>
+   <li><a href="#sanitizerconfig-remove-unsafe">remove unsafe</a><span>, in § 3.2</span>
+   <li><a href="#dom-sanitizer-removeunsafe">removeUnsafe()</a><span>, in § 2.2</span>
+   <li><a href="#sanitizer-replace-an-element-with-its-children">replace an element with its children</a><span>, in § 3.2</span>
+   <li><a href="#dom-sanitizer-replaceelementwithchildren">replaceElementWithChildren(element)</a><span>, in § 2.2</span>
+   <li><a href="#dom-sanitizerconfig-replacewithchildrenelements">replaceWithChildrenElements</a><span>, in § 2.3</span>
+   <li><a href="#safe-and-unsafe">Safe and unsafe</a><span>, in § 1.2</span>
+   <li><a href="#sanitize">sanitize</a><span>, in § 3.1</span>
+   <li><a href="#sanitize-core">sanitize core</a><span>, in § 3.1</span>
+   <li><a href="#sanitizer">Sanitizer</a><span>, in § 2.2</span>
+   <li>
+    sanitizer
+    <ul>
+     <li><a href="#dom-sethtmloptions-sanitizer">dict-member for SetHTMLOptions</a><span>, in § 2.2</span>
+     <li><a href="#dom-sethtmlunsafeoptions-sanitizer">dict-member for SetHTMLUnsafeOptions</a><span>, in § 2.2</span>
+    </ul>
+   <li><a href="#dom-sanitizer-constructor">Sanitizer()</a><span>, in § 2.2</span>
+   <li><a href="#typedefdef-sanitizerattribute">SanitizerAttribute</a><span>, in § 2.3</span>
+   <li><a href="#dictdef-sanitizerattributenamespace">SanitizerAttributeNamespace</a><span>, in § 2.3</span>
+   <li><a href="#dictdef-sanitizerconfig">SanitizerConfig</a><span>, in § 2.3</span>
+   <li><a href="#dom-sanitizer-constructor">Sanitizer(configuration)</a><span>, in § 2.2</span>
+   <li><a href="#typedefdef-sanitizerelement">SanitizerElement</a><span>, in § 2.3</span>
+   <li><a href="#dictdef-sanitizerelementnamespace">SanitizerElementNamespace</a><span>, in § 2.3</span>
+   <li><a href="#dictdef-sanitizerelementnamespacewithattributes">SanitizerElementNamespaceWithAttributes</a><span>, in § 2.3</span>
+   <li><a href="#typedefdef-sanitizerelementwithattributes">SanitizerElementWithAttributes</a><span>, in § 2.3</span>
+   <li><a href="#enumdef-sanitizerpresets">SanitizerPresets</a><span>, in § 2.2</span>
+   <li><a href="#sanitizer-set-a-configuration">set a configuration</a><span>, in § 3.3</span>
+   <li><a href="#set-and-filter-html">set and filter HTML</a><span>, in § 3</span>
+   <li><a href="#sanitizer-set-comments">set comments</a><span>, in § 3.2</span>
+   <li><a href="#dom-sanitizer-setcomments">setComments(allow)</a><span>, in § 2.2</span>
+   <li><a href="#sanitizer-set-data-attributes">set data attributes</a><span>, in § 3.2</span>
+   <li><a href="#dom-sanitizer-setdataattributes">setDataAttributes(allow)</a><span>, in § 2.2</span>
+   <li>
+    setHTML(html)
+    <ul>
+     <li><a href="#dom-element-sethtml">method for Element</a><span>, in § 2.1</span>
+     <li><a href="#dom-shadowroot-sethtml">method for ShadowRoot</a><span>, in § 2.1</span>
+    </ul>
+   <li>
+    setHTML(html, options)
+    <ul>
+     <li><a href="#dom-element-sethtml">method for Element</a><span>, in § 2.1</span>
+     <li><a href="#dom-shadowroot-sethtml">method for ShadowRoot</a><span>, in § 2.1</span>
+    </ul>
+   <li><a href="#dictdef-sethtmloptions">SetHTMLOptions</a><span>, in § 2.2</span>
+   <li>
+    setHTMLUnsafe(html)
+    <ul>
+     <li><a href="#dom-element-sethtmlunsafe">method for Element</a><span>, in § 2.1</span>
+     <li><a href="#dom-shadowroot-sethtmlunsafe">method for ShadowRoot</a><span>, in § 2.1</span>
+    </ul>
+   <li>
+    setHTMLUnsafe(html, options)
+    <ul>
+     <li><a href="#dom-element-sethtmlunsafe">method for Element</a><span>, in § 2.1</span>
+     <li><a href="#dom-shadowroot-sethtmlunsafe">method for ShadowRoot</a><span>, in § 2.1</span>
+    </ul>
+   <li><a href="#dictdef-sethtmlunsafeoptions">SetHTMLUnsafeOptions</a><span>, in § 2.2</span>
+   <li><a href="#sanitizerconfig-valid">valid</a><span>, in § 2.4</span>
+  </ul>
+  <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
+  <ul class="index">
+   <li>
+    <a data-link-type="biblio">[]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="384bdca4">custom data attribute</span>
+     <li><span class="dfn-paneled" id="93ded71a">global attribute</span>
+     <li><span class="dfn-paneled" id="f7cccb8c">HTML fragment parsing algorithm</span>
+     <li><span class="dfn-paneled" id="769996cd">parse HTML from a string</span>
+     <li><span class="dfn-paneled" id="37e32f12">report a warning to the console</span>
+     <li><span class="dfn-paneled" id="d354f084">window.toStaticHTML()</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[DOM]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="a0647283">Comment</span>
+     <li><span class="dfn-paneled" id="85394472">Document</span>
+     <li><span class="dfn-paneled" id="49a2843d">DocumentFragment</span>
+     <li><span class="dfn-paneled" id="9011c821">DocumentType</span>
+     <li><span class="dfn-paneled" id="296f3551">Element</span>
+     <li><span class="dfn-paneled" id="96c16e60">Node</span>
+     <li><span class="dfn-paneled" id="ece46d2b">ParentNode</span>
+     <li><span class="dfn-paneled" id="1cd7ff31">ShadowRoot</span>
+     <li><span class="dfn-paneled" id="597088f0">Text</span>
+     <li><span class="dfn-paneled" id="5c8f824f">allow declarative shadow roots</span>
+     <li><span class="dfn-paneled" id="db0a062f">attribute</span>
+     <li><span class="dfn-paneled" id="77211728">attribute list</span>
+     <li><span class="dfn-paneled" id="92b2d7da">children</span>
+     <li><span class="dfn-paneled" id="3f23ec71">content type</span>
+     <li><span class="dfn-paneled" id="3e6df8da">get an attribute value</span>
+     <li><span class="dfn-paneled" id="e240317a">local name <small>(for Attr)</small></span>
+     <li><span class="dfn-paneled" id="83ca4a87">local name <small>(for Element)</small></span>
+     <li><span class="dfn-paneled" id="b3955a25">namespace <small>(for Attr)</small></span>
+     <li><span class="dfn-paneled" id="746cc3ba">namespace <small>(for Element)</small></span>
+     <li><span class="dfn-paneled" id="5216e1a0">node document</span>
+     <li><span class="dfn-paneled" id="0e0b900e">remove</span>
+     <li><span class="dfn-paneled" id="414d5b08">remove an attribute</span>
+     <li><span class="dfn-paneled" id="4fd7ca14">replace all</span>
+     <li><span class="dfn-paneled" id="58a8f724">shadow host</span>
+     <li><span class="dfn-paneled" id="ce720392">shadow root</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[HTML]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="402ed79d">CEReactions</span>
+     <li><span class="dfn-paneled" id="dbd32973">DOMParser</span>
+     <li><span class="dfn-paneled" id="f099a38d">HTMLTemplateElement</span>
+     <li><span class="dfn-paneled" id="cc6d9aed">event handler content attribute</span>
+     <li><span class="dfn-paneled" id="d4127354">innerHTML</span>
+     <li><span class="dfn-paneled" id="b815ad04">parseFromString(string, type)</span>
+     <li><span class="dfn-paneled" id="e99bd18e">relevant global object</span>
+     <li><span class="dfn-paneled" id="3e7fc2a2">template contents</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[INFRA]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="53275e46">append <small>(for list)</small></span>
+     <li><span class="dfn-paneled" id="a3b18719">append <small>(for set)</small></span>
+     <li><span class="dfn-paneled" id="77b4c09a">assert</span>
+     <li><span class="dfn-paneled" id="36858240">boolean</span>
+     <li><span class="dfn-paneled" id="4135591f">code unit less than</span>
+     <li><span class="dfn-paneled" id="4943545e">code unit prefix</span>
+     <li><span class="dfn-paneled" id="ae8def21">contain <small>(for list)</small></span>
+     <li><span class="dfn-paneled" id="a326add7">contain <small>(for map)</small></span>
+     <li><span class="dfn-paneled" id="f937b7b6">continue</span>
+     <li><span class="dfn-paneled" id="a1797ffb">difference</span>
+     <li><span class="dfn-paneled" id="03afaf9c">empty</span>
+     <li><span class="dfn-paneled" id="8958b003">entry</span>
+     <li><span class="dfn-paneled" id="1243a891">exist</span>
+     <li><span class="dfn-paneled" id="16d07e10">for each</span>
+     <li><span class="dfn-paneled" id="4e92bc80">get the keys</span>
+     <li><span class="dfn-paneled" id="f052b1ea">HTML namespace</span>
+     <li><span class="dfn-paneled" id="e5ea84f2">intersection</span>
+     <li><span class="dfn-paneled" id="7a87d819">is</span>
+     <li><span class="dfn-paneled" id="f02cd417">iterate</span>
+     <li><span class="dfn-paneled" id="d14a6f26">key</span>
+     <li><span class="dfn-paneled" id="649608b9">list</span>
+     <li><span class="dfn-paneled" id="ead425bd">MathML namespace</span>
+     <li><span class="dfn-paneled" id="84b454ff">ordered map</span>
+     <li><span class="dfn-paneled" id="692595fe">ordered set</span>
+     <li><span class="dfn-paneled" id="99c988d6">remove</span>
+     <li><span class="dfn-paneled" id="15e48c39">set</span>
+     <li><span class="dfn-paneled" id="0e6b2056">set <small>(for map)</small></span>
+     <li><span class="dfn-paneled" id="5ecc2082">sort in ascending order</span>
+     <li><span class="dfn-paneled" id="0698d556">string</span>
+     <li><span class="dfn-paneled" id="5c7fa56b">subset</span>
+     <li><span class="dfn-paneled" id="35feaa5b">superset</span>
+     <li><span class="dfn-paneled" id="85a289c7">SVG namespace</span>
+     <li><span class="dfn-paneled" id="0e8de730">tuple</span>
+     <li><span class="dfn-paneled" id="6d19ac93">user agent</span>
+     <li><span class="dfn-paneled" id="802b0fdd">value</span>
+     <li><span class="dfn-paneled" id="ee469dff">with default</span>
+     <li><span class="dfn-paneled" id="e19f3699">XLink namespace</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[TRUSTED-TYPES]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="1a897bae">Get Trusted Type compliant string</span>
+     <li><span class="dfn-paneled" id="bdec671a">TrustedHTML</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[URL]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="9ed8b710">basic URL parser</span>
+     <li><span class="dfn-paneled" id="3a711be7">scheme</span>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
+    <ul>
+     <li><span class="dfn-paneled" id="8855a9aa">DOMString</span>
+     <li><span class="dfn-paneled" id="889e932f">Exposed</span>
+     <li><span class="dfn-paneled" id="82ca3efc">TypeError</span>
+     <li><span class="dfn-paneled" id="5372cca8">boolean</span>
+     <li><span class="dfn-paneled" id="bec98d30">dictionary</span>
+     <li><span class="dfn-paneled" id="a32c65d4">implements</span>
+     <li><span class="dfn-paneled" id="9cce47fd">sequence</span>
+     <li><span class="dfn-paneled" id="4013a022">this</span>
+     <li><span class="dfn-paneled" id="b4cfa5ce">throw</span>
+     <li><span class="dfn-paneled" id="5f90bbfb">undefined</span>
+    </ul>
+  </ul>
+  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
+  <dl>
+   <dt id="biblio-dom">[DOM]
+   <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/"><cite>DOM Standard</cite></a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
+   <dt id="biblio-html">[HTML]
+   <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dt id="biblio-infra">[INFRA]
+   <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/"><cite>Infra Standard</cite></a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
+   <dt id="biblio-trusted-types">[TRUSTED-TYPES]
+   <dd>Krzysztof Kotowicz. <a href="https://w3c.github.io/trusted-types/dist/spec/"><cite>Trusted Types</cite></a>. URL: <a href="https://w3c.github.io/trusted-types/dist/spec/">https://w3c.github.io/trusted-types/dist/spec/</a>
+   <dt id="biblio-url">[URL]
+   <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/"><cite>URL Standard</cite></a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
+   <dt id="biblio-webidl">[WebIDL]
+   <dd>Edgar Chen; Timothy Gu. <a href="https://webidl.spec.whatwg.org/"><cite>Web IDL Standard</cite></a>. Living Standard. URL: <a href="https://webidl.spec.whatwg.org/">https://webidl.spec.whatwg.org/</a>
+  </dl>
+  <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
+  <dl>
+   <dt id="biblio-dompurify">[DOMPURIFY]
+   <dd><a href="https://github.com/cure53/DOMPurify"><cite>DOMPurify</cite></a>. URL: <a href="https://github.com/cure53/DOMPurify">https://github.com/cure53/DOMPurify</a>
+   <dt id="biblio-htmlsanitizer">[HTMLSanitizer]
+   <dd><a href="https://www.bucksch.org/1/projects/mozilla/108153/"><cite>HTML Sanitizer</cite></a>. URL: <a href="https://www.bucksch.org/1/projects/mozilla/108153/">https://www.bucksch.org/1/projects/mozilla/108153/</a>
+   <dt id="biblio-mathml">[MathML]
+   <dd>Patrick D F Ion; Robert R Miner. <a href="https://www.w3.org/TR/REC-MathML/"><cite>Mathematical Markup Language (MathML™) 1.01 Specification</cite></a>. 7 March 2023. REC. URL: <a href="https://www.w3.org/TR/REC-MathML/">https://www.w3.org/TR/REC-MathML/</a>
+   <dt id="biblio-mxss">[MXSS]
+   <dd><a href="https://cure53.de/fp170.pdf"><cite>mXSS Attacks: Attacking well-secured Web-Applications by using innerHTML Mutations</cite></a>. URL: <a href="https://cure53.de/fp170.pdf">https://cure53.de/fp170.pdf</a>
+   <dt id="biblio-safemathml">[SafeMathML]
+   <dd><a href="https://w3c.github.io/mathml-docs/mathml-safe-list"><cite>MathML Safe List</cite></a>. URL: <a href="https://w3c.github.io/mathml-docs/mathml-safe-list">https://w3c.github.io/mathml-docs/mathml-safe-list</a>
+   <dt id="biblio-svg11">[SVG11]
+   <dd>Erik Dahlström; et al. <a href="https://www.w3.org/TR/SVG11/"><cite>Scalable Vector Graphics (SVG) 1.1 (Second Edition)</cite></a>. 16 August 2011. REC. URL: <a href="https://www.w3.org/TR/SVG11/">https://www.w3.org/TR/SVG11/</a>
+  </dl>
+  <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
+<pre class="idl highlight def"><c- b>enum</c-> <a href="#enumdef-sanitizerpresets"><code><c- g>SanitizerPresets</c-></code></a> { <a href="#dom-sanitizerpresets-default"><code><c- s>"default"</c-></code></a> };
+<c- b>dictionary</c-> <a href="#dictdef-sethtmloptions"><code><c- g>SetHTMLOptions</c-></code></a> {
+  (<a data-link-type="idl-name" href="#sanitizer"><c- n>Sanitizer</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#dictdef-sanitizerconfig"><c- n>SanitizerConfig</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#enumdef-sanitizerpresets"><c- n>SanitizerPresets</c-></a>) <a data-default="&quot;default&quot;" data-type="(Sanitizer or SanitizerConfig or SanitizerPresets)" href="#dom-sethtmloptions-sanitizer"><code><c- g>sanitizer</c-></code></a> = "default";
+};
+<c- b>dictionary</c-> <a href="#dictdef-sethtmlunsafeoptions"><code><c- g>SetHTMLUnsafeOptions</c-></code></a> {
+  (<a data-link-type="idl-name" href="#sanitizer"><c- n>Sanitizer</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#dictdef-sanitizerconfig"><c- n>SanitizerConfig</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#enumdef-sanitizerpresets"><c- n>SanitizerPresets</c-></a>) <a data-default="{}" data-type="(Sanitizer or SanitizerConfig or SanitizerPresets)" href="#dom-sethtmlunsafeoptions-sanitizer"><code><c- g>sanitizer</c-></code></a> = {};
+};
+
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <a href="#sanitizer"><code><c- g>Sanitizer</c-></code></a> {
+  <a class="idl-code" data-link-type="constructor" href="#dom-sanitizer-constructor"><c- g>constructor</c-></a>(<c- b>optional</c-> (<a data-link-type="idl-name" href="#dictdef-sanitizerconfig"><c- n>SanitizerConfig</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#enumdef-sanitizerpresets"><c- n>SanitizerPresets</c-></a>) <a href="#dom-sanitizer-sanitizer-configuration-configuration"><code><c- g>configuration</c-></code></a> = "default");
+
+  // Query configuration:
+  <a data-link-type="idl-name" href="#dictdef-sanitizerconfig"><c- n>SanitizerConfig</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-get"><c- g>get</c-></a>();
+
+  // Modify a Sanitizer’s lists and fields:
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-allowelement"><c- g>allowElement</c-></a>(<a data-link-type="idl-name" href="#typedefdef-sanitizerelementwithattributes"><c- n>SanitizerElementWithAttributes</c-></a> <a href="#dom-sanitizer-allowelement-element-element"><code><c- g>element</c-></code></a>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-removeelement"><c- g>removeElement</c-></a>(<a data-link-type="idl-name" href="#typedefdef-sanitizerelement"><c- n>SanitizerElement</c-></a> <a href="#dom-sanitizer-removeelement-element-element"><code><c- g>element</c-></code></a>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-replaceelementwithchildren"><c- g>replaceElementWithChildren</c-></a>(<a data-link-type="idl-name" href="#typedefdef-sanitizerelement"><c- n>SanitizerElement</c-></a> <a href="#dom-sanitizer-replaceelementwithchildren-element-element"><code><c- g>element</c-></code></a>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-allowattribute"><c- g>allowAttribute</c-></a>(<a data-link-type="idl-name" href="#typedefdef-sanitizerattribute"><c- n>SanitizerAttribute</c-></a> <a href="#dom-sanitizer-allowattribute-attribute-attribute"><code><c- g>attribute</c-></code></a>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-removeattribute"><c- g>removeAttribute</c-></a>(<a data-link-type="idl-name" href="#typedefdef-sanitizerattribute"><c- n>SanitizerAttribute</c-></a> <a href="#dom-sanitizer-removeattribute-attribute-attribute"><code><c- g>attribute</c-></code></a>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-setcomments"><c- g>setComments</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a href="#dom-sanitizer-setcomments-allow-allow"><code><c- g>allow</c-></code></a>);
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-setdataattributes"><c- g>setDataAttributes</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a href="#dom-sanitizer-setdataattributes-allow-allow"><code><c- g>allow</c-></code></a>);
+
+  // Remove markup that executes script.
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a class="idl-code" data-link-type="method" href="#dom-sanitizer-removeunsafe"><c- g>removeUnsafe</c-></a>();
+};
+
+<c- b>dictionary</c-> <a href="#dictdef-sanitizerelementnamespace"><code><c- g>SanitizerElementNamespace</c-></code></a> {
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a> <a data-type="DOMString" href="#dom-sanitizerelementnamespace-name"><code><c- g>name</c-></code></a>;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a>? <a data-default="&quot;http://www.w3.org/1999/xhtml&quot;" data-type="DOMString?" href="#dom-sanitizerelementnamespace-namespace"><code><c- g>_namespace</c-></code></a> = "http://www.w3.org/1999/xhtml";
+};
+
+// Used by "elements"
+<c- b>dictionary</c-> <a href="#dictdef-sanitizerelementnamespacewithattributes"><code><c- g>SanitizerElementNamespaceWithAttributes</c-></code></a> : <a data-link-type="idl-name" href="#dictdef-sanitizerelementnamespace"><c- n>SanitizerElementNamespace</c-></a> {
+  <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#typedefdef-sanitizerattribute"><c- n>SanitizerAttribute</c-></a>> <a data-type="sequence<SanitizerAttribute>" href="#dom-sanitizerelementnamespacewithattributes-attributes"><code><c- g>attributes</c-></code></a>;
+  <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#typedefdef-sanitizerattribute"><c- n>SanitizerAttribute</c-></a>> <a data-type="sequence<SanitizerAttribute>" href="#dom-sanitizerelementnamespacewithattributes-removeattributes"><code><c- g>removeAttributes</c-></code></a>;
+};
+
+<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#dictdef-sanitizerelementnamespace"><c- n>SanitizerElementNamespace</c-></a>) <a href="#typedefdef-sanitizerelement"><code><c- g>SanitizerElement</c-></code></a>;
+<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#dictdef-sanitizerelementnamespacewithattributes"><c- n>SanitizerElementNamespaceWithAttributes</c-></a>) <a href="#typedefdef-sanitizerelementwithattributes"><code><c- g>SanitizerElementWithAttributes</c-></code></a>;
+
+<c- b>dictionary</c-> <a href="#dictdef-sanitizerattributenamespace"><code><c- g>SanitizerAttributeNamespace</c-></code></a> {
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a> <a data-type="DOMString" href="#dom-sanitizerattributenamespace-name"><code><c- g>name</c-></code></a>;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a>? <a data-default="null" data-type="DOMString?" href="#dom-sanitizerattributenamespace-namespace"><code><c- g>_namespace</c-></code></a> = <c- b>null</c->;
+};
+<c- b>typedef</c-> (<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#dictdef-sanitizerattributenamespace"><c- n>SanitizerAttributeNamespace</c-></a>) <a href="#typedefdef-sanitizerattribute"><code><c- g>SanitizerAttribute</c-></code></a>;
+
+<c- b>dictionary</c-> <a href="#dictdef-sanitizerconfig"><code><c- g>SanitizerConfig</c-></code></a> {
+  <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#typedefdef-sanitizerelementwithattributes"><c- n>SanitizerElementWithAttributes</c-></a>> <a data-type="sequence<SanitizerElementWithAttributes>" href="#dom-sanitizerconfig-elements"><code><c- g>elements</c-></code></a>;
+  <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#typedefdef-sanitizerelement"><c- n>SanitizerElement</c-></a>> <a data-type="sequence<SanitizerElement>" href="#dom-sanitizerconfig-removeelements"><code><c- g>removeElements</c-></code></a>;
+  <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#typedefdef-sanitizerelement"><c- n>SanitizerElement</c-></a>> <a data-type="sequence<SanitizerElement>" href="#dom-sanitizerconfig-replacewithchildrenelements"><code><c- g>replaceWithChildrenElements</c-></code></a>;
+
+  <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#typedefdef-sanitizerattribute"><c- n>SanitizerAttribute</c-></a>> <a data-type="sequence<SanitizerAttribute>" href="#dom-sanitizerconfig-attributes"><code><c- g>attributes</c-></code></a>;
+  <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#typedefdef-sanitizerattribute"><c- n>SanitizerAttribute</c-></a>> <a data-type="sequence<SanitizerAttribute>" href="#dom-sanitizerconfig-removeattributes"><code><c- g>removeAttributes</c-></code></a>;
+
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a data-type="boolean" href="#dom-sanitizerconfig-comments"><code><c- g>comments</c-></code></a>;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-boolean"><c- b>boolean</c-></a> <a data-type="boolean" href="#dom-sanitizerconfig-dataattributes"><code><c- g>dataAttributes</c-></code></a>;
+};
+
+</pre>
+<script>/* Boilerplate: script-dom-helper */
+"use strict";
+function query(sel) { return document.querySelector(sel); }
+
+function queryAll(sel) { return [...document.querySelectorAll(sel)]; }
+
+function iter(obj) {
+	if(!obj) return [];
+	var it = obj[Symbol.iterator];
+	if(it) return it;
+	return Object.entries(obj);
+}
+
+function mk(tagname, attrs, ...children) {
+	const el = document.createElement(tagname);
+	for(const [k,v] of iter(attrs)) {
+		if(k.slice(0,3) == "_on") {
+			const eventName = k.slice(3);
+			el.addEventListener(eventName, v);
+		} else if(k[0] == "_") {
+			// property, not attribute
+			el[k.slice(1)] = v;
+		} else {
+			if(v === false || v == null) {
+        continue;
+      } else if(v === true) {
+        el.setAttribute(k, "");
+        continue;
+      } else {
+  			el.setAttribute(k, v);
+      }
+		}
+	}
+	append(el, children);
+	return el;
+}
+
+/* Create shortcuts for every known HTML element */
+[
+  "a",
+  "abbr",
+  "acronym",
+  "address",
+  "applet",
+  "area",
+  "article",
+  "aside",
+  "audio",
+  "b",
+  "base",
+  "basefont",
+  "bdo",
+  "big",
+  "blockquote",
+  "body",
+  "br",
+  "button",
+  "canvas",
+  "caption",
+  "center",
+  "cite",
+  "code",
+  "col",
+  "colgroup",
+  "datalist",
+  "dd",
+  "del",
+  "details",
+  "dfn",
+  "dialog",
+  "div",
+  "dl",
+  "dt",
+  "em",
+  "embed",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "font",
+  "footer",
+  "form",
+  "frame",
+  "frameset",
+  "head",
+  "header",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "hr",
+  "html",
+  "i",
+  "iframe",
+  "img",
+  "input",
+  "ins",
+  "kbd",
+  "label",
+  "legend",
+  "li",
+  "link",
+  "main",
+  "map",
+  "mark",
+  "meta",
+  "meter",
+  "nav",
+  "nobr",
+  "noscript",
+  "object",
+  "ol",
+  "optgroup",
+  "option",
+  "output",
+  "p",
+  "param",
+  "pre",
+  "progress",
+  "q",
+  "s",
+  "samp",
+  "script",
+  "section",
+  "select",
+  "small",
+  "source",
+  "span",
+  "strike",
+  "strong",
+  "style",
+  "sub",
+  "summary",
+  "sup",
+  "table",
+  "tbody",
+  "td",
+  "template",
+  "textarea",
+  "tfoot",
+  "th",
+  "thead",
+  "time",
+  "title",
+  "tr",
+  "u",
+  "ul",
+  "var",
+  "video",
+  "wbr",
+  "xmp",
+].forEach(tagname=>{
+	mk[tagname] = (...args) => mk(tagname, ...args);
+});
+
+function* nodesFromChildList(children) {
+	for(const child of children.flat(Infinity)) {
+		if(child instanceof Node) {
+			yield child;
+		} else {
+			yield new Text(child);
+		}
+	}
+}
+function append(el, ...children) {
+	for(const child of nodesFromChildList(children)) {
+		if(el instanceof Node) el.appendChild(child);
+		else el.push(child);
+	}
+	return el;
+}
+
+function insertAfter(el, ...children) {
+	for(const child of nodesFromChildList(children)) {
+		el.parentNode.insertBefore(child, el.nextSibling);
+	}
+	return el;
+}
+
+function clearContents(el) {
+	el.innerHTML = "";
+	return el;
+}
+
+function parseHTML(markup) {
+	if(markup.toLowerCase().trim().indexOf('<!doctype') === 0) {
+		const doc = document.implementation.createHTMLDocument("");
+		doc.documentElement.innerHTML = markup;
+		return doc;
+	} else {
+		const el = mk.template({});
+		el.innerHTML = markup;
+		return el.content;
+	}
+}</script>
+<script>/* Boilerplate: script-dfn-panel */
+"use strict";
+{
+let dfnPanelData = {
+"03afaf9c": {"dfnID":"03afaf9c","dfnText":"empty","external":true,"refSections":[{"refs":[{"id":"ref-for-list-empty"},{"id":"ref-for-list-empty\u2460"},{"id":"ref-for-list-empty\u2461"},{"id":"ref-for-list-empty\u2462"},{"id":"ref-for-list-empty\u2463"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-list-empty\u2464"}],"title":"3.2. Modify the Configuration"}],"url":"https://infra.spec.whatwg.org/#list-empty"},
+"0698d556": {"dfnID":"0698d556","dfnText":"string","external":true,"refSections":[{"refs":[{"id":"ref-for-string"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-string\u2460"},{"id":"ref-for-string\u2461"},{"id":"ref-for-string\u2462"}],"title":"3. Algorithms"}],"url":"https://infra.spec.whatwg.org/#string"},
+"0e0b900e": {"dfnID":"0e0b900e","dfnText":"remove","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-node-remove"},{"id":"ref-for-concept-node-remove\u2460"},{"id":"ref-for-concept-node-remove\u2461"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#concept-node-remove"},
+"0e6b2056": {"dfnID":"0e6b2056","dfnText":"set (for map)","external":true,"refSections":[{"refs":[{"id":"ref-for-map-set"},{"id":"ref-for-map-set\u2460"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-map-set\u2461"},{"id":"ref-for-map-set\u2462"},{"id":"ref-for-map-set\u2463"},{"id":"ref-for-map-set\u2464"},{"id":"ref-for-map-set\u2465"},{"id":"ref-for-map-set\u2466"},{"id":"ref-for-map-set\u2467"}],"title":"3.4. Canonicalize the Configuration"}],"url":"https://infra.spec.whatwg.org/#map-set"},
+"0e8de730": {"dfnID":"0e8de730","dfnText":"tuple","external":true,"refSections":[{"refs":[{"id":"ref-for-tuple"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#tuple"},
+"1243a891": {"dfnID":"1243a891","dfnText":"exist","external":true,"refSections":[{"refs":[{"id":"ref-for-map-exists"},{"id":"ref-for-map-exists\u2460"},{"id":"ref-for-map-exists\u2461"},{"id":"ref-for-map-exists\u2462"},{"id":"ref-for-map-exists\u2463"},{"id":"ref-for-map-exists\u2464"},{"id":"ref-for-map-exists\u2465"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-map-exists\u2466"},{"id":"ref-for-map-exists\u2467"},{"id":"ref-for-map-exists\u2468"},{"id":"ref-for-map-exists\u2460\u24ea"},{"id":"ref-for-map-exists\u2460\u2460"},{"id":"ref-for-map-exists\u2460\u2461"},{"id":"ref-for-map-exists\u2460\u2462"},{"id":"ref-for-map-exists\u2460\u2463"},{"id":"ref-for-map-exists\u2460\u2464"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-map-exists\u2460\u2465"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-map-exists\u2460\u2466"},{"id":"ref-for-map-exists\u2460\u2467"},{"id":"ref-for-map-exists\u2460\u2468"},{"id":"ref-for-map-exists\u2461\u24ea"},{"id":"ref-for-map-exists\u2461\u2460"},{"id":"ref-for-map-exists\u2461\u2461"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-map-exists\u2461\u2462"},{"id":"ref-for-map-exists\u2461\u2463"},{"id":"ref-for-map-exists\u2461\u2464"},{"id":"ref-for-map-exists\u2461\u2465"},{"id":"ref-for-map-exists\u2461\u2466"},{"id":"ref-for-map-exists\u2461\u2467"},{"id":"ref-for-map-exists\u2461\u2468"},{"id":"ref-for-map-exists\u2462\u24ea"},{"id":"ref-for-map-exists\u2462\u2460"},{"id":"ref-for-map-exists\u2462\u2461"},{"id":"ref-for-map-exists\u2462\u2462"},{"id":"ref-for-map-exists\u2462\u2463"},{"id":"ref-for-map-exists\u2462\u2464"},{"id":"ref-for-map-exists\u2462\u2465"},{"id":"ref-for-map-exists\u2462\u2466"},{"id":"ref-for-map-exists\u2462\u2467"},{"id":"ref-for-map-exists\u2462\u2468"},{"id":"ref-for-map-exists\u2463\u24ea"},{"id":"ref-for-map-exists\u2463\u2460"},{"id":"ref-for-map-exists\u2463\u2461"},{"id":"ref-for-map-exists\u2463\u2462"},{"id":"ref-for-map-exists\u2463\u2463"},{"id":"ref-for-map-exists\u2463\u2464"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-map-exists\u2463\u2465"},{"id":"ref-for-map-exists\u2463\u2466"},{"id":"ref-for-map-exists\u2463\u2467"},{"id":"ref-for-map-exists\u2463\u2468"},{"id":"ref-for-map-exists\u2464\u24ea"},{"id":"ref-for-map-exists\u2464\u2460"},{"id":"ref-for-map-exists\u2464\u2461"},{"id":"ref-for-map-exists\u2464\u2462"},{"id":"ref-for-map-exists\u2464\u2463"},{"id":"ref-for-map-exists\u2464\u2464"},{"id":"ref-for-map-exists\u2464\u2465"},{"id":"ref-for-map-exists\u2464\u2466"},{"id":"ref-for-map-exists\u2464\u2467"},{"id":"ref-for-map-exists\u2464\u2468"}],"title":"3.4. Canonicalize the Configuration"}],"url":"https://infra.spec.whatwg.org/#map-exists"},
+"15e48c39": {"dfnID":"15e48c39","dfnText":"set","external":true,"refSections":[{"refs":[{"id":"ref-for-ordered-set"},{"id":"ref-for-ordered-set\u2460"},{"id":"ref-for-ordered-set\u2461"},{"id":"ref-for-ordered-set\u2462"},{"id":"ref-for-ordered-set\u2463"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#ordered-set"},
+"16d07e10": {"dfnID":"16d07e10","dfnText":"for each","external":true,"refSections":[{"refs":[{"id":"ref-for-list-iterate"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-list-iterate\u2460"},{"id":"ref-for-list-iterate\u2461"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-list-iterate\u2462"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-list-iterate\u2463"},{"id":"ref-for-list-iterate\u2464"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-list-iterate\u2465"},{"id":"ref-for-list-iterate\u2466"},{"id":"ref-for-list-iterate\u2467"},{"id":"ref-for-list-iterate\u2468"},{"id":"ref-for-list-iterate\u2460\u24ea"},{"id":"ref-for-list-iterate\u2460\u2460"},{"id":"ref-for-list-iterate\u2460\u2461"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-list-iterate\u2460\u2462"},{"id":"ref-for-list-iterate\u2460\u2463"},{"id":"ref-for-list-iterate\u2460\u2464"},{"id":"ref-for-list-iterate\u2460\u2465"},{"id":"ref-for-list-iterate\u2460\u2466"},{"id":"ref-for-list-iterate\u2460\u2467"},{"id":"ref-for-list-iterate\u2460\u2468"}],"title":"3.4. Canonicalize the Configuration"},{"refs":[{"id":"ref-for-list-iterate\u2461\u24ea"},{"id":"ref-for-list-iterate\u2461\u2460"},{"id":"ref-for-list-iterate\u2461\u2461"},{"id":"ref-for-list-iterate\u2461\u2462"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#list-iterate"},
+"1a897bae": {"dfnID":"1a897bae","dfnText":"Get Trusted Type compliant string","external":true,"refSections":[{"refs":[{"id":"ref-for-abstract-opdef-get-trusted-type-compliant-string"},{"id":"ref-for-abstract-opdef-get-trusted-type-compliant-string\u2460"},{"id":"ref-for-abstract-opdef-get-trusted-type-compliant-string\u2461"}],"title":"2.1. Sanitizer API"}],"url":"https://w3c.github.io/trusted-types/dist/spec/#abstract-opdef-get-trusted-type-compliant-string"},
+"1cd7ff31": {"dfnID":"1cd7ff31","dfnText":"ShadowRoot","external":true,"refSections":[{"refs":[{"id":"ref-for-shadowroot"}],"title":"1.2. API Summary"},{"refs":[{"id":"ref-for-shadowroot\u2460"},{"id":"ref-for-shadowroot\u2461"},{"id":"ref-for-shadowroot\u2462"},{"id":"ref-for-shadowroot\u2463"}],"title":"2.1. Sanitizer API"}],"url":"https://dom.spec.whatwg.org/#shadowroot"},
+"296f3551": {"dfnID":"296f3551","dfnText":"Element","external":true,"refSections":[{"refs":[{"id":"ref-for-element"}],"title":"1. Introduction"},{"refs":[{"id":"ref-for-element\u2460"}],"title":"1.2. API Summary"},{"refs":[{"id":"ref-for-element\u2461"},{"id":"ref-for-element\u2462"},{"id":"ref-for-element\u2463"},{"id":"ref-for-element\u2464"}],"title":"2.1. Sanitizer API"},{"refs":[{"id":"ref-for-element\u2465"},{"id":"ref-for-element\u2466"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-element\u2467"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#element"},
+"35feaa5b": {"dfnID":"35feaa5b","dfnText":"superset","external":true,"refSections":[{"refs":[{"id":"ref-for-set-superset"},{"id":"ref-for-set-superset\u2460"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#set-superset"},
+"36858240": {"dfnID":"36858240","dfnText":"boolean","external":true,"refSections":[{"refs":[{"id":"ref-for-boolean"},{"id":"ref-for-boolean\u2460"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-boolean\u2461"},{"id":"ref-for-boolean\u2462"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-boolean\u2463"},{"id":"ref-for-boolean\u2464"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-boolean\u2465"}],"title":"3.3. Set the Configuration"},{"refs":[{"id":"ref-for-boolean\u2466"}],"title":"3.4. Canonicalize the Configuration"},{"refs":[{"id":"ref-for-boolean\u2467"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#boolean"},
+"37e32f12": {"dfnID":"37e32f12","dfnText":"report a warning to the console","external":true,"refSections":[{"refs":[{"id":"ref-for-report-a-warning-to-the-console"}],"title":"3.2. Modify the Configuration"}],"url":"https://console.spec.whatwg.org/#report-a-warning-to-the-console"},
+"384bdca4": {"dfnID":"384bdca4","dfnText":"custom data attribute","external":true,"refSections":[{"refs":[{"id":"ref-for-custom-data-attribute"},{"id":"ref-for-custom-data-attribute\u2460"},{"id":"ref-for-custom-data-attribute\u2461"},{"id":"ref-for-custom-data-attribute\u2462"},{"id":"ref-for-custom-data-attribute\u2463"},{"id":"ref-for-custom-data-attribute\u2464"},{"id":"ref-for-custom-data-attribute\u2465"},{"id":"ref-for-custom-data-attribute\u2466"},{"id":"ref-for-custom-data-attribute\u2467"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-custom-data-attribute\u2468"},{"id":"ref-for-custom-data-attribute\u2460\u24ea"},{"id":"ref-for-custom-data-attribute\u2460\u2460"},{"id":"ref-for-custom-data-attribute\u2460\u2461"}],"title":"3.2. Modify the Configuration"}],"url":"https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute"},
+"3a711be7": {"dfnID":"3a711be7","dfnText":"scheme","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-url-scheme"}],"title":"3.1. Sanitize"}],"url":"https://url.spec.whatwg.org/#concept-url-scheme"},
+"3e6df8da": {"dfnID":"3e6df8da","dfnText":"get an attribute value","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-element-attributes-get-value"},{"id":"ref-for-concept-element-attributes-get-value\u2460"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#concept-element-attributes-get-value"},
+"3e7fc2a2": {"dfnID":"3e7fc2a2","dfnText":"template contents","external":true,"refSections":[{"refs":[{"id":"ref-for-template-contents"},{"id":"ref-for-template-contents\u2460"}],"title":"2.1. Sanitizer API"},{"refs":[{"id":"ref-for-template-contents\u2461"}],"title":"3.1. Sanitize"}],"url":"https://html.spec.whatwg.org/multipage/scripting.html#template-contents"},
+"3f23ec71": {"dfnID":"3f23ec71","dfnText":"content type","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-document-content-type"},{"id":"ref-for-concept-document-content-type\u2460"}],"title":"2.1. Sanitizer API"}],"url":"https://dom.spec.whatwg.org/#concept-document-content-type"},
+"4013a022": {"dfnID":"4013a022","dfnText":"this","external":true,"refSections":[{"refs":[{"id":"ref-for-this"},{"id":"ref-for-this\u2460"},{"id":"ref-for-this\u2461"},{"id":"ref-for-this\u2462"},{"id":"ref-for-this\u2463"},{"id":"ref-for-this\u2464"},{"id":"ref-for-this\u2465"},{"id":"ref-for-this\u2466"},{"id":"ref-for-this\u2467"},{"id":"ref-for-this\u2468"},{"id":"ref-for-this\u2460\u24ea"},{"id":"ref-for-this\u2460\u2460"},{"id":"ref-for-this\u2460\u2461"},{"id":"ref-for-this\u2460\u2462"},{"id":"ref-for-this\u2460\u2463"}],"title":"2.1. Sanitizer API"},{"refs":[{"id":"ref-for-this\u2460\u2464"},{"id":"ref-for-this\u2460\u2465"},{"id":"ref-for-this\u2460\u2466"},{"id":"ref-for-this\u2460\u2467"},{"id":"ref-for-this\u2460\u2468"},{"id":"ref-for-this\u2461\u24ea"},{"id":"ref-for-this\u2461\u2460"},{"id":"ref-for-this\u2461\u2461"},{"id":"ref-for-this\u2461\u2462"},{"id":"ref-for-this\u2461\u2463"},{"id":"ref-for-this\u2461\u2464"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"https://webidl.spec.whatwg.org/#this"},
+"402ed79d": {"dfnID":"402ed79d","dfnText":"CEReactions","external":true,"refSections":[{"refs":[{"id":"ref-for-cereactions"},{"id":"ref-for-cereactions\u2460"},{"id":"ref-for-cereactions\u2461"},{"id":"ref-for-cereactions\u2462"}],"title":"2.1. Sanitizer API"}],"url":"https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions"},
+"4135591f": {"dfnID":"4135591f","dfnText":"code unit less than","external":true,"refSections":[{"refs":[{"id":"ref-for-code-unit-less-than"},{"id":"ref-for-code-unit-less-than\u2460"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#code-unit-less-than"},
+"414d5b08": {"dfnID":"414d5b08","dfnText":"remove an attribute","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-element-attributes-remove"},{"id":"ref-for-concept-element-attributes-remove\u2460"},{"id":"ref-for-concept-element-attributes-remove\u2461"},{"id":"ref-for-concept-element-attributes-remove\u2462"},{"id":"ref-for-concept-element-attributes-remove\u2463"},{"id":"ref-for-concept-element-attributes-remove\u2464"},{"id":"ref-for-concept-element-attributes-remove\u2465"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#concept-element-attributes-remove"},
+"4943545e": {"dfnID":"4943545e","dfnText":"code unit prefix","external":true,"refSections":[{"refs":[{"id":"ref-for-code-unit-prefix"}],"title":"3.1. Sanitize"}],"url":"https://infra.spec.whatwg.org/#code-unit-prefix"},
+"49a2843d": {"dfnID":"49a2843d","dfnText":"DocumentFragment","external":true,"refSections":[{"refs":[{"id":"ref-for-documentfragment"},{"id":"ref-for-documentfragment\u2460"}],"title":"3. Algorithms"}],"url":"https://dom.spec.whatwg.org/#documentfragment"},
+"4e92bc80": {"dfnID":"4e92bc80","dfnText":"get the keys","external":true,"refSections":[{"refs":[{"id":"ref-for-map-getting-the-keys"}],"title":"3.2. Modify the Configuration"}],"url":"https://infra.spec.whatwg.org/#map-getting-the-keys"},
+"4fd7ca14": {"dfnID":"4fd7ca14","dfnText":"replace all","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-node-replace-all"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-concept-node-replace-all\u2460"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#concept-node-replace-all"},
+"5216e1a0": {"dfnID":"5216e1a0","dfnText":"node document","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-node-document"},{"id":"ref-for-concept-node-document\u2460"}],"title":"3. Algorithms"}],"url":"https://dom.spec.whatwg.org/#concept-node-document"},
+"53275e46": {"dfnID":"53275e46","dfnText":"append (for list)","external":true,"refSections":[{"refs":[{"id":"ref-for-list-append"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-list-append\u2460"},{"id":"ref-for-list-append\u2461"},{"id":"ref-for-list-append\u2462"},{"id":"ref-for-list-append\u2463"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-list-append\u2464"},{"id":"ref-for-list-append\u2465"},{"id":"ref-for-list-append\u2466"},{"id":"ref-for-list-append\u2467"},{"id":"ref-for-list-append\u2468"},{"id":"ref-for-list-append\u2460\u24ea"},{"id":"ref-for-list-append\u2460\u2460"}],"title":"3.4. Canonicalize the Configuration"},{"refs":[{"id":"ref-for-list-append\u2460\u2461"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#list-append"},
+"5372cca8": {"dfnID":"5372cca8","dfnText":"boolean","external":true,"refSections":[{"refs":[{"id":"ref-for-idl-boolean"},{"id":"ref-for-idl-boolean\u2460"},{"id":"ref-for-idl-boolean\u2461"},{"id":"ref-for-idl-boolean\u2462"},{"id":"ref-for-idl-boolean\u2463"},{"id":"ref-for-idl-boolean\u2464"},{"id":"ref-for-idl-boolean\u2465"},{"id":"ref-for-idl-boolean\u2466"},{"id":"ref-for-idl-boolean\u2467"},{"id":"ref-for-idl-boolean\u2468"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-idl-boolean\u2460\u24ea"},{"id":"ref-for-idl-boolean\u2460\u2460"}],"title":"2.3. The Configuration Dictionary"}],"url":"https://webidl.spec.whatwg.org/#idl-boolean"},
+"58a8f724": {"dfnID":"58a8f724","dfnText":"shadow host","external":true,"refSections":[{"refs":[{"id":"ref-for-element-shadow-host"}],"title":"2.1. Sanitizer API"},{"refs":[{"id":"ref-for-element-shadow-host\u2460"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#element-shadow-host"},
+"597088f0": {"dfnID":"597088f0","dfnText":"Text","external":true,"refSections":[{"refs":[{"id":"ref-for-text"},{"id":"ref-for-text\u2460"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#text"},
+"5c7fa56b": {"dfnID":"5c7fa56b","dfnText":"subset","external":true,"refSections":[{"refs":[{"id":"ref-for-set-subset"}],"title":"2.4. Configuration Invariants"}],"url":"https://infra.spec.whatwg.org/#set-subset"},
+"5c8f824f": {"dfnID":"5c8f824f","dfnText":"allow declarative shadow roots","external":true,"refSections":[{"refs":[{"id":"ref-for-document-allow-declarative-shadow-roots"},{"id":"ref-for-document-allow-declarative-shadow-roots\u2460"}],"title":"2.1. Sanitizer API"}],"url":"https://dom.spec.whatwg.org/#document-allow-declarative-shadow-roots"},
+"5ecc2082": {"dfnID":"5ecc2082","dfnText":"sort in ascending order","external":true,"refSections":[{"refs":[{"id":"ref-for-list-sort-in-ascending-order"},{"id":"ref-for-list-sort-in-ascending-order\u2460"},{"id":"ref-for-list-sort-in-ascending-order\u2461"},{"id":"ref-for-list-sort-in-ascending-order\u2462"},{"id":"ref-for-list-sort-in-ascending-order\u2463"},{"id":"ref-for-list-sort-in-ascending-order\u2464"},{"id":"ref-for-list-sort-in-ascending-order\u2465"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"https://infra.spec.whatwg.org/#list-sort-in-ascending-order"},
+"5f90bbfb": {"dfnID":"5f90bbfb","dfnText":"undefined","external":true,"refSections":[{"refs":[{"id":"ref-for-idl-undefined"},{"id":"ref-for-idl-undefined\u2460"},{"id":"ref-for-idl-undefined\u2461"},{"id":"ref-for-idl-undefined\u2462"}],"title":"2.1. Sanitizer API"}],"url":"https://webidl.spec.whatwg.org/#idl-undefined"},
+"649608b9": {"dfnID":"649608b9","dfnText":"list","external":true,"refSections":[{"refs":[{"id":"ref-for-list"},{"id":"ref-for-list\u2460"},{"id":"ref-for-list\u2461"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#list"},
+"692595fe": {"dfnID":"692595fe","dfnText":"ordered set","external":true,"refSections":[{"refs":[{"id":"ref-for-ordered-set"},{"id":"ref-for-ordered-set\u2460"},{"id":"ref-for-ordered-set\u2461"},{"id":"ref-for-ordered-set\u2462"},{"id":"ref-for-ordered-set\u2463"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#ordered-set"},
+"6d19ac93": {"dfnID":"6d19ac93","dfnText":"user agent","external":true,"refSections":[{"refs":[{"id":"ref-for-user-agent"}],"title":"3.6. Builtins"}],"url":"https://infra.spec.whatwg.org/#user-agent"},
+"746cc3ba": {"dfnID":"746cc3ba","dfnText":"namespace (for Element)","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-element-namespace"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-concept-element-namespace\u2460"},{"id":"ref-for-concept-element-namespace\u2461"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#concept-element-namespace"},
+"769996cd": {"dfnID":"769996cd","dfnText":"parse HTML from a string","external":true,"refSections":[{"refs":[{"id":"ref-for-parse-html-from-a-string"},{"id":"ref-for-parse-html-from-a-string\u2460"}],"title":"2.1. Sanitizer API"}],"url":"https://html.spec.whatwg.org/#parse-html-from-a-string"},
+"77211728": {"dfnID":"77211728","dfnText":"attribute list","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-element-attribute"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#concept-element-attribute"},
+"77b4c09a": {"dfnID":"77b4c09a","dfnText":"assert","external":true,"refSections":[{"refs":[{"id":"ref-for-assert"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-assert\u2460"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-assert\u2461"},{"id":"ref-for-assert\u2462"},{"id":"ref-for-assert\u2463"},{"id":"ref-for-assert\u2464"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-assert\u2465"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-assert\u2466"},{"id":"ref-for-assert\u2467"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-assert\u2468"},{"id":"ref-for-assert\u2460\u24ea"}],"title":"3.4. Canonicalize the Configuration"}],"url":"https://infra.spec.whatwg.org/#assert"},
+"7a87d819": {"dfnID":"7a87d819","dfnText":"is","external":true,"refSections":[{"refs":[{"id":"ref-for-string-is"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-string-is\u2460"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-string-is\u2461"},{"id":"ref-for-string-is\u2462"},{"id":"ref-for-string-is\u2463"},{"id":"ref-for-string-is\u2464"},{"id":"ref-for-string-is\u2465"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-string-is\u2466"},{"id":"ref-for-string-is\u2467"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-string-is\u2468"},{"id":"ref-for-string-is\u2460\u24ea"},{"id":"ref-for-string-is\u2460\u2460"},{"id":"ref-for-string-is\u2460\u2461"},{"id":"ref-for-string-is\u2460\u2462"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#string-is"},
+"802b0fdd": {"dfnID":"802b0fdd","dfnText":"value","external":true,"refSections":[{"refs":[{"id":"ref-for-map-value"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#map-value"},
+"82ca3efc": {"dfnID":"82ca3efc","dfnText":"TypeError","external":true,"refSections":[{"refs":[{"id":"ref-for-exceptiondef-typeerror"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-exceptiondef-typeerror\u2460"}],"title":"3. Algorithms"}],"url":"https://webidl.spec.whatwg.org/#exceptiondef-typeerror"},
+"83ca4a87": {"dfnID":"83ca4a87","dfnText":"local name (for Element)","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-element-local-name"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-concept-element-local-name\u2460"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#concept-element-local-name"},
+"84b454ff": {"dfnID":"84b454ff","dfnText":"ordered map","external":true,"refSections":[{"refs":[{"id":"ref-for-ordered-map"},{"id":"ref-for-ordered-map\u2460"},{"id":"ref-for-ordered-map\u2461"},{"id":"ref-for-ordered-map\u2462"},{"id":"ref-for-ordered-map\u2463"},{"id":"ref-for-ordered-map\u2464"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#ordered-map"},
+"85394472": {"dfnID":"85394472","dfnText":"Document","external":true,"refSections":[{"refs":[{"id":"ref-for-document"}],"title":"1.2. API Summary"},{"refs":[{"id":"ref-for-document\u2460"},{"id":"ref-for-document\u2461"},{"id":"ref-for-document\u2462"},{"id":"ref-for-document\u2463"},{"id":"ref-for-document\u2464"},{"id":"ref-for-document\u2465"},{"id":"ref-for-document\u2466"}],"title":"2.1. Sanitizer API"}],"url":"https://dom.spec.whatwg.org/#document"},
+"85a289c7": {"dfnID":"85a289c7","dfnText":"SVG namespace","external":true,"refSections":[{"refs":[{"id":"ref-for-svg-namespace"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-svg-namespace\u2460"},{"id":"ref-for-svg-namespace\u2461"},{"id":"ref-for-svg-namespace\u2462"},{"id":"ref-for-svg-namespace\u2463"},{"id":"ref-for-svg-namespace\u2464"},{"id":"ref-for-svg-namespace\u2465"}],"title":"3.6. Builtins"}],"url":"https://infra.spec.whatwg.org/#svg-namespace"},
+"8855a9aa": {"dfnID":"8855a9aa","dfnText":"DOMString","external":true,"refSections":[{"refs":[{"id":"ref-for-idl-DOMString"},{"id":"ref-for-idl-DOMString\u2460"},{"id":"ref-for-idl-DOMString\u2461"},{"id":"ref-for-idl-DOMString\u2462"},{"id":"ref-for-idl-DOMString\u2463"},{"id":"ref-for-idl-DOMString\u2464"},{"id":"ref-for-idl-DOMString\u2465"}],"title":"2.1. Sanitizer API"},{"refs":[{"id":"ref-for-idl-DOMString\u2466"},{"id":"ref-for-idl-DOMString\u2467"},{"id":"ref-for-idl-DOMString\u2468"},{"id":"ref-for-idl-DOMString\u2460\u24ea"},{"id":"ref-for-idl-DOMString\u2460\u2460"},{"id":"ref-for-idl-DOMString\u2460\u2461"},{"id":"ref-for-idl-DOMString\u2460\u2462"}],"title":"2.3. The Configuration Dictionary"},{"refs":[{"id":"ref-for-idl-DOMString\u2460\u2463"},{"id":"ref-for-idl-DOMString\u2460\u2464"}],"title":"3.4. Canonicalize the Configuration"}],"url":"https://webidl.spec.whatwg.org/#idl-DOMString"},
+"889e932f": {"dfnID":"889e932f","dfnText":"Exposed","external":true,"refSections":[{"refs":[{"id":"ref-for-Exposed"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"https://webidl.spec.whatwg.org/#Exposed"},
+"8958b003": {"dfnID":"8958b003","dfnText":"entry","external":true,"refSections":[{"refs":[{"id":"ref-for-map-entry"},{"id":"ref-for-map-entry\u2460"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#map-entry"},
+"9011c821": {"dfnID":"9011c821","dfnText":"DocumentType","external":true,"refSections":[{"refs":[{"id":"ref-for-documenttype"},{"id":"ref-for-documenttype\u2460"},{"id":"ref-for-documenttype\u2461"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#documenttype"},
+"92b2d7da": {"dfnID":"92b2d7da","dfnText":"children","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-tree-child"},{"id":"ref-for-concept-tree-child\u2460"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#concept-tree-child"},
+"93ded71a": {"dfnID":"93ded71a","dfnText":"global attribute","external":true,"refSections":[{"refs":[{"id":"ref-for-global-attributes"}],"title":"2.4. Configuration Invariants"}],"url":"https://html.spec.whatwg.org/multipage/dom.html#global-attributes"},
+"96c16e60": {"dfnID":"96c16e60","dfnText":"Node","external":true,"refSections":[{"refs":[{"id":"ref-for-node"}],"title":"1.2. API Summary"}],"url":"https://dom.spec.whatwg.org/#node"},
+"99c988d6": {"dfnID":"99c988d6","dfnText":"remove","external":true,"refSections":[{"refs":[{"id":"ref-for-list-remove"},{"id":"ref-for-list-remove\u2460"},{"id":"ref-for-list-remove\u2461"},{"id":"ref-for-list-remove\u2462"},{"id":"ref-for-list-remove\u2463"},{"id":"ref-for-list-remove\u2464"},{"id":"ref-for-list-remove\u2465"},{"id":"ref-for-list-remove\u2466"},{"id":"ref-for-list-remove\u2467"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-list-remove\u2468"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#list-remove"},
+"9cce47fd": {"dfnID":"9cce47fd","dfnText":"sequence","external":true,"refSections":[{"refs":[{"id":"ref-for-idl-sequence"},{"id":"ref-for-idl-sequence\u2460"},{"id":"ref-for-idl-sequence\u2461"},{"id":"ref-for-idl-sequence\u2462"},{"id":"ref-for-idl-sequence\u2463"},{"id":"ref-for-idl-sequence\u2464"},{"id":"ref-for-idl-sequence\u2465"}],"title":"2.3. The Configuration Dictionary"}],"url":"https://webidl.spec.whatwg.org/#idl-sequence"},
+"9ed8b710": {"dfnID":"9ed8b710","dfnText":"basic URL parser","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-basic-url-parser"}],"title":"3.1. Sanitize"}],"url":"https://url.spec.whatwg.org/#concept-basic-url-parser"},
+"a0647283": {"dfnID":"a0647283","dfnText":"Comment","external":true,"refSections":[{"refs":[{"id":"ref-for-comment"},{"id":"ref-for-comment\u2460"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#comment"},
+"a1797ffb": {"dfnID":"a1797ffb","dfnText":"difference","external":true,"refSections":[{"refs":[{"id":"ref-for-set-difference"},{"id":"ref-for-set-difference\u2460"},{"id":"ref-for-set-difference\u2461"}],"title":"3.2. Modify the Configuration"}],"url":"https://infra.spec.whatwg.org/#set-difference"},
+"a326add7": {"dfnID":"a326add7","dfnText":"contain (for map)","external":true,"refSections":[{"refs":[{"id":"ref-for-map-exists"},{"id":"ref-for-map-exists\u2460"},{"id":"ref-for-map-exists\u2461"},{"id":"ref-for-map-exists\u2462"},{"id":"ref-for-map-exists\u2463"},{"id":"ref-for-map-exists\u2464"},{"id":"ref-for-map-exists\u2465"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-map-exists\u2466"},{"id":"ref-for-map-exists\u2467"},{"id":"ref-for-map-exists\u2468"},{"id":"ref-for-map-exists\u2460\u24ea"},{"id":"ref-for-map-exists\u2460\u2460"},{"id":"ref-for-map-exists\u2460\u2461"},{"id":"ref-for-map-exists\u2460\u2462"},{"id":"ref-for-map-exists\u2460\u2463"},{"id":"ref-for-map-exists\u2460\u2464"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-map-exists\u2460\u2465"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-map-exists\u2460\u2466"},{"id":"ref-for-map-exists\u2460\u2467"},{"id":"ref-for-map-exists\u2460\u2468"},{"id":"ref-for-map-exists\u2461\u24ea"},{"id":"ref-for-map-exists\u2461\u2460"},{"id":"ref-for-map-exists\u2461\u2461"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-map-exists\u2461\u2462"},{"id":"ref-for-map-exists\u2461\u2463"},{"id":"ref-for-map-exists\u2461\u2464"},{"id":"ref-for-map-exists\u2461\u2465"},{"id":"ref-for-map-exists\u2461\u2466"},{"id":"ref-for-map-exists\u2461\u2467"},{"id":"ref-for-map-exists\u2461\u2468"},{"id":"ref-for-map-exists\u2462\u24ea"},{"id":"ref-for-map-exists\u2462\u2460"},{"id":"ref-for-map-exists\u2462\u2461"},{"id":"ref-for-map-exists\u2462\u2462"},{"id":"ref-for-map-exists\u2462\u2463"},{"id":"ref-for-map-exists\u2462\u2464"},{"id":"ref-for-map-exists\u2462\u2465"},{"id":"ref-for-map-exists\u2462\u2466"},{"id":"ref-for-map-exists\u2462\u2467"},{"id":"ref-for-map-exists\u2462\u2468"},{"id":"ref-for-map-exists\u2463\u24ea"},{"id":"ref-for-map-exists\u2463\u2460"},{"id":"ref-for-map-exists\u2463\u2461"},{"id":"ref-for-map-exists\u2463\u2462"},{"id":"ref-for-map-exists\u2463\u2463"},{"id":"ref-for-map-exists\u2463\u2464"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-map-exists\u2463\u2465"},{"id":"ref-for-map-exists\u2463\u2466"},{"id":"ref-for-map-exists\u2463\u2467"},{"id":"ref-for-map-exists\u2463\u2468"},{"id":"ref-for-map-exists\u2464\u24ea"},{"id":"ref-for-map-exists\u2464\u2460"},{"id":"ref-for-map-exists\u2464\u2461"},{"id":"ref-for-map-exists\u2464\u2462"},{"id":"ref-for-map-exists\u2464\u2463"},{"id":"ref-for-map-exists\u2464\u2464"},{"id":"ref-for-map-exists\u2464\u2465"},{"id":"ref-for-map-exists\u2464\u2466"},{"id":"ref-for-map-exists\u2464\u2467"},{"id":"ref-for-map-exists\u2464\u2468"}],"title":"3.4. Canonicalize the Configuration"}],"url":"https://infra.spec.whatwg.org/#map-exists"},
+"a32c65d4": {"dfnID":"a32c65d4","dfnText":"implements","external":true,"refSections":[{"refs":[{"id":"ref-for-implements"},{"id":"ref-for-implements\u2460"},{"id":"ref-for-implements\u2461"},{"id":"ref-for-implements\u2462"}],"title":"3.1. Sanitize"}],"url":"https://webidl.spec.whatwg.org/#implements"},
+"a3b18719": {"dfnID":"a3b18719","dfnText":"append (for set)","external":true,"refSections":[{"refs":[{"id":"ref-for-set-append"},{"id":"ref-for-set-append\u2460"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#set-append"},
+"ae8def21": {"dfnID":"ae8def21","dfnText":"contain (for list)","external":true,"refSections":[{"refs":[{"id":"ref-for-list-contain"},{"id":"ref-for-list-contain\u2460"},{"id":"ref-for-list-contain\u2461"},{"id":"ref-for-list-contain\u2462"},{"id":"ref-for-list-contain\u2463"},{"id":"ref-for-list-contain\u2464"},{"id":"ref-for-list-contain\u2465"},{"id":"ref-for-list-contain\u2466"},{"id":"ref-for-list-contain\u2467"}],"title":"3.2. Modify the Configuration"}],"url":"https://infra.spec.whatwg.org/#list-contain"},
+"b3955a25": {"dfnID":"b3955a25","dfnText":"namespace (for Attr)","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-attribute-namespace"},{"id":"ref-for-concept-attribute-namespace\u2460"},{"id":"ref-for-concept-attribute-namespace\u2461"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#concept-attribute-namespace"},
+"b4cfa5ce": {"dfnID":"b4cfa5ce","dfnText":"throw","external":true,"refSections":[{"refs":[{"id":"ref-for-dfn-throw"}],"title":"3. Algorithms"}],"url":"https://webidl.spec.whatwg.org/#dfn-throw"},
+"b815ad04": {"dfnID":"b815ad04","dfnText":"parseFromString(string, type)","external":true,"refSections":[{"refs":[{"id":"ref-for-dom-domparser-parsefromstring"}],"title":"1.2. API Summary"}],"url":"https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring"},
+"bdec671a": {"dfnID":"bdec671a","dfnText":"TrustedHTML","external":true,"refSections":[{"refs":[{"id":"ref-for-trustedhtml"},{"id":"ref-for-trustedhtml\u2460"},{"id":"ref-for-trustedhtml\u2461"},{"id":"ref-for-trustedhtml\u2462"},{"id":"ref-for-trustedhtml\u2463"},{"id":"ref-for-trustedhtml\u2464"}],"title":"2.1. Sanitizer API"}],"url":"https://w3c.github.io/trusted-types/dist/spec/#trustedhtml"},
+"bec98d30": {"dfnID":"bec98d30","dfnText":"dictionary","external":true,"refSections":[{"refs":[{"id":"ref-for-dfn-dictionary"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-dfn-dictionary\u2460"},{"id":"ref-for-dfn-dictionary\u2461"},{"id":"ref-for-dfn-dictionary\u2462"},{"id":"ref-for-dfn-dictionary\u2463"},{"id":"ref-for-dfn-dictionary\u2464"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-dfn-dictionary\u2465"}],"title":"3.3. Set the Configuration"},{"refs":[{"id":"ref-for-dfn-dictionary\u2466"},{"id":"ref-for-dfn-dictionary\u2467"},{"id":"ref-for-dfn-dictionary\u2468"}],"title":"3.4. Canonicalize the Configuration"}],"url":"https://webidl.spec.whatwg.org/#dfn-dictionary"},
+"boolean-not": {"dfnID":"boolean-not","dfnText":"not","external":false,"refSections":[{"refs":[{"id":"ref-for-boolean-not"}],"title":"3. Algorithms"}],"url":"#boolean-not"},
+"built-in-animating-url-attributes-list": {"dfnID":"built-in-animating-url-attributes-list","dfnText":"built-in animating URL attributes list","external":false,"refSections":[{"refs":[{"id":"ref-for-built-in-animating-url-attributes-list"},{"id":"ref-for-built-in-animating-url-attributes-list\u2460"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-built-in-animating-url-attributes-list\u2461"}],"title":"3.6. Builtins"}],"url":"#built-in-animating-url-attributes-list"},
+"built-in-navigating-url-attributes-list": {"dfnID":"built-in-navigating-url-attributes-list","dfnText":"built-in navigating URL attributes list","external":false,"refSections":[{"refs":[{"id":"ref-for-built-in-navigating-url-attributes-list"},{"id":"ref-for-built-in-navigating-url-attributes-list\u2460"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-built-in-navigating-url-attributes-list\u2461"}],"title":"3.6. Builtins"}],"url":"#built-in-navigating-url-attributes-list"},
+"built-in-safe-baseline-configuration": {"dfnID":"built-in-safe-baseline-configuration","dfnText":"built-in safe baseline configuration","external":false,"refSections":[{"refs":[{"id":"ref-for-built-in-safe-baseline-configuration"},{"id":"ref-for-built-in-safe-baseline-configuration\u2460"},{"id":"ref-for-built-in-safe-baseline-configuration\u2461"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-built-in-safe-baseline-configuration\u2462"}],"title":"3.6. Builtins"}],"url":"#built-in-safe-baseline-configuration"},
+"built-in-safe-default-configuration": {"dfnID":"built-in-safe-default-configuration","dfnText":"built-in safe default configuration","external":false,"refSections":[{"refs":[{"id":"ref-for-built-in-safe-default-configuration"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-built-in-safe-default-configuration\u2460"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-built-in-safe-default-configuration\u2461"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-built-in-safe-default-configuration\u2462"}],"title":"3.6. Builtins"}],"url":"#built-in-safe-default-configuration"},
+"canonicalize-a-sanitizer-attribute": {"dfnID":"canonicalize-a-sanitizer-attribute","dfnText":"canonicalize a sanitizer attribute","external":false,"refSections":[{"refs":[{"id":"ref-for-canonicalize-a-sanitizer-attribute"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-canonicalize-a-sanitizer-attribute\u2460"},{"id":"ref-for-canonicalize-a-sanitizer-attribute\u2461"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-canonicalize-a-sanitizer-attribute\u2462"},{"id":"ref-for-canonicalize-a-sanitizer-attribute\u2463"},{"id":"ref-for-canonicalize-a-sanitizer-attribute\u2464"},{"id":"ref-for-canonicalize-a-sanitizer-attribute\u2465"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#canonicalize-a-sanitizer-attribute"},
+"canonicalize-a-sanitizer-element": {"dfnID":"canonicalize-a-sanitizer-element","dfnText":"canonicalize a sanitizer element","external":false,"refSections":[{"refs":[{"id":"ref-for-canonicalize-a-sanitizer-element"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-canonicalize-a-sanitizer-element\u2460"},{"id":"ref-for-canonicalize-a-sanitizer-element\u2461"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-canonicalize-a-sanitizer-element\u2462"},{"id":"ref-for-canonicalize-a-sanitizer-element\u2463"},{"id":"ref-for-canonicalize-a-sanitizer-element\u2464"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#canonicalize-a-sanitizer-element"},
+"canonicalize-a-sanitizer-element-with-attributes": {"dfnID":"canonicalize-a-sanitizer-element-with-attributes","dfnText":"canonicalize a sanitizer element with attributes","external":false,"refSections":[{"refs":[{"id":"ref-for-canonicalize-a-sanitizer-element-with-attributes"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-canonicalize-a-sanitizer-element-with-attributes\u2460"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#canonicalize-a-sanitizer-element-with-attributes"},
+"canonicalize-a-sanitizer-name": {"dfnID":"canonicalize-a-sanitizer-name","dfnText":"canonicalize a sanitizer name","external":false,"refSections":[{"refs":[{"id":"ref-for-canonicalize-a-sanitizer-name"},{"id":"ref-for-canonicalize-a-sanitizer-name\u2460"}],"title":"3.4. Canonicalize the Configuration"},{"refs":[{"id":"ref-for-canonicalize-a-sanitizer-name\u2461"},{"id":"ref-for-canonicalize-a-sanitizer-name\u2462"},{"id":"ref-for-canonicalize-a-sanitizer-name\u2463"},{"id":"ref-for-canonicalize-a-sanitizer-name\u2464"},{"id":"ref-for-canonicalize-a-sanitizer-name\u2465"}],"title":"3.5. Supporting Algorithms"}],"url":"#canonicalize-a-sanitizer-name"},
+"cc6d9aed": {"dfnID":"cc6d9aed","dfnText":"event handler content attribute","external":true,"refSections":[{"refs":[{"id":"ref-for-event-handler-content-attributes"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-event-handler-content-attributes\u2460"},{"id":"ref-for-event-handler-content-attributes\u2461"},{"id":"ref-for-event-handler-content-attributes\u2462"}],"title":"3.6. Builtins"}],"url":"https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes"},
+"ce720392": {"dfnID":"ce720392","dfnText":"shadow root","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-element-shadow-root"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#concept-element-shadow-root"},
+"comment": {"dfnID":"comment","dfnText":"Comment","external":false,"refSections":[{"refs":[{"id":"ref-for-comment\u2461"},{"id":"ref-for-comment\u2462"},{"id":"ref-for-comment\u2463"},{"id":"ref-for-comment\u2464"},{"id":"ref-for-comment\u2465"},{"id":"ref-for-comment\u2466"},{"id":"ref-for-comment\u2467"},{"id":"ref-for-comment\u2468"},{"id":"ref-for-comment\u2460\u24ea"},{"id":"ref-for-comment\u2460\u2460"},{"id":"ref-for-comment\u2460\u2461"},{"id":"ref-for-comment\u2460\u2462"},{"id":"ref-for-comment\u2460\u2463"},{"id":"ref-for-comment\u2460\u2464"},{"id":"ref-for-comment\u2460\u2465"},{"id":"ref-for-comment\u2460\u2466"}],"title":"3.2. Modify the Configuration"}],"url":"#comment"},
+"contains-a-javascript-url": {"dfnID":"contains-a-javascript-url","dfnText":"contains a javascript: URL","external":false,"refSections":[{"refs":[{"id":"ref-for-contains-a-javascript-url"},{"id":"ref-for-contains-a-javascript-url\u2460"}],"title":"3.1. Sanitize"}],"url":"#contains-a-javascript-url"},
+"d14a6f26": {"dfnID":"d14a6f26","dfnText":"key","external":true,"refSections":[{"refs":[{"id":"ref-for-map-key"},{"id":"ref-for-map-key\u2460"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-map-key\u2461"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#map-key"},
+"d354f084": {"dfnID":"d354f084","dfnText":"window.toStaticHTML()","external":true,"refSections":[{"refs":[{"id":"ref-for-something"}],"title":"5. Acknowledgements"}],"url":"https://msdn.microsoft.com/en-us/library/cc848922(v=vs.85).aspx"},
+"d4127354": {"dfnID":"d4127354","dfnText":"innerHTML","external":true,"refSections":[{"refs":[{"id":"ref-for-dom-element-innerhtml"}],"title":"1. Introduction"},{"refs":[{"id":"ref-for-dom-element-innerhtml\u2460"}],"title":"1.2. API Summary"}],"url":"https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-element-innerhtml"},
+"db0a062f": {"dfnID":"db0a062f","dfnText":"attribute","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-attribute"}],"title":"2.4. Configuration Invariants"}],"url":"https://dom.spec.whatwg.org/#concept-attribute"},
+"dbd32973": {"dfnID":"dbd32973","dfnText":"DOMParser","external":true,"refSections":[{"refs":[{"id":"ref-for-domparser"}],"title":"1.2. API Summary"}],"url":"https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#domparser"},
+"dictdef-sanitizerattributenamespace": {"dfnID":"dictdef-sanitizerattributenamespace","dfnText":"SanitizerAttributeNamespace","external":false,"refSections":[{"refs":[{"id":"ref-for-dictdef-sanitizerattributenamespace"}],"title":"2.3. The Configuration Dictionary"},{"refs":[{"id":"ref-for-dictdef-sanitizerattributenamespace\u2460"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-dictdef-sanitizerattributenamespace\u2461"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-dictdef-sanitizerattributenamespace\u2462"}],"title":"3.5. Supporting Algorithms"}],"url":"#dictdef-sanitizerattributenamespace"},
+"dictdef-sanitizerconfig": {"dfnID":"dictdef-sanitizerconfig","dfnText":"SanitizerConfig","external":false,"refSections":[{"refs":[{"id":"ref-for-dictdef-sanitizerconfig"},{"id":"ref-for-dictdef-sanitizerconfig\u2460"},{"id":"ref-for-dictdef-sanitizerconfig\u2461"},{"id":"ref-for-dictdef-sanitizerconfig\u2462"},{"id":"ref-for-dictdef-sanitizerconfig\u2463"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-dictdef-sanitizerconfig\u2464"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-dictdef-sanitizerconfig\u2465"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-dictdef-sanitizerconfig\u2466"},{"id":"ref-for-dictdef-sanitizerconfig\u2467"},{"id":"ref-for-dictdef-sanitizerconfig\u2468"},{"id":"ref-for-dictdef-sanitizerconfig\u2460\u24ea"},{"id":"ref-for-dictdef-sanitizerconfig\u2460\u2460"},{"id":"ref-for-dictdef-sanitizerconfig\u2460\u2461"},{"id":"ref-for-dictdef-sanitizerconfig\u2460\u2462"},{"id":"ref-for-dictdef-sanitizerconfig\u2460\u2463"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-dictdef-sanitizerconfig\u2460\u2464"},{"id":"ref-for-dictdef-sanitizerconfig\u2460\u2465"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#dictdef-sanitizerconfig"},
+"dictdef-sanitizerelementnamespace": {"dfnID":"dictdef-sanitizerelementnamespace","dfnText":"SanitizerElementNamespace","external":false,"refSections":[{"refs":[{"id":"ref-for-dictdef-sanitizerelementnamespace"},{"id":"ref-for-dictdef-sanitizerelementnamespace\u2460"}],"title":"2.3. The Configuration Dictionary"},{"refs":[{"id":"ref-for-dictdef-sanitizerelementnamespace\u2461"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-dictdef-sanitizerelementnamespace\u2462"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-dictdef-sanitizerelementnamespace\u2463"}],"title":"3.5. Supporting Algorithms"}],"url":"#dictdef-sanitizerelementnamespace"},
+"dictdef-sanitizerelementnamespacewithattributes": {"dfnID":"dictdef-sanitizerelementnamespacewithattributes","dfnText":"SanitizerElementNamespaceWithAttributes","external":false,"refSections":[{"refs":[{"id":"ref-for-dictdef-sanitizerelementnamespacewithattributes"}],"title":"2.3. The Configuration Dictionary"},{"refs":[{"id":"ref-for-dictdef-sanitizerelementnamespacewithattributes\u2460"}],"title":"2.4. Configuration Invariants"}],"url":"#dictdef-sanitizerelementnamespacewithattributes"},
+"dictdef-sethtmloptions": {"dfnID":"dictdef-sethtmloptions","dfnText":"SetHTMLOptions","external":false,"refSections":[{"refs":[{"id":"ref-for-dictdef-sethtmloptions"},{"id":"ref-for-dictdef-sethtmloptions\u2460"},{"id":"ref-for-dictdef-sethtmloptions\u2461"}],"title":"2.1. Sanitizer API"},{"refs":[{"id":"ref-for-dictdef-sethtmloptions\u2462"}],"title":"3. Algorithms"}],"url":"#dictdef-sethtmloptions"},
+"dictdef-sethtmlunsafeoptions": {"dfnID":"dictdef-sethtmlunsafeoptions","dfnText":"SetHTMLUnsafeOptions","external":false,"refSections":[{"refs":[{"id":"ref-for-dictdef-sethtmlunsafeoptions"},{"id":"ref-for-dictdef-sethtmlunsafeoptions\u2460"},{"id":"ref-for-dictdef-sethtmlunsafeoptions\u2461"}],"title":"2.1. Sanitizer API"},{"refs":[{"id":"ref-for-dictdef-sethtmlunsafeoptions\u2462"}],"title":"3. Algorithms"}],"url":"#dictdef-sethtmlunsafeoptions"},
+"dom-document-parsehtml": {"dfnID":"dom-document-parsehtml","dfnText":"parseHTML(html, options)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-document-parsehtml"}],"title":"2.1. Sanitizer API"},{"refs":[{"id":"ref-for-dom-document-parsehtml\u2460"}],"title":"3.1. Sanitize"}],"url":"#dom-document-parsehtml"},
+"dom-document-parsehtml-html-options-html": {"dfnID":"dom-document-parsehtml-html-options-html","dfnText":"html","external":false,"refSections":[],"url":"#dom-document-parsehtml-html-options-html"},
+"dom-document-parsehtml-html-options-options": {"dfnID":"dom-document-parsehtml-html-options-options","dfnText":"options","external":false,"refSections":[],"url":"#dom-document-parsehtml-html-options-options"},
+"dom-document-parsehtmlunsafe": {"dfnID":"dom-document-parsehtmlunsafe","dfnText":"parseHTMLUnsafe(html, options)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-document-parsehtmlunsafe"}],"title":"2.1. Sanitizer API"},{"refs":[{"id":"ref-for-dom-document-parsehtmlunsafe\u2460"}],"title":"3.1. Sanitize"}],"url":"#dom-document-parsehtmlunsafe"},
+"dom-document-parsehtmlunsafe-html-options-html": {"dfnID":"dom-document-parsehtmlunsafe-html-options-html","dfnText":"html","external":false,"refSections":[],"url":"#dom-document-parsehtmlunsafe-html-options-html"},
+"dom-document-parsehtmlunsafe-html-options-options": {"dfnID":"dom-document-parsehtmlunsafe-html-options-options","dfnText":"options","external":false,"refSections":[],"url":"#dom-document-parsehtmlunsafe-html-options-options"},
+"dom-element-sethtml": {"dfnID":"dom-element-sethtml","dfnText":"setHTML(html, options)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-element-sethtml"},{"id":"ref-for-dom-element-sethtml\u2460"}],"title":"2.1. Sanitizer API"},{"refs":[{"id":"ref-for-dom-element-sethtml\u2461"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#dom-element-sethtml"},
+"dom-element-sethtml-html-options-html": {"dfnID":"dom-element-sethtml-html-options-html","dfnText":"html","external":false,"refSections":[],"url":"#dom-element-sethtml-html-options-html"},
+"dom-element-sethtml-html-options-options": {"dfnID":"dom-element-sethtml-html-options-options","dfnText":"options","external":false,"refSections":[],"url":"#dom-element-sethtml-html-options-options"},
+"dom-element-sethtmlunsafe": {"dfnID":"dom-element-sethtmlunsafe","dfnText":"setHTMLUnsafe(html, options)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-element-sethtmlunsafe"},{"id":"ref-for-dom-element-sethtmlunsafe\u2460"}],"title":"2.1. Sanitizer API"},{"refs":[{"id":"ref-for-dom-element-sethtmlunsafe\u2461"}],"title":"2.4. Configuration Invariants"}],"url":"#dom-element-sethtmlunsafe"},
+"dom-element-sethtmlunsafe-html-options-html": {"dfnID":"dom-element-sethtmlunsafe-html-options-html","dfnText":"html","external":false,"refSections":[],"url":"#dom-element-sethtmlunsafe-html-options-html"},
+"dom-element-sethtmlunsafe-html-options-options": {"dfnID":"dom-element-sethtmlunsafe-html-options-options","dfnText":"options","external":false,"refSections":[],"url":"#dom-element-sethtmlunsafe-html-options-options"},
+"dom-sanitizer-allowattribute": {"dfnID":"dom-sanitizer-allowattribute","dfnText":"allowAttribute(attribute)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizer-allowattribute"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#dom-sanitizer-allowattribute"},
+"dom-sanitizer-allowattribute-attribute-attribute": {"dfnID":"dom-sanitizer-allowattribute-attribute-attribute","dfnText":"attribute","external":false,"refSections":[],"url":"#dom-sanitizer-allowattribute-attribute-attribute"},
+"dom-sanitizer-allowelement": {"dfnID":"dom-sanitizer-allowelement","dfnText":"allowElement(element)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizer-allowelement"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#dom-sanitizer-allowelement"},
+"dom-sanitizer-allowelement-element-element": {"dfnID":"dom-sanitizer-allowelement-element-element","dfnText":"element","external":false,"refSections":[],"url":"#dom-sanitizer-allowelement-element-element"},
+"dom-sanitizer-constructor": {"dfnID":"dom-sanitizer-constructor","dfnText":"constructor(configuration)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizer-constructor"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#dom-sanitizer-constructor"},
+"dom-sanitizer-get": {"dfnID":"dom-sanitizer-get","dfnText":"get()","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizer-get"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-dom-sanitizer-get\u2460"}],"title":"2.4. Configuration Invariants"}],"url":"#dom-sanitizer-get"},
+"dom-sanitizer-removeattribute": {"dfnID":"dom-sanitizer-removeattribute","dfnText":"removeAttribute(attribute)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizer-removeattribute"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#dom-sanitizer-removeattribute"},
+"dom-sanitizer-removeattribute-attribute-attribute": {"dfnID":"dom-sanitizer-removeattribute-attribute-attribute","dfnText":"attribute","external":false,"refSections":[],"url":"#dom-sanitizer-removeattribute-attribute-attribute"},
+"dom-sanitizer-removeelement": {"dfnID":"dom-sanitizer-removeelement","dfnText":"removeElement(element)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizer-removeelement"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#dom-sanitizer-removeelement"},
+"dom-sanitizer-removeelement-element-element": {"dfnID":"dom-sanitizer-removeelement-element-element","dfnText":"element","external":false,"refSections":[],"url":"#dom-sanitizer-removeelement-element-element"},
+"dom-sanitizer-removeunsafe": {"dfnID":"dom-sanitizer-removeunsafe","dfnText":"removeUnsafe()","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizer-removeunsafe"},{"id":"ref-for-dom-sanitizer-removeunsafe\u2460"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#dom-sanitizer-removeunsafe"},
+"dom-sanitizer-replaceelementwithchildren": {"dfnID":"dom-sanitizer-replaceelementwithchildren","dfnText":"replaceElementWithChildren(element)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizer-replaceelementwithchildren"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#dom-sanitizer-replaceelementwithchildren"},
+"dom-sanitizer-replaceelementwithchildren-element-element": {"dfnID":"dom-sanitizer-replaceelementwithchildren-element-element","dfnText":"element","external":false,"refSections":[],"url":"#dom-sanitizer-replaceelementwithchildren-element-element"},
+"dom-sanitizer-sanitizer-configuration-configuration": {"dfnID":"dom-sanitizer-sanitizer-configuration-configuration","dfnText":"configuration","external":false,"refSections":[],"url":"#dom-sanitizer-sanitizer-configuration-configuration"},
+"dom-sanitizer-setcomments": {"dfnID":"dom-sanitizer-setcomments","dfnText":"setComments(allow)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizer-setcomments"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#dom-sanitizer-setcomments"},
+"dom-sanitizer-setcomments-allow-allow": {"dfnID":"dom-sanitizer-setcomments-allow-allow","dfnText":"allow","external":false,"refSections":[],"url":"#dom-sanitizer-setcomments-allow-allow"},
+"dom-sanitizer-setdataattributes": {"dfnID":"dom-sanitizer-setdataattributes","dfnText":"setDataAttributes(allow)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizer-setdataattributes"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#dom-sanitizer-setdataattributes"},
+"dom-sanitizer-setdataattributes-allow-allow": {"dfnID":"dom-sanitizer-setdataattributes-allow-allow","dfnText":"allow","external":false,"refSections":[],"url":"#dom-sanitizer-setdataattributes-allow-allow"},
+"dom-sanitizerattributenamespace-name": {"dfnID":"dom-sanitizerattributenamespace-name","dfnText":"name","external":false,"refSections":[],"url":"#dom-sanitizerattributenamespace-name"},
+"dom-sanitizerattributenamespace-namespace": {"dfnID":"dom-sanitizerattributenamespace-namespace","dfnText":"_namespace","external":false,"refSections":[],"url":"#dom-sanitizerattributenamespace-namespace"},
+"dom-sanitizerconfig-attributes": {"dfnID":"dom-sanitizerconfig-attributes","dfnText":"attributes","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizerconfig-attributes"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2460"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2461"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-dom-sanitizerconfig-attributes\u2462"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2463"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2464"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2465"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2466"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2467"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2468"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2460\u24ea"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2460\u2460"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2460\u2461"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2460\u2462"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2460\u2463"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2460\u2464"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2460\u2465"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2460\u2466"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-attributes\u2460\u2467"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2460\u2468"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-attributes\u2461\u24ea"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2461\u2460"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2461\u2461"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2461\u2462"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2461\u2463"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2461\u2464"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2461\u2465"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2461\u2466"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2461\u2467"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2461\u2468"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2462\u24ea"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2462\u2460"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-attributes\u2462\u2461"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2462\u2462"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2462\u2463"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2462\u2464"},{"id":"ref-for-dom-sanitizerconfig-attributes\u2462\u2465"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#dom-sanitizerconfig-attributes"},
+"dom-sanitizerconfig-comments": {"dfnID":"dom-sanitizerconfig-comments","dfnText":"comments","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizerconfig-comments"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-comments\u2460"},{"id":"ref-for-dom-sanitizerconfig-comments\u2461"},{"id":"ref-for-dom-sanitizerconfig-comments\u2462"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-comments\u2463"},{"id":"ref-for-dom-sanitizerconfig-comments\u2464"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#dom-sanitizerconfig-comments"},
+"dom-sanitizerconfig-dataattributes": {"dfnID":"dom-sanitizerconfig-dataattributes","dfnText":"dataAttributes","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizerconfig-dataattributes"},{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2460"},{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2461"},{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2462"},{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2463"},{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2464"},{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2465"},{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2466"},{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2467"},{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2468"},{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2460\u24ea"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2460\u2460"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2460\u2461"},{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2460\u2462"},{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2460\u2463"},{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2460\u2464"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2460\u2465"},{"id":"ref-for-dom-sanitizerconfig-dataattributes\u2460\u2466"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#dom-sanitizerconfig-dataattributes"},
+"dom-sanitizerconfig-elements": {"dfnID":"dom-sanitizerconfig-elements","dfnText":"elements","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizerconfig-elements"},{"id":"ref-for-dom-sanitizerconfig-elements\u2460"},{"id":"ref-for-dom-sanitizerconfig-elements\u2461"},{"id":"ref-for-dom-sanitizerconfig-elements\u2462"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-dom-sanitizerconfig-elements\u2463"},{"id":"ref-for-dom-sanitizerconfig-elements\u2464"},{"id":"ref-for-dom-sanitizerconfig-elements\u2465"},{"id":"ref-for-dom-sanitizerconfig-elements\u2466"},{"id":"ref-for-dom-sanitizerconfig-elements\u2467"},{"id":"ref-for-dom-sanitizerconfig-elements\u2468"},{"id":"ref-for-dom-sanitizerconfig-elements\u2460\u24ea"},{"id":"ref-for-dom-sanitizerconfig-elements\u2460\u2460"},{"id":"ref-for-dom-sanitizerconfig-elements\u2460\u2461"},{"id":"ref-for-dom-sanitizerconfig-elements\u2460\u2462"},{"id":"ref-for-dom-sanitizerconfig-elements\u2460\u2463"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-elements\u2460\u2464"},{"id":"ref-for-dom-sanitizerconfig-elements\u2460\u2465"},{"id":"ref-for-dom-sanitizerconfig-elements\u2460\u2466"},{"id":"ref-for-dom-sanitizerconfig-elements\u2460\u2467"},{"id":"ref-for-dom-sanitizerconfig-elements\u2460\u2468"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-elements\u2461\u24ea"},{"id":"ref-for-dom-sanitizerconfig-elements\u2461\u2460"},{"id":"ref-for-dom-sanitizerconfig-elements\u2461\u2461"},{"id":"ref-for-dom-sanitizerconfig-elements\u2461\u2462"},{"id":"ref-for-dom-sanitizerconfig-elements\u2461\u2463"},{"id":"ref-for-dom-sanitizerconfig-elements\u2461\u2464"},{"id":"ref-for-dom-sanitizerconfig-elements\u2461\u2465"},{"id":"ref-for-dom-sanitizerconfig-elements\u2461\u2466"},{"id":"ref-for-dom-sanitizerconfig-elements\u2461\u2467"},{"id":"ref-for-dom-sanitizerconfig-elements\u2461\u2468"},{"id":"ref-for-dom-sanitizerconfig-elements\u2462\u24ea"},{"id":"ref-for-dom-sanitizerconfig-elements\u2462\u2460"},{"id":"ref-for-dom-sanitizerconfig-elements\u2462\u2461"},{"id":"ref-for-dom-sanitizerconfig-elements\u2462\u2462"},{"id":"ref-for-dom-sanitizerconfig-elements\u2462\u2463"},{"id":"ref-for-dom-sanitizerconfig-elements\u2462\u2464"},{"id":"ref-for-dom-sanitizerconfig-elements\u2462\u2465"},{"id":"ref-for-dom-sanitizerconfig-elements\u2462\u2466"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-elements\u2462\u2467"},{"id":"ref-for-dom-sanitizerconfig-elements\u2462\u2468"},{"id":"ref-for-dom-sanitizerconfig-elements\u2463\u24ea"},{"id":"ref-for-dom-sanitizerconfig-elements\u2463\u2460"},{"id":"ref-for-dom-sanitizerconfig-elements\u2463\u2461"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#dom-sanitizerconfig-elements"},
+"dom-sanitizerconfig-removeattributes": {"dfnID":"dom-sanitizerconfig-removeattributes","dfnText":"removeAttributes","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizerconfig-removeattributes"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2460"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2461"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2462"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2463"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2464"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2465"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2466"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2467"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2468"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2460\u24ea"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2460\u2460"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2460\u2461"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2460\u2462"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2460\u2463"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2460\u2464"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2460\u2465"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2460\u2466"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2460\u2467"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2460\u2468"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2461\u24ea"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2461\u2460"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2461\u2461"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2461\u2462"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2461\u2463"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2461\u2464"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2461\u2465"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2461\u2466"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2461\u2467"},{"id":"ref-for-dom-sanitizerconfig-removeattributes\u2461\u2468"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#dom-sanitizerconfig-removeattributes"},
+"dom-sanitizerconfig-removeelements": {"dfnID":"dom-sanitizerconfig-removeelements","dfnText":"removeElements","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizerconfig-removeelements"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2460"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2461"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-dom-sanitizerconfig-removeelements\u2462"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2463"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2464"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2465"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2466"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2467"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2468"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-removeelements\u2460\u24ea"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2460\u2460"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-removeelements\u2460\u2461"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2460\u2462"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2460\u2463"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2460\u2464"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2460\u2465"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2460\u2466"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2460\u2467"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-removeelements\u2460\u2468"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2461\u24ea"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2461\u2460"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2461\u2461"},{"id":"ref-for-dom-sanitizerconfig-removeelements\u2461\u2462"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#dom-sanitizerconfig-removeelements"},
+"dom-sanitizerconfig-replacewithchildrenelements": {"dfnID":"dom-sanitizerconfig-replacewithchildrenelements","dfnText":"replaceWithChildrenElements","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements"},{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2460"},{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2461"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2462"},{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2463"},{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2464"},{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2465"},{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2466"},{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2467"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2468"},{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2460\u24ea"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2460\u2460"},{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2460\u2461"},{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2460\u2462"},{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2460\u2463"},{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2460\u2464"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2460\u2465"},{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2460\u2466"},{"id":"ref-for-dom-sanitizerconfig-replacewithchildrenelements\u2460\u2467"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#dom-sanitizerconfig-replacewithchildrenelements"},
+"dom-sanitizerelementnamespace-name": {"dfnID":"dom-sanitizerelementnamespace-name","dfnText":"name","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizerelementnamespace-name"},{"id":"ref-for-dom-sanitizerelementnamespace-name\u2460"}],"title":"3.2. Modify the Configuration"}],"url":"#dom-sanitizerelementnamespace-name"},
+"dom-sanitizerelementnamespace-namespace": {"dfnID":"dom-sanitizerelementnamespace-namespace","dfnText":"_namespace","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizerelementnamespace-namespace"},{"id":"ref-for-dom-sanitizerelementnamespace-namespace\u2460"}],"title":"3.2. Modify the Configuration"}],"url":"#dom-sanitizerelementnamespace-namespace"},
+"dom-sanitizerelementnamespacewithattributes-attributes": {"dfnID":"dom-sanitizerelementnamespacewithattributes-attributes","dfnText":"attributes","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2460"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2461"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2462"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2463"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2464"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2465"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2466"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2467"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2468"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2460\u24ea"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2460\u2460"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2460\u2461"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2460\u2462"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2460\u2463"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2460\u2464"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2460\u2465"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2460\u2466"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2460\u2467"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2460\u2468"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2461\u24ea"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2461\u2460"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2461\u2461"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2461\u2462"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2461\u2463"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2461\u2464"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2461\u2465"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2461\u2466"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2461\u2467"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2461\u2468"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2462\u24ea"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2462\u2460"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2462\u2461"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2462\u2462"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2462\u2463"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-attributes\u2462\u2464"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#dom-sanitizerelementnamespacewithattributes-attributes"},
+"dom-sanitizerelementnamespacewithattributes-removeattributes": {"dfnID":"dom-sanitizerelementnamespacewithattributes-removeattributes","dfnText":"removeAttributes","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2460"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2461"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2462"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2463"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2464"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2465"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2466"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2467"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2468"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2460\u24ea"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2460\u2460"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2460\u2461"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2460\u2462"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2460\u2463"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2460\u2464"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2460\u2465"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2460\u2466"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2460\u2467"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2460\u2468"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2461\u24ea"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2461\u2460"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2461\u2461"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2461\u2462"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2461\u2463"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2461\u2464"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2461\u2465"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2461\u2466"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2461\u2467"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2461\u2468"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2462\u24ea"},{"id":"ref-for-dom-sanitizerelementnamespacewithattributes-removeattributes\u2462\u2460"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#dom-sanitizerelementnamespacewithattributes-removeattributes"},
+"dom-sanitizerpresets-default": {"dfnID":"dom-sanitizerpresets-default","dfnText":"\"default\"","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sanitizerpresets-default"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-dom-sanitizerpresets-default\u2460"},{"id":"ref-for-dom-sanitizerpresets-default\u2461"}],"title":"3. Algorithms"}],"url":"#dom-sanitizerpresets-default"},
+"dom-sethtmloptions-sanitizer": {"dfnID":"dom-sethtmloptions-sanitizer","dfnText":"sanitizer","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-sethtmloptions-sanitizer"},{"id":"ref-for-dom-sethtmloptions-sanitizer\u2460"}],"title":"3. Algorithms"}],"url":"#dom-sethtmloptions-sanitizer"},
+"dom-sethtmlunsafeoptions-sanitizer": {"dfnID":"dom-sethtmlunsafeoptions-sanitizer","dfnText":"sanitizer","external":false,"refSections":[],"url":"#dom-sethtmlunsafeoptions-sanitizer"},
+"dom-shadowroot-sethtml": {"dfnID":"dom-shadowroot-sethtml","dfnText":"setHTML(html, options)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-shadowroot-sethtml"}],"title":"2.1. Sanitizer API"}],"url":"#dom-shadowroot-sethtml"},
+"dom-shadowroot-sethtml-html-options-html": {"dfnID":"dom-shadowroot-sethtml-html-options-html","dfnText":"html","external":false,"refSections":[],"url":"#dom-shadowroot-sethtml-html-options-html"},
+"dom-shadowroot-sethtml-html-options-options": {"dfnID":"dom-shadowroot-sethtml-html-options-options","dfnText":"options","external":false,"refSections":[],"url":"#dom-shadowroot-sethtml-html-options-options"},
+"dom-shadowroot-sethtmlunsafe": {"dfnID":"dom-shadowroot-sethtmlunsafe","dfnText":"setHTMLUnsafe(html, options)","external":false,"refSections":[{"refs":[{"id":"ref-for-dom-shadowroot-sethtmlunsafe"}],"title":"2.1. Sanitizer API"}],"url":"#dom-shadowroot-sethtmlunsafe"},
+"dom-shadowroot-sethtmlunsafe-html-options-html": {"dfnID":"dom-shadowroot-sethtmlunsafe-html-options-html","dfnText":"html","external":false,"refSections":[],"url":"#dom-shadowroot-sethtmlunsafe-html-options-html"},
+"dom-shadowroot-sethtmlunsafe-html-options-options": {"dfnID":"dom-shadowroot-sethtmlunsafe-html-options-options","dfnText":"options","external":false,"refSections":[],"url":"#dom-shadowroot-sethtmlunsafe-html-options-options"},
+"e19f3699": {"dfnID":"e19f3699","dfnText":"XLink namespace","external":true,"refSections":[{"refs":[{"id":"ref-for-xlink-namespace"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-xlink-namespace\u2460"}],"title":"3.6. Builtins"}],"url":"https://infra.spec.whatwg.org/#xlink-namespace"},
+"e240317a": {"dfnID":"e240317a","dfnText":"local name (for Attr)","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-attribute-local-name"},{"id":"ref-for-concept-attribute-local-name\u2460"},{"id":"ref-for-concept-attribute-local-name\u2461"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#concept-attribute-local-name"},
+"e5ea84f2": {"dfnID":"e5ea84f2","dfnText":"intersection","external":true,"refSections":[{"refs":[{"id":"ref-for-set-intersection"},{"id":"ref-for-set-intersection\u2460"},{"id":"ref-for-set-intersection\u2461"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-set-intersection\u2462"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-set-intersection\u2463"},{"id":"ref-for-set-intersection\u2464"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#set-intersection"},
+"e99bd18e": {"dfnID":"e99bd18e","dfnText":"relevant global object","external":true,"refSections":[{"refs":[{"id":"ref-for-concept-relevant-global"},{"id":"ref-for-concept-relevant-global\u2460"},{"id":"ref-for-concept-relevant-global\u2461"}],"title":"2.1. Sanitizer API"}],"url":"https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global"},
+"ead425bd": {"dfnID":"ead425bd","dfnText":"MathML namespace","external":true,"refSections":[{"refs":[{"id":"ref-for-mathml-namespace"}],"title":"3.1. Sanitize"}],"url":"https://infra.spec.whatwg.org/#mathml-namespace"},
+"ece46d2b": {"dfnID":"ece46d2b","dfnText":"ParentNode","external":true,"refSections":[{"refs":[{"id":"ref-for-parentnode"},{"id":"ref-for-parentnode\u2460"}],"title":"3.1. Sanitize"}],"url":"https://dom.spec.whatwg.org/#parentnode"},
+"ee469dff": {"dfnID":"ee469dff","dfnText":"with default","external":true,"refSections":[{"refs":[{"id":"ref-for-map-with-default"},{"id":"ref-for-map-with-default\u2460"},{"id":"ref-for-map-with-default\u2461"},{"id":"ref-for-map-with-default\u2462"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-map-with-default\u2463"},{"id":"ref-for-map-with-default\u2464"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-map-with-default\u2465"},{"id":"ref-for-map-with-default\u2466"},{"id":"ref-for-map-with-default\u2467"},{"id":"ref-for-map-with-default\u2468"},{"id":"ref-for-map-with-default\u2460\u24ea"},{"id":"ref-for-map-with-default\u2460\u2460"}],"title":"3.2. Modify the Configuration"}],"url":"https://infra.spec.whatwg.org/#map-with-default"},
+"enumdef-sanitizerpresets": {"dfnID":"enumdef-sanitizerpresets","dfnText":"SanitizerPresets","external":false,"refSections":[{"refs":[{"id":"ref-for-enumdef-sanitizerpresets"},{"id":"ref-for-enumdef-sanitizerpresets\u2460"},{"id":"ref-for-enumdef-sanitizerpresets\u2461"},{"id":"ref-for-enumdef-sanitizerpresets\u2462"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-enumdef-sanitizerpresets\u2463"}],"title":"3. Algorithms"}],"url":"#enumdef-sanitizerpresets"},
+"f02cd417": {"dfnID":"f02cd417","dfnText":"iterate","external":true,"refSections":[{"refs":[{"id":"ref-for-list-iterate"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-list-iterate\u2460"},{"id":"ref-for-list-iterate\u2461"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-list-iterate\u2462"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-list-iterate\u2463"},{"id":"ref-for-list-iterate\u2464"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-list-iterate\u2465"},{"id":"ref-for-list-iterate\u2466"},{"id":"ref-for-list-iterate\u2467"},{"id":"ref-for-list-iterate\u2468"},{"id":"ref-for-list-iterate\u2460\u24ea"},{"id":"ref-for-list-iterate\u2460\u2460"},{"id":"ref-for-list-iterate\u2460\u2461"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-list-iterate\u2460\u2462"},{"id":"ref-for-list-iterate\u2460\u2463"},{"id":"ref-for-list-iterate\u2460\u2464"},{"id":"ref-for-list-iterate\u2460\u2465"},{"id":"ref-for-list-iterate\u2460\u2466"},{"id":"ref-for-list-iterate\u2460\u2467"},{"id":"ref-for-list-iterate\u2460\u2468"}],"title":"3.4. Canonicalize the Configuration"},{"refs":[{"id":"ref-for-list-iterate\u2461\u24ea"},{"id":"ref-for-list-iterate\u2461\u2460"},{"id":"ref-for-list-iterate\u2461\u2461"},{"id":"ref-for-list-iterate\u2461\u2462"}],"title":"3.5. Supporting Algorithms"}],"url":"https://infra.spec.whatwg.org/#list-iterate"},
+"f052b1ea": {"dfnID":"f052b1ea","dfnText":"HTML namespace","external":true,"refSections":[{"refs":[{"id":"ref-for-html-namespace"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-html-namespace\u2460"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-html-namespace\u2461"}],"title":"3.4. Canonicalize the Configuration"},{"refs":[{"id":"ref-for-html-namespace\u2462"},{"id":"ref-for-html-namespace\u2463"},{"id":"ref-for-html-namespace\u2464"},{"id":"ref-for-html-namespace\u2465"},{"id":"ref-for-html-namespace\u2466"},{"id":"ref-for-html-namespace\u2467"},{"id":"ref-for-html-namespace\u2468"}],"title":"3.6. Builtins"}],"url":"https://infra.spec.whatwg.org/#html-namespace"},
+"f099a38d": {"dfnID":"f099a38d","dfnText":"HTMLTemplateElement","external":true,"refSections":[{"refs":[{"id":"ref-for-htmltemplateelement"},{"id":"ref-for-htmltemplateelement\u2460"}],"title":"2.1. Sanitizer API"}],"url":"https://html.spec.whatwg.org/multipage/scripting.html#htmltemplateelement"},
+"f7cccb8c": {"dfnID":"f7cccb8c","dfnText":"HTML fragment parsing algorithm","external":true,"refSections":[{"refs":[{"id":"ref-for-html-fragment-parsing-algorithm"}],"title":"3. Algorithms"}],"url":"https://html.spec.whatwg.org/#html-fragment-parsing-algorithm"},
+"f937b7b6": {"dfnID":"f937b7b6","dfnText":"continue","external":true,"refSections":[{"refs":[{"id":"ref-for-iteration-continue"},{"id":"ref-for-iteration-continue\u2460"},{"id":"ref-for-iteration-continue\u2461"},{"id":"ref-for-iteration-continue\u2462"},{"id":"ref-for-iteration-continue\u2463"}],"title":"3.1. Sanitize"}],"url":"https://infra.spec.whatwg.org/#iteration-continue"},
+"handlejavascriptnavigationurls": {"dfnID":"handlejavascriptnavigationurls","dfnText":"handleJavascriptNavigationUrls","external":false,"refSections":[{"refs":[{"id":"ref-for-handlejavascriptnavigationurls"}],"title":"3.1. Sanitize"}],"url":"#handlejavascriptnavigationurls"},
+"map-equal": {"dfnID":"map-equal","dfnText":"equal","external":false,"refSections":[{"refs":[{"id":"ref-for-map-equal"}],"title":"3.2. Modify the Configuration"}],"url":"#map-equal"},
+"safe-and-unsafe": {"dfnID":"safe-and-unsafe","dfnText":"Safe and unsafe","external":false,"refSections":[{"refs":[{"id":"ref-for-safe-and-unsafe"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#safe-and-unsafe"},
+"sanitize": {"dfnID":"sanitize","dfnText":"sanitize","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitize"},{"id":"ref-for-sanitize\u2460"}],"title":"2.1. Sanitizer API"},{"refs":[{"id":"ref-for-sanitize\u2461"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-sanitize\u2462"}],"title":"3.1. Sanitize"}],"url":"#sanitize"},
+"sanitize-core": {"dfnID":"sanitize-core","dfnText":"sanitize core","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitize-core"},{"id":"ref-for-sanitize-core\u2460"},{"id":"ref-for-sanitize-core\u2461"},{"id":"ref-for-sanitize-core\u2462"},{"id":"ref-for-sanitize-core\u2463"}],"title":"3.1. Sanitize"}],"url":"#sanitize-core"},
+"sanitizer": {"dfnID":"sanitizer","dfnText":"Sanitizer","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizer"},{"id":"ref-for-sanitizer\u2460"},{"id":"ref-for-sanitizer\u2461"},{"id":"ref-for-sanitizer\u2462"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-sanitizer\u2463"},{"id":"ref-for-sanitizer\u2464"},{"id":"ref-for-sanitizer\u2465"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-sanitizer\u2466"},{"id":"ref-for-sanitizer\u2467"},{"id":"ref-for-sanitizer\u2468"},{"id":"ref-for-sanitizer\u2460\u24ea"}],"title":"3. Algorithms"},{"refs":[{"id":"ref-for-sanitizer\u2460\u2460"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-sanitizer\u2460\u2461"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-sanitizer\u2460\u2462"}],"title":"3.3. Set the Configuration"},{"refs":[{"id":"ref-for-sanitizer\u2460\u2463"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#sanitizer"},
+"sanitizer-allow-an-attribute": {"dfnID":"sanitizer-allow-an-attribute","dfnText":"allow an attribute","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizer-allow-an-attribute"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#sanitizer-allow-an-attribute"},
+"sanitizer-canonicalize-the-configuration": {"dfnID":"sanitizer-canonicalize-the-configuration","dfnText":"canonicalize the configuration","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizer-canonicalize-the-configuration"}],"title":"3.3. Set the Configuration"}],"url":"#sanitizer-canonicalize-the-configuration"},
+"sanitizer-configuration": {"dfnID":"sanitizer-configuration","dfnText":"configuration","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizer-configuration"},{"id":"ref-for-sanitizer-configuration\u2460"},{"id":"ref-for-sanitizer-configuration\u2461"},{"id":"ref-for-sanitizer-configuration\u2462"},{"id":"ref-for-sanitizer-configuration\u2463"},{"id":"ref-for-sanitizer-configuration\u2464"},{"id":"ref-for-sanitizer-configuration\u2465"},{"id":"ref-for-sanitizer-configuration\u2466"},{"id":"ref-for-sanitizer-configuration\u2467"},{"id":"ref-for-sanitizer-configuration\u2468"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-sanitizer-configuration\u2460\u24ea"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-sanitizer-configuration\u2460\u2460"}],"title":"3.3. Set the Configuration"},{"refs":[{"id":"ref-for-sanitizer-configuration\u2460\u2461"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#sanitizer-configuration"},
+"sanitizer-remove-an-attribute": {"dfnID":"sanitizer-remove-an-attribute","dfnText":"remove an attribute","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizer-remove-an-attribute"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-sanitizer-remove-an-attribute\u2460"},{"id":"ref-for-sanitizer-remove-an-attribute\u2461"}],"title":"3.2. Modify the Configuration"}],"url":"#sanitizer-remove-an-attribute"},
+"sanitizer-remove-an-element": {"dfnID":"sanitizer-remove-an-element","dfnText":"remove an element","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizer-remove-an-element"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-sanitizer-remove-an-element\u2460"}],"title":"3.2. Modify the Configuration"}],"url":"#sanitizer-remove-an-element"},
+"sanitizer-replace-an-element-with-its-children": {"dfnID":"sanitizer-replace-an-element-with-its-children","dfnText":"replace an element with its children","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizer-replace-an-element-with-its-children"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#sanitizer-replace-an-element-with-its-children"},
+"sanitizer-set-a-configuration": {"dfnID":"sanitizer-set-a-configuration","dfnText":"set a configuration","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizer-set-a-configuration"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-sanitizer-set-a-configuration\u2460"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-sanitizer-set-a-configuration\u2461"}],"title":"3. Algorithms"}],"url":"#sanitizer-set-a-configuration"},
+"sanitizer-set-comments": {"dfnID":"sanitizer-set-comments","dfnText":"set comments","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizer-set-comments"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#sanitizer-set-comments"},
+"sanitizer-set-data-attributes": {"dfnID":"sanitizer-set-data-attributes","dfnText":"set data attributes","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizer-set-data-attributes"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#sanitizer-set-data-attributes"},
+"sanitizerconfig-add": {"dfnID":"sanitizerconfig-add","dfnText":"add","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizerconfig-add"},{"id":"ref-for-sanitizerconfig-add\u2460"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-sanitizerconfig-add\u2461"}],"title":"3.5. Supporting Algorithms"}],"url":"#sanitizerconfig-add"},
+"sanitizerconfig-allow-an-element": {"dfnID":"sanitizerconfig-allow-an-element","dfnText":"allow an element","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizerconfig-allow-an-element"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#sanitizerconfig-allow-an-element"},
+"sanitizerconfig-contains": {"dfnID":"sanitizerconfig-contains","dfnText":"contains","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizerconfig-contains"},{"id":"ref-for-sanitizerconfig-contains\u2460"},{"id":"ref-for-sanitizerconfig-contains\u2461"},{"id":"ref-for-sanitizerconfig-contains\u2462"},{"id":"ref-for-sanitizerconfig-contains\u2463"},{"id":"ref-for-sanitizerconfig-contains\u2464"},{"id":"ref-for-sanitizerconfig-contains\u2465"},{"id":"ref-for-sanitizerconfig-contains\u2466"},{"id":"ref-for-sanitizerconfig-contains\u2467"},{"id":"ref-for-sanitizerconfig-contains\u2468"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-sanitizerconfig-contains\u2460\u24ea"}],"title":"3.5. Supporting Algorithms"}],"url":"#sanitizerconfig-contains"},
+"sanitizerconfig-get-a-sanitizer-instance-from-options": {"dfnID":"sanitizerconfig-get-a-sanitizer-instance-from-options","dfnText":"get a sanitizer instance from options","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizerconfig-get-a-sanitizer-instance-from-options"},{"id":"ref-for-sanitizerconfig-get-a-sanitizer-instance-from-options\u2460"}],"title":"2.1. Sanitizer API"},{"refs":[{"id":"ref-for-sanitizerconfig-get-a-sanitizer-instance-from-options\u2461"}],"title":"3. Algorithms"}],"url":"#sanitizerconfig-get-a-sanitizer-instance-from-options"},
+"sanitizerconfig-has-duplicates": {"dfnID":"sanitizerconfig-has-duplicates","dfnText":"has duplicates","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizerconfig-has-duplicates"},{"id":"ref-for-sanitizerconfig-has-duplicates\u2460"},{"id":"ref-for-sanitizerconfig-has-duplicates\u2461"}],"title":"2.4. Configuration Invariants"}],"url":"#sanitizerconfig-has-duplicates"},
+"sanitizerconfig-intersection": {"dfnID":"sanitizerconfig-intersection","dfnText":"intersection","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizerconfig-intersection"},{"id":"ref-for-sanitizerconfig-intersection\u2460"}],"title":"2.4. Configuration Invariants"}],"url":"#sanitizerconfig-intersection"},
+"sanitizerconfig-less-than-item": {"dfnID":"sanitizerconfig-less-than-item","dfnText":"less than item","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizerconfig-less-than-item"},{"id":"ref-for-sanitizerconfig-less-than-item\u2460"},{"id":"ref-for-sanitizerconfig-less-than-item\u2461"},{"id":"ref-for-sanitizerconfig-less-than-item\u2462"},{"id":"ref-for-sanitizerconfig-less-than-item\u2463"},{"id":"ref-for-sanitizerconfig-less-than-item\u2464"},{"id":"ref-for-sanitizerconfig-less-than-item\u2465"}],"title":"2.2. SetHTML options and the configuration object."}],"url":"#sanitizerconfig-less-than-item"},
+"sanitizerconfig-remove": {"dfnID":"sanitizerconfig-remove","dfnText":"remove","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizerconfig-remove"},{"id":"ref-for-sanitizerconfig-remove\u2460"},{"id":"ref-for-sanitizerconfig-remove\u2461"},{"id":"ref-for-sanitizerconfig-remove\u2462"},{"id":"ref-for-sanitizerconfig-remove\u2463"},{"id":"ref-for-sanitizerconfig-remove\u2464"},{"id":"ref-for-sanitizerconfig-remove\u2465"},{"id":"ref-for-sanitizerconfig-remove\u2466"}],"title":"3.2. Modify the Configuration"}],"url":"#sanitizerconfig-remove"},
+"sanitizerconfig-remove-duplicates": {"dfnID":"sanitizerconfig-remove-duplicates","dfnText":"remove duplicates","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizerconfig-remove-duplicates"},{"id":"ref-for-sanitizerconfig-remove-duplicates\u2460"}],"title":"3.2. Modify the Configuration"}],"url":"#sanitizerconfig-remove-duplicates"},
+"sanitizerconfig-remove-unsafe": {"dfnID":"sanitizerconfig-remove-unsafe","dfnText":"remove unsafe","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizerconfig-remove-unsafe"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-sanitizerconfig-remove-unsafe\u2460"}],"title":"3.1. Sanitize"},{"refs":[{"id":"ref-for-sanitizerconfig-remove-unsafe\u2461"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-sanitizerconfig-remove-unsafe\u2462"}],"title":"3.6. Builtins"}],"url":"#sanitizerconfig-remove-unsafe"},
+"sanitizerconfig-valid": {"dfnID":"sanitizerconfig-valid","dfnText":"valid","external":false,"refSections":[{"refs":[{"id":"ref-for-sanitizerconfig-valid"}],"title":"2.4. Configuration Invariants"},{"refs":[{"id":"ref-for-sanitizerconfig-valid\u2460"}],"title":"3.3. Set the Configuration"}],"url":"#sanitizerconfig-valid"},
+"set-and-filter-html": {"dfnID":"set-and-filter-html","dfnText":"set and filter HTML","external":false,"refSections":[{"refs":[{"id":"ref-for-set-and-filter-html"},{"id":"ref-for-set-and-filter-html\u2460"},{"id":"ref-for-set-and-filter-html\u2461"},{"id":"ref-for-set-and-filter-html\u2462"}],"title":"2.1. Sanitizer API"}],"url":"#set-and-filter-html"},
+"set-equal": {"dfnID":"set-equal","dfnText":"equal","external":false,"refSections":[{"refs":[{"id":"ref-for-set-equal"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-set-equal\u2460"}],"title":"3.5. Supporting Algorithms"}],"url":"#set-equal"},
+"typedefdef-sanitizerattribute": {"dfnID":"typedefdef-sanitizerattribute","dfnText":"SanitizerAttribute","external":false,"refSections":[{"refs":[{"id":"ref-for-typedefdef-sanitizerattribute"},{"id":"ref-for-typedefdef-sanitizerattribute\u2460"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-typedefdef-sanitizerattribute\u2461"},{"id":"ref-for-typedefdef-sanitizerattribute\u2462"},{"id":"ref-for-typedefdef-sanitizerattribute\u2463"},{"id":"ref-for-typedefdef-sanitizerattribute\u2464"}],"title":"2.3. The Configuration Dictionary"},{"refs":[{"id":"ref-for-typedefdef-sanitizerattribute\u2465"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-typedefdef-sanitizerattribute\u2466"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#typedefdef-sanitizerattribute"},
+"typedefdef-sanitizerelement": {"dfnID":"typedefdef-sanitizerelement","dfnText":"SanitizerElement","external":false,"refSections":[{"refs":[{"id":"ref-for-typedefdef-sanitizerelement"},{"id":"ref-for-typedefdef-sanitizerelement\u2460"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-typedefdef-sanitizerelement\u2461"},{"id":"ref-for-typedefdef-sanitizerelement\u2462"}],"title":"2.3. The Configuration Dictionary"},{"refs":[{"id":"ref-for-typedefdef-sanitizerelement\u2463"},{"id":"ref-for-typedefdef-sanitizerelement\u2464"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-typedefdef-sanitizerelement\u2465"}],"title":"3.4. Canonicalize the Configuration"},{"refs":[{"id":"ref-for-typedefdef-sanitizerelement\u2466"}],"title":"3.5. Supporting Algorithms"}],"url":"#typedefdef-sanitizerelement"},
+"typedefdef-sanitizerelementwithattributes": {"dfnID":"typedefdef-sanitizerelementwithattributes","dfnText":"SanitizerElementWithAttributes","external":false,"refSections":[{"refs":[{"id":"ref-for-typedefdef-sanitizerelementwithattributes"}],"title":"2.2. SetHTML options and the configuration object."},{"refs":[{"id":"ref-for-typedefdef-sanitizerelementwithattributes\u2460"}],"title":"2.3. The Configuration Dictionary"},{"refs":[{"id":"ref-for-typedefdef-sanitizerelementwithattributes\u2461"}],"title":"3.2. Modify the Configuration"},{"refs":[{"id":"ref-for-typedefdef-sanitizerelementwithattributes\u2462"}],"title":"3.4. Canonicalize the Configuration"}],"url":"#typedefdef-sanitizerelementwithattributes"},
+};
+
+document.addEventListener("DOMContentLoaded", ()=>{
+    genAllDfnPanels();
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+});
+
+window.addEventListener("resize", () => {
+    // Pin any visible dfn panel
+    queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>positionDfnPanel(el));
+});
+
+function genAllDfnPanels() {
+    for(const panelData of Object.values(dfnPanelData)) {
+        const dfnID = panelData.dfnID;
+        const dfn = document.getElementById(dfnID);
+        if(!dfn) {
+            console.log(`Can't find dfn#${dfnID}.`, panelData);
+            continue;
+        }
+        dfn.panelData = panelData;
+        insertDfnPopupAction(dfn);
+    }
+}
+
+function genDfnPanel(dfn, { dfnID, url, dfnText, refSections, external }) {
+    const dfnPanel = mk.aside({
+        class: "dfn-panel on",
+        id: `infopanel-for-${dfnID}`,
+        "data-for": dfnID,
+        "aria-labelled-by":`infopaneltitle-for-${dfnID}`,
+        },
+        mk.span({id:`infopaneltitle-for-${dfnID}`, style:"display:none"},
+            `Info about the '${dfnText}' ${external?"external":""} reference.`),
+        mk.a({href:url, class:"dfn-link"}, url),
+        refSections.length == 0 ? [] :
+            mk.b({}, "Referenced in:"),
+            mk.ul({},
+                ...refSections.map(section=>
+                    mk.li({},
+                        ...section.refs.map((ref, refI)=>
+                            [
+                                mk.a({ href: `#${ref.id}` },
+                                    (refI == 0) ? section.title : `(${refI + 1})`
+                                ),
+                                " ",
+                            ]
+                        ),
+                    ),
+                ),
+            ),
+        genLinkingSyntaxes(dfn),
+    );
+
+    dfnPanel.addEventListener('click', (event) => {
+        if (event.target.nodeName == 'A') {
+            scrollToTargetAndHighlight(event);
+            pinDfnPanel(dfnPanel);
+        }
+        event.stopPropagation();
+        refocusOnTarget(event);
+    });
+    dfnPanel.addEventListener('keydown', (event) => {
+        if(event.keyCode == 27) { // Escape key
+            hideDfnPanel({dfnPanel});
+            event.stopPropagation();
+            event.preventDefault();
+        }
+    });
+
+    dfnPanel.dfn = dfn;
+    dfn.dfnPanel = dfnPanel;
+    return dfnPanel;
+}
+
+
+
+function hideAllDfnPanels() {
+    // Delete the currently-active dfn panel.
+    queryAll(".dfn-panel").forEach(dfnPanel=>hideDfnPanel({dfnPanel}));
+}
+
+function showDfnPanel(dfn) {
+    hideAllDfnPanels(); // Only display one at a time.
+
+    dfn.setAttribute("aria-expanded", "true");
+
+    const dfnPanel = genDfnPanel(dfn, dfn.panelData);
+
+    // Give the dfn a unique tabindex, and then
+    // give all the tabbable panel bits successive indexes.
+    let tabIndex = 100;
+    dfn.tabIndex = tabIndex++;
+    const tabbable = dfnPanel.querySelectorAll(":is(a, button)");
+    for (const el of tabbable) {
+        el.tabIndex = tabIndex++;
+    }
+
+    append(document.body, dfnPanel);
+    positionDfnPanel(dfnPanel);
+}
+
+function positionDfnPanel(dfnPanel) {
+    const dfn = dfnPanel.dfn;
+    const dfnPos = getBounds(dfn);
+    dfnPanel.style.top = dfnPos.bottom + "px";
+    dfnPanel.style.left = dfnPos.left + "px";
+
+    const panelPos = dfnPanel.getBoundingClientRect();
+    const panelMargin = 8;
+    const maxRight = document.body.parentNode.clientWidth - panelMargin;
+    if (panelPos.right > maxRight) {
+        const overflowAmount = panelPos.right - maxRight;
+        const newLeft = Math.max(panelMargin, dfnPos.left - overflowAmount);
+        dfnPanel.style.left = newLeft + "px";
+    }
+}
+
+function pinDfnPanel(dfnPanel) {
+    // Switch it to "activated" state, which pins it.
+    dfnPanel.classList.add("activated");
+    dfnPanel.style.position = "fixed";
+    dfnPanel.style.left = null;
+    dfnPanel.style.top = null;
+}
+
+function hideDfnPanel({dfn, dfnPanel}) {
+    if(!dfnPanel) dfnPanel = dfn.dfnPanel;
+    if(!dfn) dfn = dfnPanel.dfn;
+    dfn.dfnPanel = undefined;
+    dfnPanel.dfn = undefined;
+    dfn.setAttribute("aria-expanded", "false");
+    dfn.tabIndex = undefined;
+    dfnPanel.remove()
+}
+
+function toggleDfnPanel(dfn) {
+    if(dfn.dfnPanel) {
+        hideDfnPanel(dfn);
+    } else {
+        showDfnPanel(dfn);
+    }
+}
+
+function insertDfnPopupAction(dfn) {
+    dfn.setAttribute('role', 'button');
+    dfn.setAttribute('aria-expanded', 'false')
+    dfn.tabIndex = 0;
+    dfn.classList.add('has-dfn-panel');
+    dfn.addEventListener('click', (event) => {
+        toggleDfnPanel(dfn);
+        event.stopPropagation();
+    });
+    dfn.addEventListener('keypress', (event) => {
+        const kc = event.keyCode;
+        // 32->Space, 13->Enter
+        if(kc == 32 || kc == 13) {
+            toggleDfnPanel(dfn);
+            event.stopPropagation();
+            event.preventDefault();
+        }
+    });
+}
+
+function refocusOnTarget(event) {
+    const target = event.target;
+    setTimeout(() => {
+        // Refocus on the event.target element.
+        // This is needed after browser scrolls to the destination.
+        target.focus();
+    });
+}
+
+// TODO: shared util
+// Returns the root-level absolute position {left and top} of element.
+function getBounds(el, relativeTo=document.body) {
+    const relativeRect = relativeTo.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+    const top = elRect.top - relativeRect.top;
+    const left = elRect.left - relativeRect.left;
+    return {
+        top,
+        left,
+        bottom: top + elRect.height,
+        right: left + elRect.width,
+    }
+}
+
+function scrollToTargetAndHighlight(event) {
+    let hash = event.target.hash;
+    if (hash) {
+        hash = decodeURIComponent(hash.substring(1));
+        const dest = document.getElementById(hash);
+        if (dest) {
+            dest.classList.add('highlighted');
+            setTimeout(() => dest.classList.remove('highlighted'), 1000);
+        }
+    }
+}
+
+// Functions, divided by link type, that wrap an autolink's
+// contents with the appropriate outer syntax.
+// Alternately, a string naming another type they format
+// the same as.
+function needsFor(type) {
+    switch(type) {
+        case "descriptor":
+        case "value":
+        case "element-attr":
+        case "attr-value":
+        case "element-state":
+        case "method":
+        case "constructor":
+        case "argument":
+        case "attribute":
+        case "const":
+        case "dict-member":
+        case "event":
+        case "enum-value":
+        case "stringifier":
+        case "serializer":
+        case "iterator":
+        case "maplike":
+        case "setlike":
+        case "state":
+        case "mode":
+        case "context":
+        case "facet": return true;
+
+        default: return false;
+    }
+}
+function refusesFor(type) {
+    switch(type) {
+        case "property":
+        case "element":
+        case "interface":
+        case "namespace":
+        case "callback":
+        case "dictionary":
+        case "enum":
+        case "exception":
+        case "typedef":
+        case "http-header":
+        case "permission": return true;
+
+        default: return false;
+    }
+}
+function linkFormatterFromType(type) {
+    switch(type) {
+        case 'scheme':
+        case 'permission':
+        case 'dfn': return (text) => `[=${text}=]`;
+
+        case 'abstract-op': return (text) => `[\$${text}\$]`;
+
+        case 'function':
+        case 'at-rule':
+        case 'selector':
+        case 'value': return (text) => `''${text}''`;
+
+        case 'http-header': return (text) => `[:${text}:]`;
+
+        case 'interface':
+        case 'constructor':
+        case 'method':
+        case 'argument':
+        case 'attribute':
+        case 'callback':
+        case 'dictionary':
+        case 'dict-member':
+        case 'enum':
+        case 'enum-value':
+        case 'exception':
+        case 'const':
+        case 'typedef':
+        case 'stringifier':
+        case 'serializer':
+        case 'iterator':
+        case 'maplike':
+        case 'setlike':
+        case 'extended-attribute':
+        case 'event':
+        case 'idl': return (text) => `{{${text}}}`;
+
+        case 'element-state':
+        case 'element-attr':
+        case 'attr-value':
+        case 'element': return (element) => `<{${element}}>`;
+
+        case 'grammar': return (text) => `${text} (within a <pre class=prod>)`;
+
+        case 'type': return (text)=> `<<${text}>>`;
+
+        case 'descriptor':
+        case 'property': return (text) => `'${text}'`;
+
+        default: return;
+    };
+};
+
+function genLinkingSyntaxes(dfn) {
+    if(dfn.tagName != "DFN") return;
+
+    const type = dfn.getAttribute('data-dfn-type');
+    if(!type) {
+        console.log(`<dfn> doesn't have a data-dfn-type:`, dfn);
+        return [];
+    }
+
+    // Return a function that wraps link text based on the type
+    const linkFormatter = linkFormatterFromType(type);
+    if(!linkFormatter) {
+        console.log(`<dfn> has an unknown data-dfn-type:`, dfn);
+        return [];
+    }
+
+    let ltAlts;
+    if(dfn.hasAttribute('data-lt')) {
+        ltAlts = dfn.getAttribute('data-lt')
+            .split("|")
+            .map(x=>x.trim());
+    } else {
+        ltAlts = [dfn.textContent.trim()];
+    }
+    if(type == "type") {
+        // lt of "<foo>", but "foo" is the interior;
+        // <<foo/bar>> is how you write it with a for,
+        // not <foo/<bar>> or whatever.
+        for(var i = 0; i < ltAlts.length; i++) {
+            const lt = ltAlts[i];
+            const match = /<(.*)>/.exec(lt);
+            if(match) { ltAlts[i] = match[1]; }
+        }
+    }
+
+    let forAlts;
+    if(dfn.hasAttribute('data-dfn-for')) {
+        forAlts = dfn.getAttribute('data-dfn-for')
+            .split(",")
+            .map(x=>x.trim());
+    } else {
+        forAlts = [''];
+    }
+
+    let linkingSyntaxes = [];
+    if(!needsFor(type)) {
+        for(const lt of ltAlts) {
+            linkingSyntaxes.push(linkFormatter(lt));
+        }
+    }
+    if(!refusesFor(type)) {
+        for(const f of forAlts) {
+            linkingSyntaxes.push(linkFormatter(`${f}/${ltAlts[0]}`))
+        }
+    }
+    return [
+        mk.b({}, 'Possible linking syntaxes:'),
+        mk.ul({},
+            ...linkingSyntaxes.map(link => {
+                const copyLink = async () =>
+                    await navigator.clipboard.writeText(link);
+                return mk.li({},
+                    mk.div({ class: 'link-item' },
+                        mk.button({
+                            class: 'copy-icon', title: 'Copy',
+                            type: 'button',
+                            _onclick: copyLink,
+                            tabindex: 0,
+                        }, mk.span({ class: 'icon' }) ),
+                        mk.span({}, link)
+                    )
+                );
+            })
+        )
+    ];
+}
+}
+</script>
+<script>/* Boilerplate: script-ref-hints */
+"use strict";
+{
+let refsData = {
+"#boolean-not": {"displayText":"not","export":true,"for_":["boolean"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"not","type":"dfn","url":"#boolean-not"},
+"#built-in-animating-url-attributes-list": {"displayText":"built-in animating url attributes list","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"built-in animating url attributes list","type":"dfn","url":"#built-in-animating-url-attributes-list"},
+"#built-in-navigating-url-attributes-list": {"displayText":"built-in navigating url attributes list","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"built-in navigating url attributes list","type":"dfn","url":"#built-in-navigating-url-attributes-list"},
+"#built-in-safe-baseline-configuration": {"displayText":"built-in safe baseline configuration","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"built-in safe baseline configuration","type":"dfn","url":"#built-in-safe-baseline-configuration"},
+"#built-in-safe-default-configuration": {"displayText":"built-in safe default configuration","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"built-in safe default configuration","type":"dfn","url":"#built-in-safe-default-configuration"},
+"#canonicalize-a-sanitizer-attribute": {"displayText":"canonicalize a sanitizer attribute","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"canonicalize a sanitizer attribute","type":"dfn","url":"#canonicalize-a-sanitizer-attribute"},
+"#canonicalize-a-sanitizer-element": {"displayText":"canonicalize a sanitizer element","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"canonicalize a sanitizer element","type":"dfn","url":"#canonicalize-a-sanitizer-element"},
+"#canonicalize-a-sanitizer-element-with-attributes": {"displayText":"canonicalize a sanitizer element with attributes","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"canonicalize a sanitizer element with attributes","type":"dfn","url":"#canonicalize-a-sanitizer-element-with-attributes"},
+"#canonicalize-a-sanitizer-name": {"displayText":"canonicalize a sanitizer name","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"canonicalize a sanitizer name","type":"dfn","url":"#canonicalize-a-sanitizer-name"},
+"#comment": {"displayText":"comment","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"comment","type":"dfn","url":"#comment"},
+"#contains-a-javascript-url": {"displayText":"contains a javascript: url","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"contains a javascript: url","type":"dfn","url":"#contains-a-javascript-url"},
+"#dictdef-sanitizerattributenamespace": {"displayText":"SanitizerAttributeNamespace","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"SanitizerAttributeNamespace","type":"dictionary","url":"#dictdef-sanitizerattributenamespace"},
+"#dictdef-sanitizerconfig": {"displayText":"SanitizerConfig","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"SanitizerConfig","type":"dictionary","url":"#dictdef-sanitizerconfig"},
+"#dictdef-sanitizerelementnamespace": {"displayText":"SanitizerElementNamespace","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"SanitizerElementNamespace","type":"dictionary","url":"#dictdef-sanitizerelementnamespace"},
+"#dictdef-sanitizerelementnamespacewithattributes": {"displayText":"SanitizerElementNamespaceWithAttributes","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"SanitizerElementNamespaceWithAttributes","type":"dictionary","url":"#dictdef-sanitizerelementnamespacewithattributes"},
+"#dictdef-sethtmloptions": {"displayText":"SetHTMLOptions","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"SetHTMLOptions","type":"dictionary","url":"#dictdef-sethtmloptions"},
+"#dictdef-sethtmlunsafeoptions": {"displayText":"SetHTMLUnsafeOptions","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"SetHTMLUnsafeOptions","type":"dictionary","url":"#dictdef-sethtmlunsafeoptions"},
+"#dom-document-parsehtml": {"displayText":"parseHTML(html, options)","export":true,"for_":["Document"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"parseHTML(html, options)","type":"method","url":"#dom-document-parsehtml"},
+"#dom-document-parsehtmlunsafe": {"displayText":"parseHTMLUnsafe(html, options)","export":true,"for_":["Document"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"parseHTMLUnsafe(html, options)","type":"method","url":"#dom-document-parsehtmlunsafe"},
+"#dom-element-sethtml": {"displayText":"setHTML(html)","export":true,"for_":["Element"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"setHTML(html)","type":"method","url":"#dom-element-sethtml"},
+"#dom-element-sethtmlunsafe": {"displayText":"setHTMLUnsafe(html)","export":true,"for_":["Element"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"setHTMLUnsafe(html)","type":"method","url":"#dom-element-sethtmlunsafe"},
+"#dom-sanitizer-allowattribute": {"displayText":"allowAttribute(attribute)","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"allowAttribute(attribute)","type":"method","url":"#dom-sanitizer-allowattribute"},
+"#dom-sanitizer-allowelement": {"displayText":"allowElement(element)","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"allowElement(element)","type":"method","url":"#dom-sanitizer-allowelement"},
+"#dom-sanitizer-constructor": {"displayText":"constructor(configuration)","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"constructor(configuration)","type":"constructor","url":"#dom-sanitizer-constructor"},
+"#dom-sanitizer-get": {"displayText":"get()","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"get()","type":"method","url":"#dom-sanitizer-get"},
+"#dom-sanitizer-removeattribute": {"displayText":"removeAttribute(attribute)","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"removeAttribute(attribute)","type":"method","url":"#dom-sanitizer-removeattribute"},
+"#dom-sanitizer-removeelement": {"displayText":"removeElement(element)","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"removeElement(element)","type":"method","url":"#dom-sanitizer-removeelement"},
+"#dom-sanitizer-removeunsafe": {"displayText":"removeUnsafe()","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"removeUnsafe()","type":"method","url":"#dom-sanitizer-removeunsafe"},
+"#dom-sanitizer-replaceelementwithchildren": {"displayText":"replaceElementWithChildren(element)","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"replaceElementWithChildren(element)","type":"method","url":"#dom-sanitizer-replaceelementwithchildren"},
+"#dom-sanitizer-setcomments": {"displayText":"setComments(allow)","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"setComments(allow)","type":"method","url":"#dom-sanitizer-setcomments"},
+"#dom-sanitizer-setdataattributes": {"displayText":"setDataAttributes(allow)","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"setDataAttributes(allow)","type":"method","url":"#dom-sanitizer-setdataattributes"},
+"#dom-sanitizerconfig-attributes": {"displayText":"attributes","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"attributes","type":"dict-member","url":"#dom-sanitizerconfig-attributes"},
+"#dom-sanitizerconfig-comments": {"displayText":"comments","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"comments","type":"dict-member","url":"#dom-sanitizerconfig-comments"},
+"#dom-sanitizerconfig-dataattributes": {"displayText":"dataAttributes","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"dataAttributes","type":"dict-member","url":"#dom-sanitizerconfig-dataattributes"},
+"#dom-sanitizerconfig-elements": {"displayText":"elements","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"elements","type":"dict-member","url":"#dom-sanitizerconfig-elements"},
+"#dom-sanitizerconfig-removeattributes": {"displayText":"removeAttributes","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"removeAttributes","type":"dict-member","url":"#dom-sanitizerconfig-removeattributes"},
+"#dom-sanitizerconfig-removeelements": {"displayText":"removeElements","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"removeElements","type":"dict-member","url":"#dom-sanitizerconfig-removeelements"},
+"#dom-sanitizerconfig-replacewithchildrenelements": {"displayText":"replaceWithChildrenElements","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"replaceWithChildrenElements","type":"dict-member","url":"#dom-sanitizerconfig-replacewithchildrenelements"},
+"#dom-sanitizerelementnamespace-name": {"displayText":"name","export":true,"for_":["SanitizerElementNamespace"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"name","type":"dict-member","url":"#dom-sanitizerelementnamespace-name"},
+"#dom-sanitizerelementnamespace-namespace": {"displayText":"namespace","export":true,"for_":["SanitizerElementNamespace"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"namespace","type":"dict-member","url":"#dom-sanitizerelementnamespace-namespace"},
+"#dom-sanitizerelementnamespacewithattributes-attributes": {"displayText":"attributes","export":true,"for_":["SanitizerElementNamespaceWithAttributes"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"attributes","type":"dict-member","url":"#dom-sanitizerelementnamespacewithattributes-attributes"},
+"#dom-sanitizerelementnamespacewithattributes-removeattributes": {"displayText":"removeAttributes","export":true,"for_":["SanitizerElementNamespaceWithAttributes"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"removeAttributes","type":"dict-member","url":"#dom-sanitizerelementnamespacewithattributes-removeattributes"},
+"#dom-sanitizerpresets-default": {"displayText":"\"default\"","export":true,"for_":["SanitizerPresets"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"\"default\"","type":"enum-value","url":"#dom-sanitizerpresets-default"},
+"#dom-sethtmloptions-sanitizer": {"displayText":"sanitizer","export":true,"for_":["SetHTMLOptions"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"sanitizer","type":"dict-member","url":"#dom-sethtmloptions-sanitizer"},
+"#dom-shadowroot-sethtml": {"displayText":"setHTML(html, options)","export":true,"for_":["ShadowRoot"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"setHTML(html, options)","type":"method","url":"#dom-shadowroot-sethtml"},
+"#dom-shadowroot-sethtmlunsafe": {"displayText":"setHTMLUnsafe(html, options)","export":true,"for_":["ShadowRoot"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"setHTMLUnsafe(html, options)","type":"method","url":"#dom-shadowroot-sethtmlunsafe"},
+"#enumdef-sanitizerpresets": {"displayText":"SanitizerPresets","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"SanitizerPresets","type":"enum","url":"#enumdef-sanitizerpresets"},
+"#handlejavascriptnavigationurls": {"displayText":"handlejavascriptnavigationurls","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"handlejavascriptnavigationurls","type":"dfn","url":"#handlejavascriptnavigationurls"},
+"#map-equal": {"displayText":"equal","export":true,"for_":["map"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"equal","type":"dfn","url":"#map-equal"},
+"#safe-and-unsafe": {"displayText":"safe and unsafe","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"safe and unsafe","type":"dfn","url":"#safe-and-unsafe"},
+"#sanitize": {"displayText":"sanitize","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"sanitize","type":"dfn","url":"#sanitize"},
+"#sanitize-core": {"displayText":"sanitize core","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"sanitize core","type":"dfn","url":"#sanitize-core"},
+"#sanitizer": {"displayText":"Sanitizer","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"Sanitizer","type":"interface","url":"#sanitizer"},
+"#sanitizer-allow-an-attribute": {"displayText":"allow an attribute","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"allow an attribute","type":"dfn","url":"#sanitizer-allow-an-attribute"},
+"#sanitizer-canonicalize-the-configuration": {"displayText":"canonicalize the configuration","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"canonicalize the configuration","type":"dfn","url":"#sanitizer-canonicalize-the-configuration"},
+"#sanitizer-configuration": {"displayText":"configuration","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"configuration","type":"dfn","url":"#sanitizer-configuration"},
+"#sanitizer-remove-an-attribute": {"displayText":"remove an attribute","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"remove an attribute","type":"dfn","url":"#sanitizer-remove-an-attribute"},
+"#sanitizer-remove-an-element": {"displayText":"remove an element","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"remove an element","type":"dfn","url":"#sanitizer-remove-an-element"},
+"#sanitizer-replace-an-element-with-its-children": {"displayText":"replace an element with its children","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"replace an element with its children","type":"dfn","url":"#sanitizer-replace-an-element-with-its-children"},
+"#sanitizer-set-a-configuration": {"displayText":"set a configuration","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"set a configuration","type":"dfn","url":"#sanitizer-set-a-configuration"},
+"#sanitizer-set-comments": {"displayText":"set comments","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"set comments","type":"dfn","url":"#sanitizer-set-comments"},
+"#sanitizer-set-data-attributes": {"displayText":"set data attributes","export":true,"for_":["Sanitizer"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"set data attributes","type":"dfn","url":"#sanitizer-set-data-attributes"},
+"#sanitizerconfig-add": {"displayText":"add","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"add","type":"dfn","url":"#sanitizerconfig-add"},
+"#sanitizerconfig-allow-an-element": {"displayText":"allow an element","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"allow an element","type":"dfn","url":"#sanitizerconfig-allow-an-element"},
+"#sanitizerconfig-contains": {"displayText":"contains","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"contains","type":"dfn","url":"#sanitizerconfig-contains"},
+"#sanitizerconfig-get-a-sanitizer-instance-from-options": {"displayText":"get a sanitizer instance from options","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"get a sanitizer instance from options","type":"dfn","url":"#sanitizerconfig-get-a-sanitizer-instance-from-options"},
+"#sanitizerconfig-has-duplicates": {"displayText":"has duplicates","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"has duplicates","type":"dfn","url":"#sanitizerconfig-has-duplicates"},
+"#sanitizerconfig-intersection": {"displayText":"intersection","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"intersection","type":"dfn","url":"#sanitizerconfig-intersection"},
+"#sanitizerconfig-less-than-item": {"displayText":"less than item","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"less than item","type":"dfn","url":"#sanitizerconfig-less-than-item"},
+"#sanitizerconfig-remove": {"displayText":"remove","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"remove","type":"dfn","url":"#sanitizerconfig-remove"},
+"#sanitizerconfig-remove-duplicates": {"displayText":"remove duplicates","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"remove duplicates","type":"dfn","url":"#sanitizerconfig-remove-duplicates"},
+"#sanitizerconfig-remove-unsafe": {"displayText":"remove unsafe","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"remove unsafe","type":"dfn","url":"#sanitizerconfig-remove-unsafe"},
+"#sanitizerconfig-valid": {"displayText":"valid","export":true,"for_":["SanitizerConfig"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"valid","type":"dfn","url":"#sanitizerconfig-valid"},
+"#set-and-filter-html": {"displayText":"set and filter html","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"set and filter html","type":"dfn","url":"#set-and-filter-html"},
+"#set-equal": {"displayText":"equal","export":true,"for_":["set"],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"equal","type":"dfn","url":"#set-equal"},
+"#typedefdef-sanitizerattribute": {"displayText":"SanitizerAttribute","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"SanitizerAttribute","type":"typedef","url":"#typedefdef-sanitizerattribute"},
+"#typedefdef-sanitizerelement": {"displayText":"SanitizerElement","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"SanitizerElement","type":"typedef","url":"#typedefdef-sanitizerelement"},
+"#typedefdef-sanitizerelementwithattributes": {"displayText":"SanitizerElementWithAttributes","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"sanitizer-api-1","status":"local","text":"SanitizerElementWithAttributes","type":"typedef","url":"#typedefdef-sanitizerelementwithattributes"},
+"https://console.spec.whatwg.org/#report-a-warning-to-the-console": {"displayText":"report a warning to the console","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"","status":"anchor-block","text":"report a warning to the console","type":"dfn","url":"https://console.spec.whatwg.org/#report-a-warning-to-the-console"},
+"https://dom.spec.whatwg.org/#comment": {"displayText":"Comment","export":true,"for_":[],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"Comment","type":"interface","url":"https://dom.spec.whatwg.org/#comment"},
+"https://dom.spec.whatwg.org/#concept-attribute": {"displayText":"attribute","export":true,"for_":[],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"attribute","type":"dfn","url":"https://dom.spec.whatwg.org/#concept-attribute"},
+"https://dom.spec.whatwg.org/#concept-attribute-local-name": {"displayText":"local name","export":true,"for_":["Attr"],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"local name","type":"dfn","url":"https://dom.spec.whatwg.org/#concept-attribute-local-name"},
+"https://dom.spec.whatwg.org/#concept-attribute-namespace": {"displayText":"namespace","export":true,"for_":["Attr"],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"namespace","type":"dfn","url":"https://dom.spec.whatwg.org/#concept-attribute-namespace"},
+"https://dom.spec.whatwg.org/#concept-document-content-type": {"displayText":"content type","export":true,"for_":["Document"],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"content type","type":"dfn","url":"https://dom.spec.whatwg.org/#concept-document-content-type"},
+"https://dom.spec.whatwg.org/#concept-element-attribute": {"displayText":"attribute list","export":true,"for_":["Element"],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"attribute list","type":"dfn","url":"https://dom.spec.whatwg.org/#concept-element-attribute"},
+"https://dom.spec.whatwg.org/#concept-element-attributes-get-value": {"displayText":"get an attribute value","export":true,"for_":[],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"get an attribute value","type":"dfn","url":"https://dom.spec.whatwg.org/#concept-element-attributes-get-value"},
+"https://dom.spec.whatwg.org/#concept-element-attributes-remove": {"displayText":"remove an attribute","export":true,"for_":[],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"remove an attribute","type":"dfn","url":"https://dom.spec.whatwg.org/#concept-element-attributes-remove"},
+"https://dom.spec.whatwg.org/#concept-element-local-name": {"displayText":"local name","export":true,"for_":["Element"],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"local name","type":"dfn","url":"https://dom.spec.whatwg.org/#concept-element-local-name"},
+"https://dom.spec.whatwg.org/#concept-element-namespace": {"displayText":"namespace","export":true,"for_":["Element"],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"namespace","type":"dfn","url":"https://dom.spec.whatwg.org/#concept-element-namespace"},
+"https://dom.spec.whatwg.org/#concept-element-shadow-root": {"displayText":"shadow root","export":true,"for_":["Element"],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"shadow root","type":"dfn","url":"https://dom.spec.whatwg.org/#concept-element-shadow-root"},
+"https://dom.spec.whatwg.org/#concept-node-document": {"displayText":"node document","export":true,"for_":["Node"],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"node document","type":"dfn","url":"https://dom.spec.whatwg.org/#concept-node-document"},
+"https://dom.spec.whatwg.org/#concept-node-remove": {"displayText":"remove","export":true,"for_":[],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"remove","type":"dfn","url":"https://dom.spec.whatwg.org/#concept-node-remove"},
+"https://dom.spec.whatwg.org/#concept-node-replace-all": {"displayText":"replace all","export":true,"for_":["Node"],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"replace all","type":"dfn","url":"https://dom.spec.whatwg.org/#concept-node-replace-all"},
+"https://dom.spec.whatwg.org/#concept-tree-child": {"displayText":"children","export":true,"for_":["tree"],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"children","type":"dfn","url":"https://dom.spec.whatwg.org/#concept-tree-child"},
+"https://dom.spec.whatwg.org/#document": {"displayText":"Document","export":true,"for_":[],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"Document","type":"interface","url":"https://dom.spec.whatwg.org/#document"},
+"https://dom.spec.whatwg.org/#document-allow-declarative-shadow-roots": {"displayText":"allow declarative shadow roots","export":true,"for_":["Document"],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"allow declarative shadow roots","type":"dfn","url":"https://dom.spec.whatwg.org/#document-allow-declarative-shadow-roots"},
+"https://dom.spec.whatwg.org/#documentfragment": {"displayText":"DocumentFragment","export":true,"for_":[],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"DocumentFragment","type":"interface","url":"https://dom.spec.whatwg.org/#documentfragment"},
+"https://dom.spec.whatwg.org/#documenttype": {"displayText":"DocumentType","export":true,"for_":[],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"DocumentType","type":"interface","url":"https://dom.spec.whatwg.org/#documenttype"},
+"https://dom.spec.whatwg.org/#element": {"displayText":"Element","export":true,"for_":[],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"Element","type":"interface","url":"https://dom.spec.whatwg.org/#element"},
+"https://dom.spec.whatwg.org/#element-shadow-host": {"displayText":"shadow host","export":true,"for_":["Element"],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"shadow host","type":"dfn","url":"https://dom.spec.whatwg.org/#element-shadow-host"},
+"https://dom.spec.whatwg.org/#node": {"displayText":"Node","export":true,"for_":[],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"Node","type":"interface","url":"https://dom.spec.whatwg.org/#node"},
+"https://dom.spec.whatwg.org/#parentnode": {"displayText":"ParentNode","export":true,"for_":[],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"ParentNode","type":"interface","url":"https://dom.spec.whatwg.org/#parentnode"},
+"https://dom.spec.whatwg.org/#shadowroot": {"displayText":"ShadowRoot","export":true,"for_":[],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"ShadowRoot","type":"interface","url":"https://dom.spec.whatwg.org/#shadowroot"},
+"https://dom.spec.whatwg.org/#text": {"displayText":"Text","export":true,"for_":[],"level":"1","normative":true,"shortname":"dom","spec":"dom","status":"current","text":"Text","type":"interface","url":"https://dom.spec.whatwg.org/#text"},
+"https://html.spec.whatwg.org/#html-fragment-parsing-algorithm": {"displayText":"HTML fragment parsing algorithm","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"","status":"anchor-block","text":"html fragment parsing algorithm","type":"dfn","url":"https://html.spec.whatwg.org/#html-fragment-parsing-algorithm"},
+"https://html.spec.whatwg.org/#parse-html-from-a-string": {"displayText":"parse HTML from a string","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"","status":"anchor-block","text":"parse html from a string","type":"dfn","url":"https://html.spec.whatwg.org/#parse-html-from-a-string"},
+"https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions": {"displayText":"CEReactions","export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"CEReactions","type":"extended-attribute","url":"https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions"},
+"https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute": {"displayText":"custom data attribute","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"","status":"anchor-block","text":"custom data attribute","type":"dfn","url":"https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute"},
+"https://html.spec.whatwg.org/multipage/dom.html#global-attributes": {"displayText":"global attribute","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"","status":"anchor-block","text":"global attribute","type":"dfn","url":"https://html.spec.whatwg.org/multipage/dom.html#global-attributes"},
+"https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring": {"displayText":"parseFromString(string, type)","export":true,"for_":["DOMParser"],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"parseFromString(string, type)","type":"method","url":"https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring"},
+"https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-element-innerhtml": {"displayText":"innerHTML","export":true,"for_":["Element"],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"innerHTML","type":"attribute","url":"https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-element-innerhtml"},
+"https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#domparser": {"displayText":"DOMParser","export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"DOMParser","type":"interface","url":"https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#domparser"},
+"https://html.spec.whatwg.org/multipage/scripting.html#htmltemplateelement": {"displayText":"HTMLTemplateElement","export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"HTMLTemplateElement","type":"interface","url":"https://html.spec.whatwg.org/multipage/scripting.html#htmltemplateelement"},
+"https://html.spec.whatwg.org/multipage/scripting.html#template-contents": {"displayText":"template contents","export":false,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"template contents","type":"dfn","url":"https://html.spec.whatwg.org/multipage/scripting.html#template-contents"},
+"https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global": {"displayText":"relevant global object","export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"relevant global object","type":"dfn","url":"https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global"},
+"https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes": {"displayText":"event handler content attribute","export":true,"for_":[],"level":"1","normative":true,"shortname":"html","spec":"html","status":"current","text":"event handler content attribute","type":"dfn","url":"https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes"},
+"https://infra.spec.whatwg.org/#assert": {"displayText":"assert","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"assert","type":"dfn","url":"https://infra.spec.whatwg.org/#assert"},
+"https://infra.spec.whatwg.org/#boolean": {"displayText":"boolean","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"boolean","type":"dfn","url":"https://infra.spec.whatwg.org/#boolean"},
+"https://infra.spec.whatwg.org/#code-unit-less-than": {"displayText":"code unit less than","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"code unit less than","type":"dfn","url":"https://infra.spec.whatwg.org/#code-unit-less-than"},
+"https://infra.spec.whatwg.org/#code-unit-prefix": {"displayText":"code unit prefix","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"code unit prefix","type":"dfn","url":"https://infra.spec.whatwg.org/#code-unit-prefix"},
+"https://infra.spec.whatwg.org/#html-namespace": {"displayText":"HTML namespace","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"html namespace","type":"dfn","url":"https://infra.spec.whatwg.org/#html-namespace"},
+"https://infra.spec.whatwg.org/#iteration-continue": {"displayText":"continue","export":true,"for_":["iteration"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"continue","type":"dfn","url":"https://infra.spec.whatwg.org/#iteration-continue"},
+"https://infra.spec.whatwg.org/#list": {"displayText":"list","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"list","type":"dfn","url":"https://infra.spec.whatwg.org/#list"},
+"https://infra.spec.whatwg.org/#list-append": {"displayText":"append","export":true,"for_":["list"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"append","type":"dfn","url":"https://infra.spec.whatwg.org/#list-append"},
+"https://infra.spec.whatwg.org/#list-contain": {"displayText":"contain","export":true,"for_":["list","stack","queue","set"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"contain","type":"dfn","url":"https://infra.spec.whatwg.org/#list-contain"},
+"https://infra.spec.whatwg.org/#list-empty": {"displayText":"empty","export":true,"for_":["list","stack","queue","set"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"empty","type":"dfn","url":"https://infra.spec.whatwg.org/#list-empty"},
+"https://infra.spec.whatwg.org/#list-iterate": {"displayText":"iterate","export":true,"for_":["list","set"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"iterate","type":"dfn","url":"https://infra.spec.whatwg.org/#list-iterate"},
+"https://infra.spec.whatwg.org/#list-remove": {"displayText":"remove","export":true,"for_":["list","set"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"remove","type":"dfn","url":"https://infra.spec.whatwg.org/#list-remove"},
+"https://infra.spec.whatwg.org/#list-sort-in-ascending-order": {"displayText":"sort in ascending order","export":true,"for_":["list","stack","queue","set"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"sort in ascending order","type":"dfn","url":"https://infra.spec.whatwg.org/#list-sort-in-ascending-order"},
+"https://infra.spec.whatwg.org/#map-entry": {"displayText":"entry","export":true,"for_":["map"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"entry","type":"dfn","url":"https://infra.spec.whatwg.org/#map-entry"},
+"https://infra.spec.whatwg.org/#map-exists": {"displayText":"exist","export":true,"for_":["map"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"exist","type":"dfn","url":"https://infra.spec.whatwg.org/#map-exists"},
+"https://infra.spec.whatwg.org/#map-getting-the-keys": {"displayText":"get the keys","export":true,"for_":["map"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"get the keys","type":"dfn","url":"https://infra.spec.whatwg.org/#map-getting-the-keys"},
+"https://infra.spec.whatwg.org/#map-key": {"displayText":"key","export":true,"for_":["map"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"key","type":"dfn","url":"https://infra.spec.whatwg.org/#map-key"},
+"https://infra.spec.whatwg.org/#map-set": {"displayText":"set","export":true,"for_":["map"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"set","type":"dfn","url":"https://infra.spec.whatwg.org/#map-set"},
+"https://infra.spec.whatwg.org/#map-value": {"displayText":"value","export":true,"for_":["map"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"value","type":"dfn","url":"https://infra.spec.whatwg.org/#map-value"},
+"https://infra.spec.whatwg.org/#map-with-default": {"displayText":"with default","export":true,"for_":["map"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"with default","type":"dfn","url":"https://infra.spec.whatwg.org/#map-with-default"},
+"https://infra.spec.whatwg.org/#mathml-namespace": {"displayText":"MathML namespace","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"mathml namespace","type":"dfn","url":"https://infra.spec.whatwg.org/#mathml-namespace"},
+"https://infra.spec.whatwg.org/#ordered-map": {"displayText":"ordered map","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"ordered map","type":"dfn","url":"https://infra.spec.whatwg.org/#ordered-map"},
+"https://infra.spec.whatwg.org/#ordered-set": {"displayText":"ordered set","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"ordered set","type":"dfn","url":"https://infra.spec.whatwg.org/#ordered-set"},
+"https://infra.spec.whatwg.org/#set-append": {"displayText":"append","export":true,"for_":["set"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"append","type":"dfn","url":"https://infra.spec.whatwg.org/#set-append"},
+"https://infra.spec.whatwg.org/#set-difference": {"displayText":"difference","export":true,"for_":["set"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"difference","type":"dfn","url":"https://infra.spec.whatwg.org/#set-difference"},
+"https://infra.spec.whatwg.org/#set-intersection": {"displayText":"intersection","export":true,"for_":["set"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"intersection","type":"dfn","url":"https://infra.spec.whatwg.org/#set-intersection"},
+"https://infra.spec.whatwg.org/#set-subset": {"displayText":"subset","export":true,"for_":["set"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"subset","type":"dfn","url":"https://infra.spec.whatwg.org/#set-subset"},
+"https://infra.spec.whatwg.org/#set-superset": {"displayText":"superset","export":true,"for_":["set"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"superset","type":"dfn","url":"https://infra.spec.whatwg.org/#set-superset"},
+"https://infra.spec.whatwg.org/#string": {"displayText":"string","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"string","type":"dfn","url":"https://infra.spec.whatwg.org/#string"},
+"https://infra.spec.whatwg.org/#string-is": {"displayText":"is","export":true,"for_":["string"],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"is","type":"dfn","url":"https://infra.spec.whatwg.org/#string-is"},
+"https://infra.spec.whatwg.org/#svg-namespace": {"displayText":"SVG namespace","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"svg namespace","type":"dfn","url":"https://infra.spec.whatwg.org/#svg-namespace"},
+"https://infra.spec.whatwg.org/#tuple": {"displayText":"tuple","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"tuple","type":"dfn","url":"https://infra.spec.whatwg.org/#tuple"},
+"https://infra.spec.whatwg.org/#user-agent": {"displayText":"user agent","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"user agent","type":"dfn","url":"https://infra.spec.whatwg.org/#user-agent"},
+"https://infra.spec.whatwg.org/#xlink-namespace": {"displayText":"XLink namespace","export":true,"for_":[],"level":"1","normative":true,"shortname":"infra","spec":"infra","status":"current","text":"xlink namespace","type":"dfn","url":"https://infra.spec.whatwg.org/#xlink-namespace"},
+"https://msdn.microsoft.com/en-us/library/cc848922(v=vs.85).aspx": {"displayText":"window.toStaticHTML()","export":true,"for_":[],"level":"1","normative":true,"shortname":"sanitizer-api","spec":"","status":"anchor-block","text":"window.toStaticHTML()","type":"method","url":"https://msdn.microsoft.com/en-us/library/cc848922(v=vs.85).aspx"},
+"https://url.spec.whatwg.org/#concept-basic-url-parser": {"displayText":"basic URL parser","export":true,"for_":[],"level":"1","normative":true,"shortname":"url","spec":"url","status":"current","text":"basic url parser","type":"dfn","url":"https://url.spec.whatwg.org/#concept-basic-url-parser"},
+"https://url.spec.whatwg.org/#concept-url-scheme": {"displayText":"scheme","export":true,"for_":["url"],"level":"1","normative":true,"shortname":"url","spec":"url","status":"current","text":"scheme","type":"dfn","url":"https://url.spec.whatwg.org/#concept-url-scheme"},
+"https://w3c.github.io/trusted-types/dist/spec/#abstract-opdef-get-trusted-type-compliant-string": {"displayText":"Get Trusted Type compliant string","export":true,"for_":[],"level":"1","normative":true,"shortname":"trusted-types","spec":"trusted-types","status":"current","text":"Get Trusted Type compliant string","type":"abstract-op","url":"https://w3c.github.io/trusted-types/dist/spec/#abstract-opdef-get-trusted-type-compliant-string"},
+"https://w3c.github.io/trusted-types/dist/spec/#trustedhtml": {"displayText":"TrustedHTML","export":true,"for_":[],"level":"1","normative":true,"shortname":"trusted-types","spec":"trusted-types","status":"current","text":"TrustedHTML","type":"interface","url":"https://w3c.github.io/trusted-types/dist/spec/#trustedhtml"},
+"https://webidl.spec.whatwg.org/#Exposed": {"displayText":"Exposed","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"Exposed","type":"extended-attribute","url":"https://webidl.spec.whatwg.org/#Exposed"},
+"https://webidl.spec.whatwg.org/#dfn-dictionary": {"displayText":"dictionary","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"dictionary","type":"dfn","url":"https://webidl.spec.whatwg.org/#dfn-dictionary"},
+"https://webidl.spec.whatwg.org/#dfn-throw": {"displayText":"throw","export":true,"for_":["exception"],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"throw","type":"dfn","url":"https://webidl.spec.whatwg.org/#dfn-throw"},
+"https://webidl.spec.whatwg.org/#exceptiondef-typeerror": {"displayText":"TypeError","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"TypeError","type":"exception","url":"https://webidl.spec.whatwg.org/#exceptiondef-typeerror"},
+"https://webidl.spec.whatwg.org/#idl-DOMString": {"displayText":"DOMString","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"DOMString","type":"interface","url":"https://webidl.spec.whatwg.org/#idl-DOMString"},
+"https://webidl.spec.whatwg.org/#idl-boolean": {"displayText":"boolean","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"boolean","type":"interface","url":"https://webidl.spec.whatwg.org/#idl-boolean"},
+"https://webidl.spec.whatwg.org/#idl-sequence": {"displayText":"sequence","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"sequence","type":"dfn","url":"https://webidl.spec.whatwg.org/#idl-sequence"},
+"https://webidl.spec.whatwg.org/#idl-undefined": {"displayText":"undefined","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"undefined","type":"interface","url":"https://webidl.spec.whatwg.org/#idl-undefined"},
+"https://webidl.spec.whatwg.org/#implements": {"displayText":"implements","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"implements","type":"dfn","url":"https://webidl.spec.whatwg.org/#implements"},
+"https://webidl.spec.whatwg.org/#this": {"displayText":"this","export":true,"for_":[],"level":"1","normative":true,"shortname":"webidl","spec":"webidl","status":"current","text":"this","type":"dfn","url":"https://webidl.spec.whatwg.org/#this"},
+};
+
+function mkRefHint(link, ref) {
+    const linkText = link.textContent;
+    let dfnTextElements = '';
+    if (ref.displayText.toLowerCase() != linkText.toLowerCase()) {
+        // Give the original term if it's being displayed in a different way.
+        // But allow casing differences, they're insignificant.
+        dfnTextElements =
+            mk.li({},
+                mk.b({}, "Term: "),
+                mk.span({}, ref.displayText)
+            );
+    }
+    const forList = ref.for_;
+    let forListElements;
+    if(forList.length == 0) {
+        forListElements = [];
+    } else if(forList.length == 1) {
+        forListElements = mk.li({},
+            mk.b({}, "For: "),
+            mk.span({}, forList[0]),
+        );
+    } else {
+        forListElements = mk.li({},
+            mk.b({}, "For: "),
+            mk.ul({},
+                ...forList.map(forItem =>
+                    mk.li({},
+                        mk.span({}, forItem)
+                    ),
+                ),
+            ),
+        );
+    }
+    const url = ref.url;
+    const safeUrl = encodeURIComponent(url);
+    const hintPanel = mk.aside({
+        class: "ref-hint",
+        id: `ref-hint-for-${safeUrl}`,
+        "data-for": url,
+        "aria-labelled-by": `ref-hint-for-${safeUrl}`,
+    },
+        mk.ul({},
+            dfnTextElements,
+            mk.li({},
+                mk.b({}, "URL: "),
+                mk.a({ href: url, class: "ref" }, url),
+            ),
+            mk.li({},
+                mk.b({}, "Type: "),
+                mk.span({}, `${ref.type}`),
+            ),
+            mk.li({},
+                mk.b({}, "Spec: "),
+                mk.span({}, `${ref.spec ? ref.spec : ''}`),
+            ),
+            forListElements
+        ),
+    );
+    hintPanel.forLink = link;
+    setupRefHintEventListeners(link, hintPanel);
+    return hintPanel;
+}
+
+function hideAllRefHints() {
+    queryAll(".ref-hint").forEach(el=>hideRefHint(el));
+}
+
+function hideRefHint(refHint) {
+    const link = refHint.forLink;
+    link.setAttribute("aria-expanded", "false");
+    if(refHint.teardownEventListeners) {
+        refHint.teardownEventListeners();
+    }
+    refHint.remove();
+}
+
+function showRefHint(link) {
+    if(link.classList.contains("dfn-link")) return;
+    const url = link.getAttribute("href");
+    const refHintKey = link.getAttribute("data-refhint-key");
+    let key = url;
+    if(refHintKey) {
+        key = refHintKey + "_" + url;
+    }
+    const ref = refsData[key];
+    if(!ref) return;
+
+    hideAllRefHints(); // Only display one at this time.
+
+    const refHint = mkRefHint(link, ref);
+    append(document.body, refHint);
+    link.setAttribute("aria-expanded", "true");
+    positionRefHint(refHint);
+}
+
+function setupRefHintEventListeners(link, refHint) {
+    if (refHint.teardownEventListeners) return;
+    // Add event handlers to hide the refHint after the user moves away
+    // from both the link and refHint, if not hovering either within one second.
+    let timeout = null;
+    const startHidingRefHint = (event) => {
+        if (timeout) {
+            clearTimeout(timeout);
+        }
+        timeout = setTimeout(() => {
+            hideRefHint(refHint);
+        }, 1000);
+    }
+    const resetHidingRefHint = (event) => {
+        if (timeout) clearTimeout(timeout);
+        timeout = null;
+    };
+    link.addEventListener("mouseleave", startHidingRefHint);
+    link.addEventListener("mouseenter", resetHidingRefHint);
+    link.addEventListener("blur", startHidingRefHint);
+    link.addEventListener("focus", resetHidingRefHint);
+    refHint.addEventListener("mouseleave", startHidingRefHint);
+    refHint.addEventListener("mouseenter", resetHidingRefHint);
+    refHint.addEventListener("blur", startHidingRefHint);
+    refHint.addEventListener("focus", resetHidingRefHint);
+
+    refHint.teardownEventListeners = () => {
+        // remove event listeners
+        resetHidingRefHint();
+        link.removeEventListener("mouseleave", startHidingRefHint);
+        link.removeEventListener("mouseenter", resetHidingRefHint);
+        link.removeEventListener("blur", startHidingRefHint);
+        link.removeEventListener("focus", resetHidingRefHint);
+        refHint.removeEventListener("mouseleave", startHidingRefHint);
+        refHint.removeEventListener("mouseenter", resetHidingRefHint);
+        refHint.removeEventListener("blur", startHidingRefHint);
+        refHint.removeEventListener("focus", resetHidingRefHint);
+    };
+}
+
+function positionRefHint(refHint) {
+    const link = refHint.forLink;
+    const linkPos = getBounds(link);
+    refHint.style.top = linkPos.bottom + "px";
+    refHint.style.left = linkPos.left + "px";
+
+    const panelPos = refHint.getBoundingClientRect();
+    const panelMargin = 8;
+    const maxRight = document.body.parentNode.clientWidth - panelMargin;
+    if (panelPos.right > maxRight) {
+        const overflowAmount = panelPos.right - maxRight;
+        const newLeft = Math.max(panelMargin, linkPos.left - overflowAmount);
+        refHint.style.left = newLeft + "px";
+    }
+}
+
+// TODO: shared util
+// Returns the root-level absolute position {left and top} of element.
+function getBounds(el, relativeTo=document.body) {
+    const relativeRect = relativeTo.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+    const top = elRect.top - relativeRect.top;
+    const left = elRect.left - relativeRect.left;
+    return {
+        top,
+        left,
+        bottom: top + elRect.height,
+        right: left + elRect.width,
+    }
+}
+
+function showRefHintListener(e) {
+    // If the target isn't in a link (or is a link),
+    // just ignore it.
+    let link = e.target.closest("a");
+    if(!link) return;
+
+    // If the target is in a ref-hint panel
+    // (aka a link in the already-open one),
+    // also just ignore it.
+    if(link.closest(".ref-hint")) return;
+
+    // Otherwise, show the panel for the link.
+    showRefHint(link);
+}
+
+function hideAllHintsListener(e) {
+    // If the click is inside a ref-hint panel, ignore it.
+    if(e.target.closest(".ref-hint")) return;
+    // Otherwise, close all the current panels.
+    hideAllRefHints();
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    document.body.addEventListener("mousedown", showRefHintListener);
+    document.body.addEventListener("focus", showRefHintListener);
+
+    document.body.addEventListener("click", hideAllHintsListener);
+});
+
+window.addEventListener("resize", () => {
+    // Hide any open ref hint.
+    hideAllRefHints();
+});
+}
+</script>
+<script>/* Boilerplate: script-var-click-highlighting */
+"use strict";
+{
+/*
+Color-choosing design:
+
+* Colors are ordered by goodness.
+* On clicking a var, give it the earliest color
+    with the lowest usage in the algorithm.
+* On re-clicking, re-use the var's most recent color
+    if that's not currently being used elsewhere.
+*/
+
+const COLOR_COUNT = 7;
+
+document.addEventListener("click", e=>{
+    if(e.target.nodeName == "VAR") {
+        highlightSameAlgoVars(e.target);
+    }
+});
+
+function highlightSameAlgoVars(v) {
+    // Find the algorithm container.
+    let algoContainer = findAlgoContainer(v);
+
+    // Not highlighting document-global vars,
+    // too likely to be unrelated.
+    if(algoContainer == null) return;
+
+    const varName = nameFromVar(v);
+    if(!v.hasAttribute("data-var-color")) {
+        const newColor = chooseHighlightColor(algoContainer, v);
+        for(const el of algoContainer.querySelectorAll("var")) {
+            if(nameFromVar(el) == varName) {
+                el.setAttribute("data-var-color", newColor);
+                el.setAttribute("data-var-last-color", newColor);
+            }
+        }
+    } else {
+        for(const el of algoContainer.querySelectorAll("var")) {
+            if(nameFromVar(el) == varName) {
+                el.removeAttribute("data-var-color");
+            }
+        }
+    }
+}
+function findAlgoContainer(el) {
+    while(el != document.body) {
+        if(el.hasAttribute("data-algorithm")) return el;
+        el = el.parentNode;
+    }
+    return null;
+}
+function nameFromVar(el) {
+    return el.textContent.replace(/(\s|\xa0)+/g, " ").trim();
+}
+function colorCountsFromContainer(container) {
+    const namesFromColor = Array.from({length:COLOR_COUNT}, x=>new Set());
+    for(let v of container.querySelectorAll("var[data-var-color]")) {
+        let color = +v.getAttribute("data-var-color");
+        namesFromColor[color].add(nameFromVar(v));
+    }
+
+    return namesFromColor.map(x=>x.size);
+}
+function leastUsedColor(colors) {
+    // Find the earliest color with the lowest count.
+    let minCount = Infinity;
+    let minColor = null;
+    for(var i = 0; i < colors.length; i++) {
+        if(colors[i] < minCount) {
+            minColor = i;
+            minCount = colors[i];
+        }
+    }
+    return minColor;
+}
+function chooseHighlightColor(container, v) {
+    const colorCounts = colorCountsFromContainer(container);
+    if(v.hasAttribute("data-var-last-color")) {
+        let color = +v.getAttribute("data-var-last-color");
+        if(colorCounts[color] == 0) return color;
+    }
+    return leastUsedColor(colorCounts);
+}
+}
+</script>


### PR DESCRIPTION
- Add a new invariant, that both local `attributes` and `removeAttributes` are forbidden with a global `removeAttributes` list.
- Start throwing in the constructor
- Switches the conditions in allowElement (please double check..)
- In allowElement with a global removeAttributes lists, first make sure to remove everything in the local `removeAttributes` list from the local `attributes` list. Afterwards get rid of the disallowed local `removeAttributes` lists.

Fixes #305


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evilpie/sanitizer-api/pull/311.html" title="Last updated on Oct 17, 2025, 7:13 AM UTC (e26b216)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/311/fc36ba1...evilpie:e26b216.html" title="Last updated on Oct 17, 2025, 7:13 AM UTC (e26b216)">Diff</a>