### PR TITLE
Introduce a canonical form for SanitizerElementNamespaceWithAttributes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -855,7 +855,9 @@ allow- or remove-lists for attributes. This requires that we distinguish 4 cases
     1. [=list/Append=] |element| to |configuration|["{{SanitizerConfig/elements}}"]
     1. Return true.
 1. Otherwise:
-  1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] or |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/exists=]:
+  1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/exists=] or
+     |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=with default=] &laquo; &raquo;
+     is not [=list/empty=]:
     1. The user agent may [=report a warning to the console=] that this operation is not supported.
     1. Return false.
   1. Set |modified| to the result of [=SanitizerConfig/remove=] |element| from


### PR DESCRIPTION
- SanitizerElementNamespaceWithAttributes now always have at least an empty `removeAttributes` list. (Fixes #308)
- We handle missing properties correctly during **canonicalize a sanitizer element with attributes**
- Make sure to accept the canonical form (`{ name: .., namespace: ..., removeAttributes: [] }`)  when doing `allowElement()` with a `removeElements` lists. (Fixes #304)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evilpie/sanitizer-api/pull/316.html" title="Last updated on Sep 25, 2025, 3:09 PM UTC (2ce4551)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/316/b799894...evilpie:2ce4551.html" title="Last updated on Sep 25, 2025, 3:09 PM UTC (2ce4551)">Diff</a>