### PR TITLE
Check for duplicate element-local attributes also with global removeAttributes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -542,7 +542,7 @@ conditions hold:
     |config|[{{SanitizerConfig/replaceWithChildrenElements}}] is [=list/empty=].
 1. If |config|[{{SanitizerConfig/attributes}}] [=map/exists=]:
     1. If |config|[{{SanitizerConfig/elements}}] [=map/exists=]:
-        1. [=list/iterate|For any=] |element| in |config|[{{SanitizerConfig/elements}}]:
+        1. [=list/iterate|For each=] |element| of |config|[{{SanitizerConfig/elements}}]:
             1. Neither |element|[{{SanitizerElementNamespaceWithAttributes/attributes}}] nor
                |element|[{{SanitizerElementNamespaceWithAttributes/removeAttributes}}], if they exist, [=SanitizerConfig/has duplicates=].
             1. The [=set/intersection=] of |config|[{{SanitizerConfig/attributes}}] and
@@ -560,7 +560,9 @@ conditions hold:
             a [=custom data attribute=].
 1. If |config|[{{SanitizerConfig/removeAttributes}}] [=map/exists=]:
     1. If |config|[{{SanitizerConfig/elements}}] [=map/exists=],
-       then [=list/iterate|for any=] |element| in |config|[{{SanitizerConfig/elements}}]:
+       then [=list/iterate|for each=] |element| of |config|[{{SanitizerConfig/elements}}]:
+        1. Neither |element|[{{SanitizerElementNamespaceWithAttributes/attributes}}] nor
+           |element|[{{SanitizerElementNamespaceWithAttributes/removeAttributes}}], if they exist, [=SanitizerConfig/has duplicates=].
         1. The [=set/intersection=] of |config|[{{SanitizerConfig/removeAttributes}}] and
             |element|[{{SanitizerElementNamespaceWithAttributes/attributes}}] [=with default=]
             &laquo; &raquo; is [=list/empty=].


### PR DESCRIPTION
Fixes #337


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evilpie/sanitizer-api/pull/338.html" title="Last updated on Oct 9, 2025, 2:08 PM UTC (eda7671)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/338/be5bbb4...evilpie:eda7671.html" title="Last updated on Oct 9, 2025, 2:08 PM UTC (eda7671)">Diff</a>