### PR TITLE
Refactor "is attribute allowed"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -758,7 +758,7 @@ NOTE: It's expected that the configuration being passing in has previously been 
     1. If |config|["{{SanitizerConfig/removeAttributes}}"]
         [=SanitizerConfig/has duplicates=], then return false.
 1. If |config|["{{SanitizerConfig/replaceWithChildrenElements}}"] [=map/exists=]:
-    1. If |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"]
+    1. If |config|["{{SanitizerConfig/replaceWithChildrenElements}}"]
        [=SanitizerConfig/contains=] &laquo;[ "`name`" &rightarrow; "`html`",
         "`namespace`" &rightarrow; [=HTML namespace=] ]&raquo;, then return false.
     1. If |config|["{{SanitizerConfig/elements}}"] [=map/exists=]:
@@ -932,41 +932,10 @@ beginning with |node|. It consistes of these steps:
     1. If |child| is a [=shadow host=],
        then call [=sanitize core=] on |child|'s [=Element/shadow root=] with
        |configuration| and |handleJavascriptNavigationUrls|.
-    1. Let |elementWithLocalAttributes| be &laquo; [] &raquo;.
-    1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=] and
-        |configuration|["{{SanitizerConfig/elements}}"] [=SanitizerConfig/contains=]
-        |elementName|:
-       1. Set |elementWithLocalAttributes| to
-           |configuration|["{{SanitizerConfig/elements}}"][|elementName|].
     1. [=list/iterate|For each=] |attribute| in |child|'s [=Element/attribute list=]:
-      1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
-         [=Attr/local name=] and [=Attr/namespace=].
-
-      1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/with default=] &laquo; &raquo;
-        [=SanitizerConfig/contains=] |attrName|:
-          1. [=/remove an attribute|Remove=] |attribute|.
-      1. Otherwise, if |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
-          1. Let the [=boolean=] |globallyAllowed| be whether
-              |configuration|["{{SanitizerConfig/attributes}}"]
-              [=SanitizerConfig/contains=] |attrName|.
-          1. Let the [=boolean=] |locallyAllowed| be whether
-              |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/with default=] &laquo; &raquo;
-              [=SanitizerConfig/contains=] |attrName|.
-          1. Let the [=boolean=] |isDataAttributeAllowed| be whether both,
-              "data-" is a [=code unit prefix=] of |attribute|'s
-              [=Attr/local name=] and [=Attr/namespace=] is `null`, and
-              |configuration|["{{SanitizerConfig/dataAttributes}}"] is true.
-          1. If neither |globallyAllowed| nor |locallyAllowed| nor
-              |isDataAttributeAllowed|,
-              [=/remove an attribute|remove=] |attribute|.
-      1. Otherwise:
-        1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
-          [=map/exists=] and |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] does not [=SanitizerConfig/contain=] |attrName|:
-          1. [=/remove an attribute|Remove=] |attribute|.
-
-        1. Otherwise, if |configuration|["{{SanitizerConfig/removeAttributes}}"] [=SanitizerConfig/contains=] |attrName|:
-              1. [=/remove an attribute|Remove=] |attribute|.
-
+        1. If [=is attribute allowed=] for |attribute| given |configuration|
+            and |child| is `remove`,
+            then [=/remove an attribute|remove=] |attribute|.
       1. If |handleJavascriptNavigationUrls|:
          1. If &laquo;[|elementName|, |attrName|]&raquo; matches an entry in
             the [=built-in navigating URL attributes list=], and if |attribute|
@@ -984,6 +953,48 @@ beginning with |node|. It consistes of these steps:
     1. Call [=sanitize core=] on |child| with |configuration| and |handleJavascriptNavigationUrls|.
 
 </div>
