### PR TITLE
Correctly remove attributes from the per-element attributes list

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1056,6 +1056,7 @@ to fix up per-element allow- or remove-lists to maintain our validity criteria. 
                     |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"].            
             1. If |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
                [=map/with default=] &laquo; &raquo; [=list/contains=] |attribute|:
+                1. [=Assert=]: |modified| is true.
                 1. [=list/Remove=] |attribute| from
                     |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"].
     1. Return |modified|.


### PR DESCRIPTION
Fixes #368.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evilpie/sanitizer-api/pull/369.html" title="Last updated on Jan 29, 2026, 2:44 PM UTC (8744f41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/369/f1d275e...evilpie:8744f41.html" title="Last updated on Jan 29, 2026, 2:44 PM UTC (8744f41)">Diff</a>