### PR TITLE
Also add empty removeAttributes to element strings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1140,10 +1140,6 @@ To <dfn>canonicalize a sanitizer element with attributes</dfn> a {{SanitizerElem
 
 1. Let |result| be the result of [=canonicalize a sanitizer element=] with |element|.
 1. If |element| is a [=dictionary=]:
-  1. If neither |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] nor
-     |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/exist=]:
-    1. [=map/Set=] |result|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to &laquo; &raquo;.
-    2. Return |result|.
   1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/exists=]:
     1. Let |attributes| be &laquo; &raquo;.
     1. [=list/iterate|For each=] |attribute| of |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]:
@@ -1154,6 +1150,9 @@ To <dfn>canonicalize a sanitizer element with attributes</dfn> a {{SanitizerElem
     1. [=list/iterate|For each=] |attribute| of |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]:
       1. [=list/Append=] the result of [=canonicalize a sanitizer attribute=] with |attribute| to |attributes|.
     1. [=map/Set=] |result|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to |attributes|.
+1. If neither |result|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] nor
+   |result|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/exist=]:
+  1. [=map/Set=] |result|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to &laquo; &raquo;.
 1. Return |result|.
 
 </div>


### PR DESCRIPTION
Another follow up to #316.

We should obviously treat `{ elements: ["p"] }` and `{ elements: [{ name: "p" }] }` the same and also add an empty removeAttributes list in the first instance.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evilpie/sanitizer-api/pull/328.html" title="Last updated on Sep 29, 2025, 10:34 AM UTC (880a867)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/328/2ee1de9...evilpie:880a867.html" title="Last updated on Sep 29, 2025, 10:34 AM UTC (880a867)">Diff</a>