### PR TITLE
Editorial: Fix references.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -444,7 +444,7 @@ The <dfn for="Sanitizer" method export>replaceElementWithChildren(|element|)</df
 1. If |element|["{{SanitizerElementNamespace/name}}"] [=string/is|equals=] "`html`"
     and |element|["{{SanitizerElementNamespace/namespace}}"] [=string/is|equals=] [=HTML namespace=]:
     1. Return false.
-1. If |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"] [=map/contains=] |element|:
+1. If |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"] [=SanitizerConfig/contains=] |element|:
     1. Return false.
 1. [=SanitizerConfig/Remove=] |element| from |configuration|["{{SanitizerConfig/removeElements}}"].
 1. [=SanitizerConfig/Remove=] |element| from |configuration|["{{SanitizerConfig/elements}}"] list.
@@ -758,7 +758,7 @@ NOTE: It's expected that the configuration being passing in has previously been 
     1. If |config|["{{SanitizerConfig/removeAttributes}}"]
         [=SanitizerConfig/has duplicates=], then return false.
 1. If |config|["{{SanitizerConfig/replaceWithChildrenElements}}"] [=map/exists=]:
-    1. If |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"]
+    1. If |config|["{{SanitizerConfig/replaceWithChildrenElements}}"]
        [=SanitizerConfig/contains=] &laquo;[ "`name`" &rightarrow; "`html`",
         "`namespace`" &rightarrow; [=HTML namespace=] ]&raquo;, then return false.
     1. If |config|["{{SanitizerConfig/elements}}"] [=map/exists=]:


### PR DESCRIPTION
- Fix 'contains' in replaceElementWithChildren to use [=SanitizerConfig/contains=] instead of [=list/contains=].
- Fix reference to |config| in [=valid=].

Fix: #378


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/386.html" title="Last updated on Mar 23, 2026, 5:26 PM UTC (0526b21)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/386/32bfe71...otherdaniel:0526b21.html" title="Last updated on Mar 23, 2026, 5:26 PM UTC (0526b21)">Diff</a>