### PR TITLE
Use neither/nor.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -543,7 +543,7 @@ conditions hold:
 1. If |config|[{{SanitizerConfig/attributes}}] [=map/exists=]:
     1. If |config|[{{SanitizerConfig/elements}}] [=map/exists=]:
         1. [=list/iterate|For any=] |element| in |config|[{{SanitizerConfig/elements}}]:
-            1. Neither |element|[{{SanitizerElementNamespaceWithAttributes/attributes}}] or
+            1. Neither |element|[{{SanitizerElementNamespaceWithAttributes/attributes}}] nor
                |element|[{{SanitizerElementNamespaceWithAttributes/removeAttributes}}], if they exist, [=SanitizerConfig/has duplicates=].
             1. The [=set/intersection=] of |config|[{{SanitizerConfig/attributes}}] and
                 |element|[{{SanitizerElementNamespaceWithAttributes/attributes}}] [=with default=]


### PR DESCRIPTION
Grammar: Non-contrasting, negative alternatives should be joined with 'nor'.

Ref: https://en.wikipedia.org/wiki/Conjunction_(grammar)#Coordinating_conjunctions

Fix: #321


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/332.html" title="Last updated on Oct 1, 2025, 2:46 PM UTC (683c7af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/332/c4e9c31...otherdaniel:683c7af.html" title="Last updated on Oct 1, 2025, 2:46 PM UTC (683c7af)">Diff</a>