### PR TITLE
Remove `<svg:animateMotion>` from built-in animating URL attributes list

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1474,11 +1474,6 @@ URLs, is as follows:
   ],
   <br>
   [
-    { "`name`" &rightarrow; "`animateMotion`", "`namespace`" &rightarrow; [=SVG namespace=] },
-    { "`name`" &rightarrow; "`attributeName`", "`namespace`" &rightarrow; `null` }
-  ],
-  <br>
-  [
     { "`name`" &rightarrow; "`animateTransform`", "`namespace`" &rightarrow; [=SVG namespace=] },
     { "`name`" &rightarrow; "`attributeName`", "`namespace`" &rightarrow; `null` }
   ],


### PR DESCRIPTION
Per https://www.w3.org/TR/SVG11/animate.html#AnimateMotionElement, the `<svg:animateMotion>` element does not support the `attriuteName=` attribute and cannot be used to animate other content attributes.

Fixes: #374


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/376.html" title="Last updated on Mar 4, 2026, 2:32 PM UTC (ed2db38)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/376/84c7deb...otherdaniel:ed2db38.html" title="Last updated on Mar 4, 2026, 2:32 PM UTC (ed2db38)">Diff</a>