### PR TITLE
Do nothing for allowElement with local attributes and a global removeElements list

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -31,6 +31,7 @@ text: parse HTML from a string; type: dfn; url: https://html.spec.whatwg.org/#pa
 text: HTML fragment parsing algorithm; type: dfn; url: https://html.spec.whatwg.org/#html-fragment-parsing-algorithm
 text: global attribute; type: dfn; url: https://html.spec.whatwg.org/multipage/dom.html#global-attributes
 text: custom data attribute; type: dfn; url: https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute
+text: report a warning to the console; type: dfn; url: https://console.spec.whatwg.org/#report-a-warning-to-the-console
 </pre>
 <pre class="biblio">
 {
@@ -800,9 +801,9 @@ allow- or remove-lists for attributes. This requires that we distinguish 4 cases
 
 1. Set |element| to the result of [=canonicalize a sanitizer element with attributes=] with
     |element|.
-1. Set |modified| to the result of [=SanitizerConfig/remove=] |element| from
-    |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"].
 1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=]:
+    1. Set |modified| to the result of [=SanitizerConfig/remove=] |element| from
+       |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"].
     1. [=Comment=]: We need to make sure the per-element attributes do not overlap with global
         attributes.
     1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/exists=]:
@@ -849,8 +850,11 @@ allow- or remove-lists for attributes. This requires that we distinguish 4 cases
     1. [=list/Append=] |element| to |configuration|["{{SanitizerConfig/elements}}"]
     1. Return true.
 1. Otherwise:
-  1. [=Comment=]: If we have a global remove-list, the per-element attributes of |element|
-      get ignored.
+  1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] or |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/exists=]:
+    1. The user agent may [=report a warning to the console=] that this operation is not supported.
+    1. Return false.
+  1. Set |modified| to the result of [=SanitizerConfig/remove=] |element| from
+     |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"].
   1. If |configuration|["{{SanitizerConfig/removeElements}}"] does not [=map/contain=] |element|:
       1. [=Comment=]: This is the case with a global remove-list that does not contain |element|.
       1. Return |modified|.


### PR DESCRIPTION
Local attributes/removeAttributes list are only supported with a global elements list. Otherwise we should just ignore the unsatisfiable request. I also added an optional warning, but we can remove that if it is unwanted.

Fixes #304


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evilpie/sanitizer-api/pull/312.html" title="Last updated on Sep 22, 2025, 10:37 AM UTC (e54c6fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/312/51f78b0...evilpie:e54c6fa.html" title="Last updated on Sep 22, 2025, 10:37 AM UTC (e54c6fa)">Diff</a>