+
+<div algorithm>
+To determine <dfn>is attribute allowed</dfn> for an |attribute|,
+given a {{SanitizerConfig}} |configuration| and an {{Element}} |current element|:
+
+1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
+    [=Attr/local name=] and [=Attr/namespace=].
+1. Let |elementName| be a {{SanitizerElementNamespace}} with |current element|'s
+    [=Element/local name=] and [=Element/namespace=].
+1. Let |elementWithLocalAttributes| be &laquo; [] &raquo;.
+1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=] and
+    |configuration|["{{SanitizerConfig/elements}}"] [=SanitizerConfig/contains=]
+    |elementName|:
+   1. Set |elementWithLocalAttributes| to
+       |configuration|["{{SanitizerConfig/elements}}"][|elementName|].
+1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/with default=] &laquo; &raquo;
+    [=SanitizerConfig/contains=] |attrName|:
+    1. Return `remove`.
+1. Otherwise, if |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
+    1. Let the [=boolean=] |globallyAllowed| be whether
+        |configuration|["{{SanitizerConfig/attributes}}"]
+        [=SanitizerConfig/contains=] |attrName|.
+    1. Let the [=boolean=] |locallyAllowed| be whether
+        |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/with default=] &laquo; &raquo;
+        [=SanitizerConfig/contains=] |attrName|.
+    1. Let the [=boolean=] |isDataAttributeAllowed| be whether both,
+        "data-" is a [=code unit prefix=] of |attribute|'s
+        [=Attr/local name=] and [=Attr/namespace=] is `null`, and
+        |configuration|["{{SanitizerConfig/dataAttributes}}"] is true.
+    1. If neither |globallyAllowed| nor |locallyAllowed| nor
+        |isDataAttributeAllowed|, return `remove`.
+1. Otherwise:
+    1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
+        [=map/exists=] and |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] does not [=SanitizerConfig/contain=] |attrName|:
+        1. Return `remove`.
+
+    1. Otherwise, if |configuration|["{{SanitizerConfig/removeAttributes}}"] [=SanitizerConfig/contains=] |attrName|:
+        1. Return `remove`.
+1. Return `keep`.
+
+</div>
+
 
 <div class=note>
 <span class=marker>Note:</span> Current browsers support `javascript:` URLs

--- a/index.bs
+++ b/index.bs
@@ -758,7 +758,7 @@ NOTE: It's expected that the configuration being passing in has previously been 
     1. If |config|["{{SanitizerConfig/removeAttributes}}"]
         [=SanitizerConfig/has duplicates=], then return false.
 1. If |config|["{{SanitizerConfig/replaceWithChildrenElements}}"] [=map/exists=]:
-    1. If |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"]
+    1. If |config|["{{SanitizerConfig/replaceWithChildrenElements}}"]
        [=SanitizerConfig/contains=] &laquo;[ "`name`" &rightarrow; "`html`",
         "`namespace`" &rightarrow; [=HTML namespace=] ]&raquo;, then return false.
     1. If |config|["{{SanitizerConfig/elements}}"] [=map/exists=]:
@@ -946,14 +946,19 @@ beginning with |node|. It consistes of these steps:
         [=SanitizerConfig/contains=] |attrName|:
           1. [=/remove an attribute|Remove=] |attribute|.
       1. Otherwise, if |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
-          1. If |configuration|["{{SanitizerConfig/attributes}}"] does not
-              [=SanitizerConfig/contain=] |attrName| and
+          1. Let the [=boolean=] |globallyAllowed| be whether
+              |configuration|["{{SanitizerConfig/attributes}}"]
+              [=SanitizerConfig/contains=] |attrName|.
+          1. Let the [=boolean=] |locallyAllowed| be whether
               |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/with default=] &laquo; &raquo;
-              does not [=SanitizerConfig/contain=] |attrName|, and if
-              "data-" is not a [=code unit prefix=] of |attribute|'s [=Attr/local name=] and
-              [=Attr/namespace=] is not `null` or
-              |configuration|["{{SanitizerConfig/dataAttributes}}"] is not true:
-              1. [=/remove an attribute|Remove=] |attribute|.
+              [=SanitizerConfig/contains=] |attrName|.
+          1. Let the [=boolean=] |isDataAttributeAllowed| be whether both,
+              "data-" is a [=code unit prefix=] of |attribute|'s
+              [=Attr/local name=] and [=Attr/namespace=] is `null`, and
+              |configuration|["{{SanitizerConfig/dataAttributes}}"] is true.
+          1. If neither |globallyAllowed| nor |locallyAllowed| nor
+              |isDataAttributeAllowed|,
+              [=/remove an attribute|remove=] |attribute|.
       1. Otherwise:
         1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
           [=map/exists=] and |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] does not [=SanitizerConfig/contain=] |attrName|:

--- a/index.bs
+++ b/index.bs
@@ -758,7 +758,7 @@ NOTE: It's expected that the configuration being passing in has previously been 
     1. If |config|["{{SanitizerConfig/removeAttributes}}"]
         [=SanitizerConfig/has duplicates=], then return false.
 1. If |config|["{{SanitizerConfig/replaceWithChildrenElements}}"] [=map/exists=]:
