### PR TITLE
Editorial: Reference 'get TT compliant string' as a definition.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -149,7 +149,7 @@ partial interface Element {
 <div algorithm>
 {{Element}}'s <dfn for="Element" method export>setHTMLUnsafe(|html|, |options|)</dfn> method steps are:
 
-1. Let |compliantHTML| be the result of invoking the [$Get Trusted Type compliant string$] algorithm with
+1. Let |compliantHTML| be the result of invoking the [=get Trusted Type compliant string=] algorithm with
    {{TrustedHTML}}, [=this=]'s [=relevant global object=], |html|, "Element setHTMLUnsafe", and "script".
 1. Let |target| be [=this=]'s [=template contents=] if [=this=] is a
    {{HTMLTemplateElement|template}} element; otherwise [=this=].
@@ -178,7 +178,7 @@ These methods are mirrored on the {{ShadowRoot}}:
 <div algorithm>
 {{ShadowRoot}}'s <dfn for="ShadowRoot" method export>setHTMLUnsafe(|html|, |options|)</dfn> method steps are:
 
-1. Let |compliantHTML| be the result of invoking the [$Get Trusted Type compliant string$] algorithm with
+1. Let |compliantHTML| be the result of invoking the [=get Trusted Type compliant string=] algorithm with
    {{TrustedHTML}}, [=this=]'s [=relevant global object=], |html|, "ShadowRoot setHTMLUnsafe", and "script".
 1. [=Set and filter HTML=] using [=this=],
    [=this=]'s [=shadow host=] (as context element),
@@ -206,7 +206,7 @@ partial interface Document {
 <div algorithm>
 The <dfn for="Document" method export>parseHTMLUnsafe(|html|, |options|)</dfn> method steps are:
 
-1. Let |compliantHTML| be the result of invoking the [$Get Trusted Type compliant string$] algorithm with
+1. Let |compliantHTML| be the result of invoking the [=get Trusted Type compliant string=] algorithm with
    {{TrustedHTML}}, the [=current global object=], |html|, "Document parseHTMLUnsafe", and "script".
 1. Let |document| be a new {{Document}}, whose [=Document/content type=] is "text/html".
 

--- a/index.bs
+++ b/index.bs
@@ -149,7 +149,7 @@ partial interface Element {
 <div algorithm>
 {{Element}}'s <dfn for="Element" method export>setHTMLUnsafe(|html|, |options|)</dfn> method steps are:
 
-1. Let |compliantHTML| be the result of invoking the [=get Trusted Type compliant string=] algorithm with
+1. Let |compliantHTML| be the result of invoking the [=get trusted type compliant string=] algorithm with
    {{TrustedHTML}}, [=this=]'s [=relevant global object=], |html|, "Element setHTMLUnsafe", and "script".
 1. Let |target| be [=this=]'s [=template contents=] if [=this=] is a
    {{HTMLTemplateElement|template}} element; otherwise [=this=].
@@ -178,7 +178,7 @@ These methods are mirrored on the {{ShadowRoot}}:
 <div algorithm>
 {{ShadowRoot}}'s <dfn for="ShadowRoot" method export>setHTMLUnsafe(|html|, |options|)</dfn> method steps are:
 
-1. Let |compliantHTML| be the result of invoking the [=get Trusted Type compliant string=] algorithm with
+1. Let |compliantHTML| be the result of invoking the [=get trusted type compliant string=] algorithm with
    {{TrustedHTML}}, [=this=]'s [=relevant global object=], |html|, "ShadowRoot setHTMLUnsafe", and "script".
 1. [=Set and filter HTML=] using [=this=],
    [=this=]'s [=shadow host=] (as context element),
@@ -206,7 +206,7 @@ partial interface Document {
 <div algorithm>
 The <dfn for="Document" method export>parseHTMLUnsafe(|html|, |options|)</dfn> method steps are:
 
-1. Let |compliantHTML| be the result of invoking the [=get Trusted Type compliant string=] algorithm with
+1. Let |compliantHTML| be the result of invoking the [=get trusted type compliant string=] algorithm with
    {{TrustedHTML}}, the [=current global object=], |html|, "Document parseHTMLUnsafe", and "script".
 1. Let |document| be a new {{Document}}, whose [=Document/content type=] is "text/html".
 


### PR DESCRIPTION
This changes the reference type for "Get Trusted Type compliant string" to a definition reference, not an abstract-op reference.

Currently, `bikeshed` throws three warnings, like:
```
LINE 181:54: No 'abstract-op' refs found for 'Get Trusted Type compliant string'.
[$Get Trusted Type compliant string$]
```

The bikeshed refs system has these stored as a `dfn`, not as an `abstract-op`:
```
$ bikeshed refs --text "Get Trusted Type compliant string"
text:        get trusted type compliant string
displayText: get trusted type compliant string
type:        dfn
spec:        trusted-types
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/361.html" title="Last updated on Nov 24, 2025, 4:22 PM UTC (818a2fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/361/666c8fd...otherdaniel:818a2fe.html" title="Last updated on Nov 24, 2025, 4:22 PM UTC (818a2fe)">Diff</a>