### PR TITLE
Add "index.html" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.project
 /out
 /*.ninja*
+index.html


### PR DESCRIPTION
Add index.html to .gitignore.

index.html is the default output of `bikeshed` when called without paramters. It should not be committed.
Inspired by #343.