-    1. If |config|["{{SanitizerConfig/replaceWithChildrenElements}}"]
+    1. If |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"]
        [=SanitizerConfig/contains=] &laquo;[ "`name`" &rightarrow; "`html`",
         "`namespace`" &rightarrow; [=HTML namespace=] ]&raquo;, then return false.
     1. If |config|["{{SanitizerConfig/elements}}"] [=map/exists=]:

--- a/index.bs
+++ b/index.bs
@@ -933,45 +933,36 @@ beginning with |node|. It consistes of these steps:
        then call [=sanitize core=] on |child|'s [=Element/shadow root=] with
        |configuration| and |handleJavascriptNavigationUrls|.
     1. [=list/iterate|For each=] |attribute| in |child|'s [=Element/attribute list=]:
-        1. If [=is attribute allowed=] for |attribute| given |configuration|
-            and |child| is `remove`,
+        1. If [=is attribute allowed=] for |attribute| given |configuration|,
+            |child|, and |handleJavascriptNavigationUrls| is [=/blocked=],
             then [=/remove an attribute|remove=] |attribute|.
-      1. If |handleJavascriptNavigationUrls|:
-         1. If &laquo;[|elementName|, |attrName|]&raquo; matches an entry in
-            the [=built-in navigating URL attributes list=], and if |attribute|
-            [=contains a javascript: URL=], then [=/remove an attribute|remove=] |attribute|.
-         1. If |child|'s [=Element/namespace=] [=string/is=] the
-            [=MathML Namespace=] and |attr|'s [=Attr/local name=] [=string/is=]
-            "`href`" and  |attr|'s [=Attr/namespace=] is `null` or the
-            [=XLink namespace=] and |attr| [=contains a javascript: URL=],
-            then [=/remove an attribute|remove=] |attribute|.
-         1. If the [=built-in animating URL attributes list=]
-            [=SanitizerConfig/contains=]
-            &laquo;[|elementName|, |attrName|]&raquo; and |attr|'s
-            [=get an attribute value|value=] [=string/is=] "`href`" or
-            "`xlink:href`", then [=/remove an attribute|remove=] |attribute|.
     1. Call [=sanitize core=] on |child| with |configuration| and |handleJavascriptNavigationUrls|.
 
 </div>
 
 <div algorithm>
 To determine <dfn>is attribute allowed</dfn> for an |attribute|,
-given a {{SanitizerConfig}} |configuration| and an {{Element}} |current element|:
+given a {{SanitizerConfig}} |configuration|, an {{Element}} |current element|,
+and a [=boolean=] |handleJavascriptNavigationUrls|:
 
 1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
     [=Attr/local name=] and [=Attr/namespace=].
 1. Let |elementName| be a {{SanitizerElementNamespace}} with |current element|'s
     [=Element/local name=] and [=Element/namespace=].
-1. Let |elementWithLocalAttributes| be &laquo; [] &raquo;.
+1. Let |elementWithLocalAttributes| be an empty [=ordered map=].
 1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=] and
     |configuration|["{{SanitizerConfig/elements}}"] [=SanitizerConfig/contains=]
     |elementName|:
-   1. Set |elementWithLocalAttributes| to
-       |configuration|["{{SanitizerConfig/elements}}"][|elementName|].
+   1. Set |elementWithLocalAttributes| to the |item| in
+       |configuration|["{{SanitizerConfig/elements}}"] where
+       |elementName|[{{SanitizerElementNamespace/name}}] [=string/is=]
+       |item|[{{SanitizerElementNamespace/name}}] and
+       |elementName|[{{SanitizerElementNamespace/namespace}}] [=string/is=]
+       |item|[{{SanitizerElementNamespace/namespace}}].
 1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/with default=] &laquo; &raquo;
     [=SanitizerConfig/contains=] |attrName|:
-    1. Return `remove`.
-1. Otherwise, if |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
+    1. Return [=/blocked=].
+1. If |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
     1. Let the [=boolean=] |globallyAllowed| be whether
         |configuration|["{{SanitizerConfig/attributes}}"]
         [=SanitizerConfig/contains=] |attrName|.
