### PR TITLE
Remove `rel` attribute from `a` element - fixes #344

### DIFF
--- a/builtins/safe-default-configuration.json
+++ b/builtins/safe-default-configuration.json
@@ -255,10 +255,6 @@
           "namespace": null
         },
         {
-          "name": "rel",
-          "namespace": null
-        },
-        {
           "name": "type",
           "namespace": null
         }

--- a/builtins/safe-default-configuration.txt
+++ b/builtins/safe-default-configuration.txt
@@ -60,13 +60,13 @@ div
 
 a
 - href
-- rel
 - hreflang
 - type
 // Purposely omitted:
 // - target
 // - download
 // - referrerpolicy
+// - rel
 // - ping
 em
 strong

--- a/index.bs
+++ b/index.bs
@@ -1550,6 +1550,6 @@ A more complete treatment of mXSS can be found in [[MXSS]].
 
 This work is informed and inspired by [[DOMPURIFY]] from cure53,
 Internet Explorer's {{window.toStaticHTML()}} as well as the original
-[[HTMLSanitizer]] from Ben Bucksch.
-Anne van Kesteren, Krzysztof Kotowicz, Tom Schuster, Luke Warlow,
-Guillaume Weghsteen, and Mike West for their valuable feedback.
+[[HTMLSanitizer]] from Ben Bucksch. Anne van Kesteren, Krzysztof Kotowicz,
+Andrew C. H. Mc Millan, Tom Schuster, Luke Warlow, Guillaume Weghsteen,
+and Mike West for their valuable feedback.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mozfreddyb/sanitizer-api/pull/346.html" title="Last updated on Oct 28, 2025, 7:49 AM UTC (324c67e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/346/8bcf166...mozfreddyb:324c67e.html" title="Last updated on Oct 28, 2025, 7:49 AM UTC (324c67e)">Diff</a>