### PR TITLE
Item less-than comparison

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1278,11 +1278,12 @@ To <dfn for="SanitizerConfig">add</dfn> a |name| to a |list|, where |name| is
 An item |itemA| is <dfn for="SanitizerConfig">less than item</dfn> |itemB| if:
 
 1. If |itemA|["namespace"] is null:
-    1. If |itemB|["namespace"] is not null, return true.
+    1. If |itemB|["namespace"] is not null, then return true.
 1. Otherwise:
-    1. If |itemB|["namespace"] is null, return false.
-    1. If |itemA|["namespace"] is [=/code unit less than=] |itemB|["namespace"], return true.
-1. Return |itemA|["name"] is [=/code unit less than=]|itemB|["name"].
+    1. If |itemB|["namespace"] is null, then return false.
+    1. If |itemA|["namespace"] is [=/code unit less than=] |itemB|["namespace"], then return true.
+    1. If |itemA|["namespace"] [=string/is=] not |itemB|["namespace"], then return false.
+1. Return |itemA|["name"] is [=/code unit less than=] |itemB|["name"].
 
 </div>
 


### PR DESCRIPTION
While updating my implementation to the spec steps, I noticed a missed line in the initial PR.

An item with namespace "z" must not be less than an item with namespace "a". Currently we just handle "a" being less than "z".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evilpie/sanitizer-api/pull/341.html" title="Last updated on Oct 20, 2025, 10:49 AM UTC (2ea1fc4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/341/55d159e...evilpie:2ea1fc4.html" title="Last updated on Oct 20, 2025, 10:49 AM UTC (2ea1fc4)">Diff</a>