@@ -983,15 +974,26 @@ given a {{SanitizerConfig}} |configuration| and an {{Element}} |current element|
         [=Attr/local name=] and [=Attr/namespace=] is `null`, and
         |configuration|["{{SanitizerConfig/dataAttributes}}"] is true.
     1. If neither |globallyAllowed| nor |locallyAllowed| nor
-        |isDataAttributeAllowed|, return `remove`.
+        |isDataAttributeAllowed|, return [=/blocked=].
 1. Otherwise:
     1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
         [=map/exists=] and |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] does not [=SanitizerConfig/contain=] |attrName|:
-        1. Return `remove`.
-
-    1. Otherwise, if |configuration|["{{SanitizerConfig/removeAttributes}}"] [=SanitizerConfig/contains=] |attrName|:
-        1. Return `remove`.
-1. Return `keep`.
+        1. Return [=/blocked=].
+1. If |handleJavascriptNavigationUrls|:
+   1. If &laquo;[|elementName|, |attrName|]&raquo; matches an entry in
+      the [=built-in navigating URL attributes list=], and if |attribute|
+      [=contains a javascript: URL=], then return [=/blocked=].
+   1. If |current element|'s [=Element/namespace=] [=string/is=] the
+      [=MathML Namespace=] and |attr|'s [=Attr/local name=] [=string/is=]
+      "`href`" and  |attr|'s [=Attr/namespace=] is `null` or the
+      [=XLink namespace=] and |attr| [=contains a javascript: URL=],
+      then return [=/blocked=].
+   1. If the [=built-in animating URL attributes list=]
+      [=SanitizerConfig/contains=]
+      &laquo;[|elementName|, |attrName|]&raquo; and |attr|'s
+      [=get an attribute value|value=] [=string/is=] "`href`" or
+      "`xlink:href`", then return [=/blocked=].
+1. Return [=/allowed=].
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1094,6 +1094,9 @@ and an {{SanitizerElementNamespace}} |elementName|:
     1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
         [=map/exists=] and |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] does not [=SanitizerConfig/contain=] |attrName|:
         1. Return [=/blocked=].
+    1. Otherwise, if |configuration|["{{SanitizerConfig/removeAttributes}}"]
+       [=SanitizerConfig/contains=] |attrName|:
+        1. Return [=/blocked=].
 1. Return [=/allowed=].
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1033,13 +1033,12 @@ beginning with |node|. It consistes of these steps:
        then call [=sanitize core=] on |child|'s [=Element/shadow root=] with
        |configuration| and |handleJavascriptNavigationUrls|.
     1. [=list/iterate|For each=] |attribute| in |child|'s [=Element/attribute list=]:
-      1. If [=is attribute allowed=] for |attribute| given |configuration|,
-         and |child| is [=/blocked=],
+      1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
+         [=Attr/local name=] and [=Attr/namespace=].
+      1. If [=is attribute allowed=] for |attrName| given |configuration|,
+         and |elementName| is [=/blocked=],
          then [=/remove an attribute|remove=] |attribute|.
-
       1. If |handleJavascriptNavigationUrls|:
-        1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
-           [=Attr/local name=] and [=Attr/namespace=].
         1. If &laquo;[|elementName|, |attrName|]&raquo; matches an entry in
            the [=built-in navigating URL attributes list=], and if |attribute|
            [=contains a javascript: URL=], then [=/remove an attribute|remove=]
@@ -1059,13 +1058,11 @@ beginning with |node|. It consistes of these steps:
 </div>
 
 <div algorithm>
-To determine <dfn>is attribute allowed</dfn> for an |attribute|,
-given a {{SanitizerConfig}} |configuration|, an {{Element}} |current element|:
+To determine <dfn>is attribute allowed</dfn> for a
+{{SanitizerAttributeNamespace}} |attrName|,
+given a {{SanitizerConfig}} |configuration|,
+and an {{SanitizerElementNamespace}} |elementName|:
 
-1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
-    [=Attr/local name=] and [=Attr/namespace=].
-1. Let |elementName| be a {{SanitizerElementNamespace}} with |current element|'s
-    [=Element/local name=] and [=Element/namespace=].
 1. Let |elementWithLocalAttributes| be an empty [=ordered map=].
 1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=] and
     |configuration|["{{SanitizerConfig/elements}}"] [=SanitizerConfig/contains=]
