### PR TITLE
Fix the wrong nesting of remove duplicates in allowElement()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -809,9 +809,9 @@ allow- or remove-lists for attributes. This requires that we distinguish 4 cases
     1. [=Comment=]: We need to make sure the per-element attributes do not overlap with global
         attributes.
     1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/exists=]:
+        1. Set |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] to
+           [=SanitizerConfig/remove duplicates=] from |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"].
         1. If |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
-            1. Set |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] to
-               [=SanitizerConfig/remove duplicates=] from |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"].
             1. Set |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] to the
                 [=set/difference=] of
                 |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] and


### PR DESCRIPTION
We should always remove duplicates from `element["attributes"]` in **allow an element**. (Regression from #309)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evilpie/sanitizer-api/pull/319.html" title="Last updated on Sep 24, 2025, 12:05 PM UTC (0eccfda)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/319/86da938...evilpie:0eccfda.html" title="Last updated on Sep 24, 2025, 12:05 PM UTC (0eccfda)">Diff</a>