### PR TITLE
Add svg <a> element to default config -- fixes #349

### DIFF
--- a/builtins/safe-default-configuration.json
+++ b/builtins/safe-default-configuration.json
@@ -726,6 +726,24 @@
       "attributes": []
     },
     {
+      "name": "a",
+      "namespace": "http://www.w3.org/2000/svg",
+      "attributes": [
+        {
+          "name": "href",
+          "namespace": null
+        },
+        {
+          "name": "hreflang",
+          "namespace": null
+        },
+        {
+          "name": "type",
+          "namespace": null
+        }
+      ]
+    },
+    {
       "name": "circle",
       "namespace": "http://www.w3.org/2000/svg",
       "attributes": [

--- a/builtins/safe-default-configuration.txt
+++ b/builtins/safe-default-configuration.txt
@@ -157,7 +157,7 @@ th
 //
 // Purposely omitted.
 
-// SVG: TBD
+// SVG: See below
 
 // HTML global attributes
 //
@@ -356,7 +356,24 @@ svg marker
 - markerHeight
 - orient
 
+
+// Scripting, https://svgwg.org/svg2-draft/interact.html
 // Purposely omitted: svg script
+
+// Linking, https://svgwg.org/svg2-draft/linking.html
+svg a
+- href
+- hreflang
+- type
+// Purposely omitted:
+// - xlink attributes
+// - target
+// - download
+// - ping
+// - referrerpolicy
+// - rel
+
+// Purposely omitted: svg view (because `id` attribute is not allowed)
 
 // Common attributes: https://svgwg.org/svg2-draft/struct.html#CommonAttributes
 [SVG Global]


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mozfreddyb/sanitizer-api/pull/357.html" title="Last updated on Nov 12, 2025, 12:14 PM UTC (ac1f7ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/357/dddc8df...mozfreddyb:ac1f7ad.html" title="Last updated on Nov 12, 2025, 12:14 PM UTC (ac1f7ad)">Diff</a>