@@ -1087,8 +1084,9 @@ given a {{SanitizerConfig}} |configuration|, an {{Element}} |current element|:
         |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/with default=] &laquo; &raquo;
         [=SanitizerConfig/contains=] |attrName|.
     1. Let the [=boolean=] |isDataAttributeAllowed| be whether both,
-        "data-" is a [=code unit prefix=] of |attribute|'s
-        [=Attr/local name=] and [=Attr/namespace=] is `null`, and
+        "data-" is a [=code unit prefix=] of
+        |attrName|[{{SanitizerAttributeNamespace/name}}] and
+        |attrName|[{{SanitizerAttributeNamespace/namespace}}] is `null`, and
         |configuration|["{{SanitizerConfig/dataAttributes}}"] is true.
     1. If neither |globallyAllowed| nor |locallyAllowed| nor
         |isDataAttributeAllowed|, return [=/blocked=].

--- a/index.bs
+++ b/index.bs
@@ -1032,53 +1032,74 @@ beginning with |node|. It consistes of these steps:
     1. If |child| is a [=shadow host=],
        then call [=sanitize core=] on |child|'s [=Element/shadow root=] with
        |configuration| and |handleJavascriptNavigationUrls|.
-    1. Let |elementWithLocalAttributes| be « [] ».
-    1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=] and
-        |configuration|["{{SanitizerConfig/elements}}"] [=SanitizerConfig/contains=]
-        |elementName|:
-       1. Set |elementWithLocalAttributes| to
-           |configuration|["{{SanitizerConfig/elements}}"][|elementName|].
     1. [=list/iterate|For each=] |attribute| in |child|'s [=Element/attribute list=]:
-      1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
-         [=Attr/local name=] and [=Attr/namespace=].
-
-      1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/with default=] « »
-        [=SanitizerConfig/contains=] |attrName|:
-          1. [=/remove an attribute|Remove=] |attribute|.
-      1. Otherwise, if |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
-          1. If |configuration|["{{SanitizerConfig/attributes}}"] does not
-              [=SanitizerConfig/contain=] |attrName| and
-              |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/with default=] « »
-              does not [=SanitizerConfig/contain=] |attrName|, and if
-              "data-" is not a [=code unit prefix=] of |attribute|'s [=Attr/local name=] and
-              [=Attr/namespace=] is not `null` or
-              |configuration|["{{SanitizerConfig/dataAttributes}}"] is not true:
-              1. [=/remove an attribute|Remove=] |attribute|.
-      1. Otherwise:
-        1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
-          [=map/exists=] and |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] does not [=SanitizerConfig/contain=] |attrName|:
-          1. [=/remove an attribute|Remove=] |attribute|.
-
-        1. Otherwise, if |configuration|["{{SanitizerConfig/removeAttributes}}"] [=SanitizerConfig/contains=] |attrName|:
-              1. [=/remove an attribute|Remove=] |attribute|.
+      1. If [=is attribute allowed=] for |attribute| given |configuration|,
+         and |child| is [=/blocked=],
+         then [=/remove an attribute|remove=] |attribute|.
 
       1. If |handleJavascriptNavigationUrls|:
-         1. If «[|elementName|, |attrName|]» matches an entry in
-            the [=built-in navigating URL attributes list=], and if |attribute|
-            [=contains a javascript: URL=], then [=/remove an attribute|remove=] |attribute|.
-         1. If |child|'s [=Element/namespace=] [=string/is=] the
-            [=MathML Namespace=] and |attr|'s [=Attr/local name=] [=string/is=]
-            "`href`" and  |attr|'s [=Attr/namespace=] is `null` or the
-            [=XLink namespace=] and |attr| [=contains a javascript: URL=],
-            then [=/remove an attribute|remove=] |attribute|.
-         1. If the [=built-in animating URL attributes list=]
-            [=SanitizerConfig/contains=]
-            «[|elementName|, |attrName|]» and |attr|'s
-            [=get an attribute value|value=] [=string/is=] "`href`" or
-            "`xlink:href`", then [=/remove an attribute|remove=] |attribute|.
+        1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
+           [=Attr/local name=] and [=Attr/namespace=].
+        1. If &laquo;[|elementName|, |attrName|]&raquo; matches an entry in
+           the [=built-in navigating URL attributes list=], and if |attribute|
+           [=contains a javascript: URL=], then [=/remove an attribute|remove=]
+           |attribute|.
+        1. If |child|'s [=Element/namespace=] [=string/is=] the
+           [=MathML Namespace=] and |attr|'s [=Attr/local name=] [=string/is=]
+           "`href`" and  |attr|'s [=Attr/namespace=] is `null` or the
+           [=XLink namespace=] and |attr| [=contains a javascript: URL=],
+           then [=/remove an attribute|remove=] |attribute|.
+        1. If the [=built-in animating URL attributes list=]
+           [=SanitizerConfig/contains=]
+           &laquo;[|elementName|, |attrName|]&raquo; and |attr|'s
+           [=get an attribute value|value=] [=string/is=] "`href`" or
+           "`xlink:href`", then [=/remove an attribute|remove=] |attribute|.
     1. Call [=sanitize core=] on |child| with |configuration| and |handleJavascriptNavigationUrls|.
 
 </div>
