### PR TITLE
Remove <iframe src> from 'built-in navigating URL attributes list'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1411,11 +1411,6 @@ navigations are "unsafe", are as follows:
   ],
   <br>
   [
-    { "`name`" &rightarrow; "`iframe`", "`namespace`" &rightarrow; [=HTML namespace=] },
-    { "`name`" &rightarrow; "`src`", "`namespace`" &rightarrow; `null` }
-  ],
-  <br>
-  [
     { "`name`" &rightarrow; "`input`", "`namespace`" &rightarrow; [=HTML namespace=] },
     { "`name`" &rightarrow; "`formaction`", "`namespace`" &rightarrow; `null` }
   ],


### PR DESCRIPTION
`<iframe>` elements are completely removed already (with "safe"), so we don't need to worry about the `src` attribute.

Fixes #358


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evilpie/sanitizer-api/pull/359.html" title="Last updated on Nov 13, 2025, 9:45 AM UTC (12ce20f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/359/f0b6602...evilpie:12ce20f.html" title="Last updated on Nov 13, 2025, 9:45 AM UTC (12ce20f)">Diff</a>