### PR TITLE
Use current global objects in static method.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -207,7 +207,7 @@ partial interface Document {
 The <dfn for="Document" method export>parseHTMLUnsafe(|html|, |options|)</dfn> method steps are:
 
 1. Let |compliantHTML| be the result of invoking the [$Get Trusted Type compliant string$] algorithm with
-   {{TrustedHTML}}, [=this=]'s [=relevant global object=], |html|, "Document parseHTMLUnsafe", and "script".
+   {{TrustedHTML}}, the [=current global object=], |html|, "Document parseHTMLUnsafe", and "script".
 1. Let |document| be a new {{Document}}, whose [=Document/content type=] is "text/html".
 
    Note: Since |document| does not have a browsing context, scripting is disabled.


### PR DESCRIPTION
Document.parseHTMLUnsafe is a static method and doesn't have a this. This fixes Document.parseHTMLUnsafe's algorithm to use the current global object, rather than this' relevant global object.

Analogous to: https://github.com/whatwg/html/pull/11799
Based on: https://github.com/whatwg/html/issues/11778


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/342.html" title="Last updated on Oct 16, 2025, 12:35 PM UTC (b387c06)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/342/fc36ba1...otherdaniel:b387c06.html" title="Last updated on Oct 16, 2025, 12:35 PM UTC (b387c06)">Diff</a>