+
+<div algorithm>
+To determine <dfn>is attribute allowed</dfn> for an |attribute|,
+given a {{SanitizerConfig}} |configuration|, an {{Element}} |current element|:
+
+1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
+    [=Attr/local name=] and [=Attr/namespace=].
+1. Let |elementName| be a {{SanitizerElementNamespace}} with |current element|'s
+    [=Element/local name=] and [=Element/namespace=].
+1. Let |elementWithLocalAttributes| be an empty [=ordered map=].
+1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=] and
+    |configuration|["{{SanitizerConfig/elements}}"] [=SanitizerConfig/contains=]
+    |elementName|:
+   1. Set |elementWithLocalAttributes| to the |item| in
+       |configuration|["{{SanitizerConfig/elements}}"] where
+       |elementName|["{{SanitizerElementNamespace/name}}"] [=string/is=]
+       |item|["{{SanitizerElementNamespace/name}}"] and
+       |elementName|["{{SanitizerElementNamespace/namespace}}"] [=string/is=]
+       |item|["{{SanitizerElementNamespace/namespace}}"].
+1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/with default=] &laquo; &raquo;
+    [=SanitizerConfig/contains=] |attrName|:
+    1. Return [=/blocked=].
+1. If |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
+    1. Let the [=boolean=] |globallyAllowed| be whether
+        |configuration|["{{SanitizerConfig/attributes}}"]
+        [=SanitizerConfig/contains=] |attrName|.
+    1. Let the [=boolean=] |locallyAllowed| be whether
+        |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/with default=] &laquo; &raquo;
+        [=SanitizerConfig/contains=] |attrName|.
+    1. Let the [=boolean=] |isDataAttributeAllowed| be whether both,
+        "data-" is a [=code unit prefix=] of |attribute|'s
+        [=Attr/local name=] and [=Attr/namespace=] is `null`, and
+        |configuration|["{{SanitizerConfig/dataAttributes}}"] is true.
+    1. If neither |globallyAllowed| nor |locallyAllowed| nor
+        |isDataAttributeAllowed|, return [=/blocked=].
+1. Otherwise:
+    1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
+        [=map/exists=] and |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] does not [=SanitizerConfig/contain=] |attrName|:
+        1. Return [=/blocked=].
+1. Return [=/allowed=].
+
+</div>
+
 
 <div class=note>
 <span class=marker>Note:</span> Current browsers support `javascript:` URLs

--- a/index.bs
+++ b/index.bs
@@ -1094,7 +1094,7 @@ and an {{SanitizerElementNamespace}} |elementName|:
     1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
         [=map/exists=] and |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] does not [=SanitizerConfig/contain=] |attrName|:
         1. Return [=/blocked=].
-    1. Otherwise, if |configuration|["{{SanitizerConfig/removeAttributes}}"]
+    1. If |configuration|["{{SanitizerConfig/removeAttributes}}"]
        [=SanitizerConfig/contains=] |attrName|:
         1. Return [=/blocked=].
 1. Return [=/allowed=].


### PR DESCRIPTION
Split the dreaded multi-line condition into several subclauses, assign each to an appropriately named boolean, and then test those bools.

That's more verbose than I usually go for, but it's surely more readable than the old version.

Fix: whatwg/sanitizer-api#380


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/385.html" title="Last updated on May 22, 2026, 9:15 AM UTC (93d8663)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/385/8b4bdb0...otherdaniel:93d8663.html" title="Last updated on May 22, 2026, 9:15 AM UTC (93d8663)">Diff</a>