### PR TITLE
Make the SanitizerConfig remove algorithm return a boolean.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1200,10 +1200,17 @@ if there exists an |entry| of |list| that is an [=ordered map=], and where
 </div>
 
 <div algorithm>
-To <dfn for="SanitizerConfig">remove</dfn> an |item| from a |list| that is an
-[=ordered map=], [=list/remove=] all |entry| from |list|
-where |item|["name"] [=string/is|equals=] |entry|["name"] and
-|item|["namespace"] [=string/is|equals=] |entry|["namespace"].
+To <dfn for="SanitizerConfig">remove</dfn> an |item| from a
+[=/list=] |list|:
+
+1. Set |removed| to false.
+1. [=list/iterate|For each=] |entry| in |list|:
+  1. If |item|["name"] [=string/is|equals=] |entry|["name"] and
+      |item|["namespace"] [=string/is|equals=] |entry|["namespace"]:
+      1. Remove item |entry| from |list|.
+      1. Set |removed| to true.
+1. Return |removed|.
+
 </div>
 
 <div algorithm>

--- a/index.bs
+++ b/index.bs
@@ -1204,7 +1204,7 @@ To <dfn for="SanitizerConfig">remove</dfn> an |item| from a
 [=/list=] |list|:
 
 1. Set |removed| to false.
-1. [=list/iterate|For each=] |entry| in |list|:
+1. [=list/iterate|For each=] |entry| of |list|:
   1. If |item|["name"] [=string/is|equals=] |entry|["name"] and
       |item|["namespace"] [=string/is|equals=] |entry|["namespace"]:
       1. Remove item |entry| from |list|.


### PR DESCRIPTION
[=SanitizerConfig/remove=] is called in a number of places that also want to know whether a value was removed. We will return a boolean value whether a value was returned.

An alternative would be to check at every call site by calling [=SanitizerConfig/contains=] beforehand.

Fix: #322


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/334.html" title="Last updated on Oct 17, 2025, 1:52 PM UTC (63c91a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/334/c4e9c31...otherdaniel:63c91a9.html" title="Last updated on Oct 17, 2025, 1:52 PM UTC (63c91a9)">Diff</a>