### PR TITLE
Replace `replace all` with steps from `replaceWith`.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -32,6 +32,7 @@ text: HTML fragment parsing algorithm; type: dfn; url: https://html.spec.whatwg.
 text: global attribute; type: dfn; url: https://html.spec.whatwg.org/multipage/dom.html#global-attributes
 text: custom data attribute; type: dfn; url: https://html.spec.whatwg.org/multipage/dom.html#custom-data-attribute
 text: report a warning to the console; type: dfn; url: https://console.spec.whatwg.org/#report-a-warning-to-the-console
+text: convert nodes into a node; type: dfn; url: https://dom.spec.whatwg.org/#convert-nodes-into-a-node
 </pre>
 <pre class="biblio">
 {
@@ -913,7 +914,9 @@ beginning with |node|. It consistes of these steps:
       1. [=Assert=]: |node| does not [=implement=] {{Document}}.
       1. Call [=sanitize core=] on |child| with |configuration| and
           |handleJavascriptNavigationUrls|.
-      1. Call [=replace all=] with |child|'s [=tree/children=] within |child|.
+      1. Let |fragment| be the result of [=convert nodes into a node=]
+         given |child|'s [=tree/children=] and |node|'s [=node document=].
+      1. [=/Replace=] |child| with |fragment| within |child|'s [=tree/parent=].
       1. [=Continue=].
     1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=]:
       1. If |configuration|["{{SanitizerConfig/elements}}"] does not

--- a/index.bs
+++ b/index.bs
@@ -914,9 +914,16 @@ beginning with |node|. It consistes of these steps:
       1. [=Assert=]: |node| does not [=implement=] {{Document}}.
       1. Call [=sanitize core=] on |child| with |configuration| and
           |handleJavascriptNavigationUrls|.
-      1. Let |fragment| be the result of [=convert nodes into a node=]
-         given |child|'s [=tree/children=] and |node|'s [=node document=].
-      1. [=/Replace=] |child| with |fragment| within |child|'s [=tree/parent=].
+      1. Let |fragment| be a new {{DocumentFragment}} whose [=node document=]
+          is |node|'s [=node document=].
+      1. [=list/iterate|For each=] |innerChild| of |child|'s [=tree/children=],
+          [=/append=] |innerChild| to |fragment|.
+      1. [=/Replace=] |child| with |fragment| within |node|.
+
+          NOTE: [=/Replace=] shouldn't throw here, since the structural
+              preconditions for successful execution of the algorithm should
+              be met.
+
       1. [=Continue=].
     1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=]:
       1. If |configuration|["{{SanitizerConfig/elements}}"] does not


### PR DESCRIPTION
Replace `[=replace all=]` with `[=convert nodes into a node=]` and `[=replace=]`.

Fixes: #372


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/375.html" title="Last updated on Mar 23, 2026, 2:26 PM UTC (1c09b59)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/375/32bfe71...otherdaniel:1c09b59.html" title="Last updated on Mar 23, 2026, 2:26 PM UTC (1c09b59)">Diff</a>