### PR TITLE
Do not check for the existence of dataAttributes.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -816,8 +816,7 @@ allow- or remove-lists for attributes. This requires that we distinguish 4 cases
                 [=set/difference=] of
                 |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] and
                 |configuration|["{{SanitizerConfig/attributes}}"].
-            1. If |configuration|["{{SanitizerConfig/dataAttributes}}"] [=map/exists=] and
-                |configuration|["{{SanitizerConfig/dataAttributes}}"] is true:
+            1. If |configuration|["{{SanitizerConfig/dataAttributes}}"] is true:
                 1. [=list/Remove=] all items |item| from
                     |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
                     where |item| is a [=custom data attribute=].
@@ -1016,8 +1015,7 @@ To <dfn for="Sanitizer">set data attributes</dfn> with a [=boolean=] |allow|
 on a {{SanitizerConfig}} |configuration|:
 
 1. If |configuration|["{{SanitizerConfig/attributes}}"] does not [=map/exist=], then return false.
-1. If |configuration|["{{SanitizerConfig/dataAttributes}}"] [=map/exists=] and
-   |configuration|["{{SanitizerConfig/dataAttributes}}"] equals |allow|, then return false.
+1. If |configuration|["{{SanitizerConfig/dataAttributes}}"] equals |allow|, then return false.
 1. If |allow| is true:
    1. [=list/Remove=] any items |attr| from |configuration|["{{SanitizerConfig/attributes}}"]
        where |attr| is a [=custom data attribute=].


### PR DESCRIPTION
I am removing two places where we were checking for the existence of `config["dataAttributes"]`, but we are in a branch with `config["attributes"]`, so it must exist due to:

> If configuration["attributes"] exists and configuration["dataAttributes"] does not exist, then set configuration["dataAttributes"] to allowCommentsAndDataAttributes.

https://wicg.github.io/sanitizer-api/#configuration-canonicalize


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evilpie/sanitizer-api/pull/315.html" title="Last updated on Sep 23, 2025, 2:06 PM UTC (12f7ed4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/315/0955282...evilpie:12f7ed4.html" title="Last updated on Sep 23, 2025, 2:06 PM UTC (12f7ed4)">Diff</a>