### PR TITLE
Split up partial elements, and set up `SetHTML` variants for extraction.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -142,6 +142,10 @@ markup, and an optional configuration.
 <pre class="idl extract">
 partial interface Element {
   [CEReactions] undefined setHTMLUnsafe((TrustedHTML or DOMString) html, optional SetHTMLUnsafeOptions options = {});
+};
+</pre>
+<pre class="idl">
+partial interface Element {
   [CEReactions] undefined setHTML(DOMString html, optional SetHTMLOptions options = {});
 };
 </pre>
@@ -169,6 +173,10 @@ partial interface Element {
 <pre class="idl extract">
 partial interface ShadowRoot {
   [CEReactions] undefined setHTMLUnsafe((TrustedHTML or DOMString) html, optional SetHTMLUnsafeOptions options = {});
+};
+</pre>
+<pre class="idl">
+partial interface ShadowRoot {
   [CEReactions] undefined setHTML(DOMString html, optional SetHTMLOptions options = {});
 };
 </pre>
@@ -199,6 +207,10 @@ The {{Document}} interface gains two new methods which parse an entire {{Documen
 <pre class="idl extract">
 partial interface Document {
   static Document parseHTMLUnsafe((TrustedHTML or DOMString) html, optional SetHTMLUnsafeOptions options = {});
+};
+</pre>
+<pre class="idl">
+partial interface Document {
   static Document parseHTML(DOMString html, optional SetHTMLOptions options = {});
 };
 </pre>


### PR DESCRIPTION
This splits up the partial interfaces, so that the setHTML/parseHTML methods can be extracted, while setHTMLUnsafe/parseHTMLUnsafe are not, as requested by #391.

Fix: #391


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/otherdaniel/purification/pull/392.html" title="Last updated on Apr 9, 2026, 3:20 PM UTC (9c803ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/392/c4e3280...otherdaniel:9c803ec.html" title="Last updated on Apr 9, 2026, 3:20 PM UTC (9c803ec)">Diff</a>