### PR TITLE
Return result instead of wrongly using continue.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1143,7 +1143,7 @@ To <dfn>canonicalize a sanitizer element with attributes</dfn> a {{SanitizerElem
   1. If neither |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] nor
      |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/exist=]:
     1. [=map/Set=] |result|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to &laquo; &raquo;.
-    2. [=Continue=].
+    2. Return |result|.
   1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/exists=]:
     1. Let |attributes| be &laquo; &raquo;.
     1. [=list/iterate|For each=] |attribute| of |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]:


### PR DESCRIPTION
Regression from #316. Somehow, I thought we were in a loop.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evilpie/sanitizer-api/pull/326.html" title="Last updated on Sep 26, 2025, 2:18 PM UTC (0db70b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/326/a1c5410...evilpie:0db70b4.html" title="Last updated on Sep 26, 2025, 2:18 PM UTC (0db70b4)">Diff</a>