### PR TITLE
Editorial: use unicode for raquo/laquo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -393,7 +393,7 @@ allow- or remove-lists for attributes. This requires that we distinguish 4 cases
                 [=set/difference=] of
                 |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] and
                 |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-                [=map/with default=] &#171; &#187;.
+                [=map/with default=] « ».
         1. [=map/Remove=] |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"].
         1. Set |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] to the
                 [=set/difference=] of
@@ -422,7 +422,7 @@ allow- or remove-lists for attributes. This requires that we distinguish 4 cases
     1. Return true.
 1. Otherwise:
   1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/exists=] or
-     |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=with default=] &#171; &#187;
+     |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=with default=] « »
      is not [=list/empty=]:
     1. The user agent may [=report a warning to the console=] that this operation is not supported.
     1. Return false.
@@ -524,11 +524,11 @@ up per-element allow- or remove-lists to maintain our validity criteria.
     1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=]:
         1. [=list/iterate|For each=] |element| in |configuration|["{{SanitizerConfig/elements}}"]:
             1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
-               [=map/with default=] &#171; &#187; [=list/contains=] |attribute|:
+               [=map/with default=] « » [=list/contains=] |attribute|:
                 1. [=list/Remove=] |attribute| from
                     |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"].
             1. [=Assert=]: |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-               [=map/with default=] &#171; &#187;
+               [=map/with default=] « »
                does not [=list/contain=] |attribute|.
     1. [=list/Append=] |attribute| to |configuration|["{{SanitizerConfig/attributes}}"]
     1. Return true.
@@ -655,11 +655,11 @@ Several conditions need to hold for a configuration to be valid:
   - {{SanitizerConfig/elements}} or {{SanitizerConfig/removeElements}} can exist,
     but not both.
     If both are missing, this is equivalent to {{SanitizerConfig/removeElements}}
-    [=map/set=] to &#171; &#187;.
+    [=map/set=] to « ».
   - {{SanitizerConfig/attributes}} or {{SanitizerConfig/removeAttributes}} can exist,
     but not both.
     If both are missing, this is equivalent to {{SanitizerConfig/removeAttributes}}
-    [=map/set=] to &#171; &#187;.
+    [=map/set=] to « ».
   - {{SanitizerConfig/dataAttributes}} is conceptually an extension of the
     {{SanitizerConfig/attributes}} allow-list. The {{SanitizerConfig/dataAttributes}}
     attribute is only allowed when a {{SanitizerConfig/attributes}} list is used.
@@ -851,9 +851,9 @@ NOTE: It's expected that the configuration being passing in has previously been 
                 [=SanitizerConfig/has duplicates=], then return false.
             1. If the [=set/intersection=] of |config|["{{SanitizerConfig/attributes}}"] and
                 |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=with default=]
-                &#171; &#187; is not [=list/empty=], then return false.
+                « » is not [=list/empty=], then return false.
             1. If |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-                [=with default=] &#171; &#187; is not a
+                [=with default=] « » is not a
                 [=set/subset=] of |config|["{{SanitizerConfig/attributes}}"], then return false.
             1. If |config|["{{SanitizerConfig/dataAttributes}}"] is true and
                 |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
@@ -875,10 +875,10 @@ NOTE: It's expected that the configuration being passing in has previously been 
                [=SanitizerConfig/has duplicates=], then return false.
             1. If the [=set/intersection=] of |config|["{{SanitizerConfig/removeAttributes}}"] and
                 |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=with default=]
-                &#171; &#187; is not [=list/empty=], then return false.
+                « » is not [=list/empty=], then return false.
             1. If the [=set/intersection=] of |config|["{{SanitizerConfig/removeAttributes}}"] and
                 |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=with default=]
-                &#171; &#187; is not [=list/empty=], then return false.
+                « » is not [=list/empty=], then return false.
     1. If |config|["{{SanitizerConfig/dataAttributes}}"] [=map/exists=], then return false.
 1. Return true.
 
@@ -1003,14 +1003,14 @@ beginning with |node|. It consistes of these steps:
          |elementName|:
         1. [=/Remove=] |child|.
         1. [=Continue=].
-    1. If |elementName| [=string/is|equals=] &#171;[ "`name`" &rightarrow; "`template`",
-       "`namespace`" &rightarrow; [=HTML namespace=] ]&#187;,
+    1. If |elementName| [=string/is|equals=] «[ "`name`" &rightarrow; "`template`",
+       "`namespace`" &rightarrow; [=HTML namespace=] ]»,
           then call [=sanitize core=] on |child|'s [=template contents=] with
           |configuration| and |handleJavascriptNavigationUrls|.
     1. If |child| is a [=shadow host=],
        then call [=sanitize core=] on |child|'s [=Element/shadow root=] with
        |configuration| and |handleJavascriptNavigationUrls|.
-    1. Let |elementWithLocalAttributes| be &#171; [] &#187;.
+    1. Let |elementWithLocalAttributes| be « [] ».
     1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=] and
         |configuration|["{{SanitizerConfig/elements}}"] [=SanitizerConfig/contains=]
         |elementName|:
@@ -1020,13 +1020,13 @@ beginning with |node|. It consistes of these steps:
       1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
          [=Attr/local name=] and [=Attr/namespace=].
 
-      1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/with default=] &#171; &#187;
+      1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/with default=] « »
         [=SanitizerConfig/contains=] |attrName|:
           1. [=/remove an attribute|Remove=] |attribute|.
       1. Otherwise, if |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
           1. If |configuration|["{{SanitizerConfig/attributes}}"] does not
               [=SanitizerConfig/contain=] |attrName| and
-              |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/with default=] &#171; &#187;
+              |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/with default=] « »
               does not [=SanitizerConfig/contain=] |attrName|, and if
               "data-" is not a [=code unit prefix=] of |attribute|'s [=Attr/local name=] and
               [=Attr/namespace=] is not `null` or
@@ -1041,7 +1041,7 @@ beginning with |node|. It consistes of these steps:
               1. [=/remove an attribute|Remove=] |attribute|.
 
       1. If |handleJavascriptNavigationUrls|:
-         1. If &#171;[|elementName|, |attrName|]&#187; matches an entry in
+         1. If «[|elementName|, |attrName|]» matches an entry in
             the [=built-in navigating URL attributes list=], and if |attribute|
             [=contains a javascript: URL=], then [=/remove an attribute|remove=] |attribute|.
          1. If |child|'s [=Element/namespace=] [=string/is=] the
@@ -1051,7 +1051,7 @@ beginning with |node|. It consistes of these steps:
             then [=/remove an attribute|remove=] |attribute|.
          1. If the [=built-in animating URL attributes list=]
             [=SanitizerConfig/contains=]
-            &#171;[|elementName|, |attrName|]&#187; and |attr|'s
+            «[|elementName|, |attrName|]» and |attr|'s
             [=get an attribute value|value=] [=string/is=] "`href`" or
             "`xlink:href`", then [=/remove an attribute|remove=] |attribute|.
     1. Call [=sanitize core=] on |child| with |configuration| and |handleJavascriptNavigationUrls|.
@@ -1165,12 +1165,12 @@ to fix up per-element allow- or remove-lists to maintain our validity criteria. 
     1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=]:
         1. [=list/iterate|For each=] |element| of |configuration|["{{SanitizerConfig/elements}}"]:
             1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
-               [=map/with default=] &#171; &#187; [=list/contains=] |attribute|:
+               [=map/with default=] « » [=list/contains=] |attribute|:
                 1. Set |modified| to true.
                 1. [=list/Remove=] |attribute| from
                     |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"].            
             1. If |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-               [=map/with default=] &#171; &#187; [=list/contains=] |attribute|:
+               [=map/with default=] « » [=list/contains=] |attribute|:
                 1. [=Assert=]: |modified| is true.
                 1. [=list/Remove=] |attribute| from
                     |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"].
@@ -1183,11 +1183,11 @@ to fix up per-element allow- or remove-lists to maintain our validity criteria. 
     1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=]:
         1. [=list/iterate|For each=] |element| in |configuration|["{{SanitizerConfig/elements}}"]:
             1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
-               [=map/with default=] &#171; &#187; [=list/contains=] |attribute|:
+               [=map/with default=] « » [=list/contains=] |attribute|:
                 1. [=list/Remove=] |attribute| from
                     |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"].
             1. If |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-               [=map/with default=] &#171; &#187; [=list/contains=] |attribute|:
+               [=map/with default=] « » [=list/contains=] |attribute|:
                 1. [=list/Remove=] |attribute| from
                     |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"].
     1. [=list/Append=] |attribute| to |configuration|["{{SanitizerConfig/removeAttributes}}"]
@@ -1207,7 +1207,7 @@ Note: While this algorithm is called [=remove unsafe=], we use
 
 1. [=Assert=]: The [=map/get the keys|key set=] of [=built-in safe baseline configuration=]
    [=set/equals=]
-   &#171;[ "{{SanitizerConfig/removeElements}}", "{{SanitizerConfig/removeAttributes}}" ] &#187;.
+   «[ "{{SanitizerConfig/removeElements}}", "{{SanitizerConfig/removeAttributes}}" ] ».
 1. [=Assert=]: |configuration| is [=SanitizerConfig/valid=].
 1. Let |result| be false.
 1. [=list/For each=] |element| in
@@ -1258,51 +1258,51 @@ value to a {{SanitizerConfig}}.
 
 1. If neither |configuration|["{{SanitizerConfig/elements}}"] nor
     |configuration|["{{SanitizerConfig/removeElements}}"] [=map/exist=], then [=map/set=]
-    |configuration|["{{SanitizerConfig/removeElements}}"] to &#171; &#187;.
+    |configuration|["{{SanitizerConfig/removeElements}}"] to « ».
 1. If neither |configuration|["{{SanitizerConfig/processingInstructions}}"] nor
     |configuration|["{{SanitizerConfig/removeProcessingInstructions}}"] [=map/exist=]:
-    1. If |allowCommentsPIsAndDataAttributes| is true, then [=map/set=] |configuration|["{{SanitizerConfig/removeProcessingInstructions}}"] to &#171; &#187;.
-    1. Otherwise, [=map/set=] |configuration|["{{SanitizerConfig/processingInstructions}}"] to &#171; &#187;.
+    1. If |allowCommentsPIsAndDataAttributes| is true, then [=map/set=] |configuration|["{{SanitizerConfig/removeProcessingInstructions}}"] to « ».
+    1. Otherwise, [=map/set=] |configuration|["{{SanitizerConfig/processingInstructions}}"] to « ».
 1. If neither |configuration|["{{SanitizerConfig/attributes}}"] nor
     |configuration|["{{SanitizerConfig/removeAttributes}}"] [=map/exist=], then [=map/set=]
-    |configuration|["{{SanitizerConfig/removeAttributes}}"] to &#171; &#187;.
+    |configuration|["{{SanitizerConfig/removeAttributes}}"] to « ».
 1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=]:
-   1. Let |elements| be &#171; &#187;.
+   1. Let |elements| be « ».
    1. [=list/iterate|For each=] |element| of |configuration|["{{SanitizerConfig/elements}}"] do:
       1. [=list/Append=] the result of [=canonicalize a sanitizer element with attributes=]
           |element| to |elements|.
    1. Set |configuration|["{{SanitizerConfig/elements}}"] to |elements|.
 1. If |configuration|["{{SanitizerConfig/removeElements}}"] [=map/exists=]:
-   1. Let |elements| be &#171; &#187;.
+   1. Let |elements| be « ».
    1. [=list/iterate|For each=] |element| of |configuration|["{{SanitizerConfig/removeElements}}"] do:
       1. [=list/Append=] the result of [=canonicalize a sanitizer element=] |element| to
           |elements|.
    1. Set |configuration|["{{SanitizerConfig/removeElements}}"] to |elements|.
 1. If |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"] [=map/exists=]:
-   1. Let |elements| be &#171; &#187;.
+   1. Let |elements| be « ».
    1. [=list/iterate|For each=] |element| of |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"] do:
       1. [=list/Append=] the result of [=canonicalize a sanitizer element=] |element| to |elements|.
    1. Set |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"] to |elements|.
 1. If |configuration|["{{SanitizerConfig/processingInstructions}}"] [=map/exists=]:
-   1. Let |processingInstructions| be &#171; &#187;.
+   1. Let |processingInstructions| be « ».
    1. [=list/iterate|For each=] |pi| of |configuration|["{{SanitizerConfig/processingInstructions}}"]:
       1. [=list/Append=] the result of [=canonicalize a sanitizer processing instruction=]
           |pi| to |processingInstructions|.
    1. Set |configuration|["{{SanitizerConfig/processingInstructions}}"] to |processingInstructions|.
 1. If |configuration|["{{SanitizerConfig/removeProcessingInstructions}}"] [=map/exists=]:
-   1. Let |processingInstructions| be &#171; &#187;.
+   1. Let |processingInstructions| be « ».
    1. [=list/iterate|For each=] |pi| of |configuration|["{{SanitizerConfig/removeProcessingInstructions}}"]:
       1. [=list/Append=] the result of [=canonicalize a sanitizer processing instruction=] |pi| to
           |processingInstructions|.
    1. Set |configuration|["{{SanitizerConfig/removeProcessingInstructions}}"] to |processingInstructions|.
 1. If |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
-   1. Let |attributes| be &#171; &#187;.
+   1. Let |attributes| be « ».
    1. [=list/iterate|For each=] |attribute| of |configuration|["{{SanitizerConfig/attributes}}"] do:
       1. [=list/Append=] the result of [=canonicalize a sanitizer attribute=] |attribute| to
           |attributes|.
    1. Set |configuration|["{{SanitizerConfig/attributes}}"] to |attributes|.
 1. If |configuration|["{{SanitizerConfig/removeAttributes}}"] [=map/exists=]:
-   1. Let |attributes| be &#171; &#187;.
+   1. Let |attributes| be « ».
    1. [=list/iterate|For each=] |attribute| of |configuration|["{{SanitizerConfig/removeAttributes}}"] do:
       1. [=list/Append=] the result of [=canonicalize a sanitizer attribute=] |attribute| to
           |attributes|.
@@ -1322,18 +1322,18 @@ To <dfn>canonicalize a sanitizer element with attributes</dfn> a {{SanitizerElem
 1. Let |result| be the result of [=canonicalize a sanitizer element=] with |element|.
 1. If |element| is a [=dictionary=]:
   1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/exists=]:
-    1. Let |attributes| be &#171; &#187;.
+    1. Let |attributes| be « ».
     1. [=list/iterate|For each=] |attribute| of |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]:
       1. [=list/Append=] the result of [=canonicalize a sanitizer attribute=] with |attribute| to |attributes|.
     1. [=map/Set=] |result|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] to |attributes|.
   1. If |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/exists=]:
-    1. Let |attributes| be &#171; &#187;.
+    1. Let |attributes| be « ».
     1. [=list/iterate|For each=] |attribute| of |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]:
       1. [=list/Append=] the result of [=canonicalize a sanitizer attribute=] with |attribute| to |attributes|.
     1. [=map/Set=] |result|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to |attributes|.
 1. If neither |result|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] nor
    |result|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/exist=]:
-  1. [=map/Set=] |result|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to &#171; &#187;.
+  1. [=map/Set=] |result|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to « ».
 1. Return |result|.
 
 </div>
@@ -1348,9 +1348,9 @@ return the result of [=canonicalize a sanitizer name=] with |element| and the [=
 In order to <dfn>canonicalize a sanitizer processing instruction</dfn> |pi|, run the following steps:
 
 1. [=Assert=]: |pi| is either a {{DOMString}} or a [=dictionary=].
-1. If |pi| is a {{DOMString}}, then return &#171;[ "`target`" &rightarrow; |pi| ]&#187;.
+1. If |pi| is a {{DOMString}}, then return «[ "`target`" &rightarrow; |pi| ]».
 1. [=Assert=]: |pi| is a [=dictionary=] and |pi|["target"] [=map/exists=].
-1. Return &#171;[ "`target`" &rightarrow; |pi|["target"] ]&#187;.
+1. Return «[ "`target`" &rightarrow; |pi|["target"] ]».
 
 </div>
 
@@ -1366,13 +1366,13 @@ In order to <dfn>canonicalize a sanitizer name</dfn> |name|, with a default
 namespace |defaultNamespace|, run the following steps:
 
 1. [=Assert=]: |name| is either a {{DOMString}} or a [=dictionary=].
-1. If |name| is a {{DOMString}}, then return &#171;[ "`name`" &rightarrow; |name|, "`namespace`" &rightarrow; |defaultNamespace|]&#187;.
+1. If |name| is a {{DOMString}}, then return «[ "`name`" &rightarrow; |name|, "`namespace`" &rightarrow; |defaultNamespace|]».
 1. [=Assert=]: |name| is a [=dictionary=] and both |name|["name"] and |name|["namespace"] [=map/exist=].
 1. If |name|["namespace"] is the empty string, then set it to null.
-1. Return &#171;[ <br>
+1. Return «[ <br>
   "`name`" &rightarrow; |name|["name"], <br>
   "`namespace`" &rightarrow; |name|["namespace"] <br>
-  ]&#187;.
+  ]».
 
 </div>
 
@@ -1465,7 +1465,7 @@ there is more than one |entry| in |list| where
 <div algorithm>
 To <dfn for=SanitizerConfig>remove duplicates</dfn> from a [=/list=] |list|,
 
-1. Let |result| be &#171; &#187;.
+1. Let |result| be « ».
 1. [=list/iterate|For each=] |entry| of |list|, [=SanitizerConfig/add=] |entry| to |result|.
 1. Return |result|.
 
@@ -1476,8 +1476,8 @@ The <dfn for=SanitizerConfig>intersection</dfn> of two [=/lists=] |A| and |B|
 containing {{SanitizerElement}} is the same as [=set/intersection|set intersection=],
 but with the [=/set=] entries previously [=canonicalize a sanitizer name|canonicalized=]:
 
-1. Let |set A| be &#171; [] &#187;
-1. Let |set B| be &#171; [] &#187;
+1. Let |set A| be « [] »
+1. Let |set B| be « [] »
 1. [=list/iterate|For each=] |entry| of |A|, [=set/append=] the result of
     [=canonicalize a sanitizer name=] |entry| to |set A|.
 1. [=list/iterate|For each=] |entry| of |B|, [=set/append=] the result of
@@ -1545,7 +1545,7 @@ highlight: json
 The <dfn>built-in navigating URL attributes list</dfn>, for which "`javascript:`"
 navigations are "unsafe", are as follows:
 
-&#171;[
+«[
   <br>
   [
     { "`name`" &rightarrow; "`a`", "`namespace`" &rightarrow; [=HTML namespace=] },
@@ -1587,14 +1587,14 @@ navigations are "unsafe", are as follows:
     { "`name`" &rightarrow; "`href`", "`namespace`" &rightarrow; [=XLink namespace=] }
   ],
   <br>
-]&#187;
+]»
 </div>
 
 The <dfn>built-in animating URL attributes list</dfn>, which can be used in
 [[SVG11]] to declaratively modify navigation elements to use "`javascript:`"
 URLs, is as follows:
 
-&#171;[
+«[
   <br>
   [
     { "`name`" &rightarrow; "`animate`", "`namespace`" &rightarrow; [=SVG namespace=] },
@@ -1611,12 +1611,12 @@ URLs, is as follows:
     { "`name`" &rightarrow; "`attributeName`", "`namespace`" &rightarrow; `null` }
   ],
   <br>
-]&#187;
+]»
 
 The <dfn>built-in non-replaceable elements list</dfn> contains elements that must not be
 replaced with their children, as doing so can lead to re-parsing issues or an invalid node tree.
 
-&#171;[
+«[
   <br>
   { "`name`" &rightarrow; "`html`", "`namespace`" &rightarrow; [=HTML namespace=] },
   <br>
@@ -1624,7 +1624,7 @@ replaced with their children, as doing so can lead to re-parsing issues or an in
   <br>
   { "`name`" &rightarrow; "`math`", "`namespace`" &rightarrow; [=MathML Namespace=] },
   <br>
-]&#187;
+]»
 
 <div class=note><span class=marker>Note:</span>
 

--- a/index.bs
+++ b/index.bs
@@ -1476,8 +1476,8 @@ The <dfn for=SanitizerConfig>intersection</dfn> of two [=/lists=] |A| and |B|
 containing {{SanitizerElement}} is the same as [=set/intersection|set intersection=],
 but with the [=/set=] entries previously [=canonicalize a sanitizer name|canonicalized=]:
 
-1. Let |set A| be « [] »
-1. Let |set B| be « [] »
+1. Let |set A| be « [] ».
+1. Let |set B| be « [] ».
 1. [=list/iterate|For each=] |entry| of |A|, [=set/append=] the result of
     [=canonicalize a sanitizer name=] |entry| to |set A|.
 1. [=list/iterate|For each=] |entry| of |B|, [=set/append=] the result of

--- a/index.bs
+++ b/index.bs
@@ -393,7 +393,7 @@ allow- or remove-lists for attributes. This requires that we distinguish 4 cases
                 [=set/difference=] of
                 |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] and
                 |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-                [=map/with default=] &laquo; &raquo;.
+                [=map/with default=] &#171; &#187;.
         1. [=map/Remove=] |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"].
         1. Set |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] to the
                 [=set/difference=] of
@@ -422,7 +422,7 @@ allow- or remove-lists for attributes. This requires that we distinguish 4 cases
     1. Return true.
 1. Otherwise:
   1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/exists=] or
-     |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=with default=] &laquo; &raquo;
+     |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=with default=] &#171; &#187;
      is not [=list/empty=]:
     1. The user agent may [=report a warning to the console=] that this operation is not supported.
     1. Return false.
@@ -524,11 +524,11 @@ up per-element allow- or remove-lists to maintain our validity criteria.
     1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=]:
         1. [=list/iterate|For each=] |element| in |configuration|["{{SanitizerConfig/elements}}"]:
             1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
-               [=map/with default=] &laquo; &raquo; [=list/contains=] |attribute|:
+               [=map/with default=] &#171; &#187; [=list/contains=] |attribute|:
                 1. [=list/Remove=] |attribute| from
                     |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"].
             1. [=Assert=]: |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-               [=map/with default=] &laquo; &raquo;
+               [=map/with default=] &#171; &#187;
                does not [=list/contain=] |attribute|.
     1. [=list/Append=] |attribute| to |configuration|["{{SanitizerConfig/attributes}}"]
     1. Return true.
@@ -655,11 +655,11 @@ Several conditions need to hold for a configuration to be valid:
   - {{SanitizerConfig/elements}} or {{SanitizerConfig/removeElements}} can exist,
     but not both.
     If both are missing, this is equivalent to {{SanitizerConfig/removeElements}}
-    [=map/set=] to &laquo; &raquo;.
+    [=map/set=] to &#171; &#187;.
   - {{SanitizerConfig/attributes}} or {{SanitizerConfig/removeAttributes}} can exist,
     but not both.
     If both are missing, this is equivalent to {{SanitizerConfig/removeAttributes}}
-    [=map/set=] to &laquo; &raquo;.
+    [=map/set=] to &#171; &#187;.
   - {{SanitizerConfig/dataAttributes}} is conceptually an extension of the
     {{SanitizerConfig/attributes}} allow-list. The {{SanitizerConfig/dataAttributes}}
     attribute is only allowed when a {{SanitizerConfig/attributes}} list is used.
@@ -851,9 +851,9 @@ NOTE: It's expected that the configuration being passing in has previously been 
                 [=SanitizerConfig/has duplicates=], then return false.
             1. If the [=set/intersection=] of |config|["{{SanitizerConfig/attributes}}"] and
                 |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=with default=]
-                &laquo; &raquo; is not [=list/empty=], then return false.
+                &#171; &#187; is not [=list/empty=], then return false.
             1. If |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-                [=with default=] &laquo; &raquo; is not a
+                [=with default=] &#171; &#187; is not a
                 [=set/subset=] of |config|["{{SanitizerConfig/attributes}}"], then return false.
             1. If |config|["{{SanitizerConfig/dataAttributes}}"] is true and
                 |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
@@ -875,10 +875,10 @@ NOTE: It's expected that the configuration being passing in has previously been 
                [=SanitizerConfig/has duplicates=], then return false.
             1. If the [=set/intersection=] of |config|["{{SanitizerConfig/removeAttributes}}"] and
                 |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=with default=]
-                &laquo; &raquo; is not [=list/empty=], then return false.
+                &#171; &#187; is not [=list/empty=], then return false.
             1. If the [=set/intersection=] of |config|["{{SanitizerConfig/removeAttributes}}"] and
                 |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=with default=]
-                &laquo; &raquo; is not [=list/empty=], then return false.
+                &#171; &#187; is not [=list/empty=], then return false.
     1. If |config|["{{SanitizerConfig/dataAttributes}}"] [=map/exists=], then return false.
 1. Return true.
 
@@ -1003,14 +1003,14 @@ beginning with |node|. It consistes of these steps:
          |elementName|:
         1. [=/Remove=] |child|.
         1. [=Continue=].
-    1. If |elementName| [=string/is|equals=] &laquo;[ "`name`" &rightarrow; "`template`",
-       "`namespace`" &rightarrow; [=HTML namespace=] ]&raquo;,
+    1. If |elementName| [=string/is|equals=] &#171;[ "`name`" &rightarrow; "`template`",
+       "`namespace`" &rightarrow; [=HTML namespace=] ]&#187;,
           then call [=sanitize core=] on |child|'s [=template contents=] with
           |configuration| and |handleJavascriptNavigationUrls|.
     1. If |child| is a [=shadow host=],
        then call [=sanitize core=] on |child|'s [=Element/shadow root=] with
        |configuration| and |handleJavascriptNavigationUrls|.
-    1. Let |elementWithLocalAttributes| be &laquo; [] &raquo;.
+    1. Let |elementWithLocalAttributes| be &#171; [] &#187;.
     1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=] and
         |configuration|["{{SanitizerConfig/elements}}"] [=SanitizerConfig/contains=]
         |elementName|:
@@ -1020,13 +1020,13 @@ beginning with |node|. It consistes of these steps:
       1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
          [=Attr/local name=] and [=Attr/namespace=].
 
-      1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/with default=] &laquo; &raquo;
+      1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/with default=] &#171; &#187;
         [=SanitizerConfig/contains=] |attrName|:
           1. [=/remove an attribute|Remove=] |attribute|.
       1. Otherwise, if |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
           1. If |configuration|["{{SanitizerConfig/attributes}}"] does not
               [=SanitizerConfig/contain=] |attrName| and
-              |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/with default=] &laquo; &raquo;
+              |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/with default=] &#171; &#187;
               does not [=SanitizerConfig/contain=] |attrName|, and if
               "data-" is not a [=code unit prefix=] of |attribute|'s [=Attr/local name=] and
               [=Attr/namespace=] is not `null` or
@@ -1041,7 +1041,7 @@ beginning with |node|. It consistes of these steps:
               1. [=/remove an attribute|Remove=] |attribute|.
 
       1. If |handleJavascriptNavigationUrls|:
-         1. If &laquo;[|elementName|, |attrName|]&raquo; matches an entry in
+         1. If &#171;[|elementName|, |attrName|]&#187; matches an entry in
             the [=built-in navigating URL attributes list=], and if |attribute|
             [=contains a javascript: URL=], then [=/remove an attribute|remove=] |attribute|.
          1. If |child|'s [=Element/namespace=] [=string/is=] the
@@ -1051,7 +1051,7 @@ beginning with |node|. It consistes of these steps:
             then [=/remove an attribute|remove=] |attribute|.
          1. If the [=built-in animating URL attributes list=]
             [=SanitizerConfig/contains=]
-            &laquo;[|elementName|, |attrName|]&raquo; and |attr|'s
+            &#171;[|elementName|, |attrName|]&#187; and |attr|'s
             [=get an attribute value|value=] [=string/is=] "`href`" or
             "`xlink:href`", then [=/remove an attribute|remove=] |attribute|.
     1. Call [=sanitize core=] on |child| with |configuration| and |handleJavascriptNavigationUrls|.
@@ -1165,12 +1165,12 @@ to fix up per-element allow- or remove-lists to maintain our validity criteria. 
     1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=]:
         1. [=list/iterate|For each=] |element| of |configuration|["{{SanitizerConfig/elements}}"]:
             1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
-               [=map/with default=] &laquo; &raquo; [=list/contains=] |attribute|:
+               [=map/with default=] &#171; &#187; [=list/contains=] |attribute|:
                 1. Set |modified| to true.
                 1. [=list/Remove=] |attribute| from
                     |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"].            
             1. If |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-               [=map/with default=] &laquo; &raquo; [=list/contains=] |attribute|:
+               [=map/with default=] &#171; &#187; [=list/contains=] |attribute|:
                 1. [=Assert=]: |modified| is true.
                 1. [=list/Remove=] |attribute| from
                     |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"].
@@ -1183,11 +1183,11 @@ to fix up per-element allow- or remove-lists to maintain our validity criteria. 
     1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=]:
         1. [=list/iterate|For each=] |element| in |configuration|["{{SanitizerConfig/elements}}"]:
             1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
-               [=map/with default=] &laquo; &raquo; [=list/contains=] |attribute|:
+               [=map/with default=] &#171; &#187; [=list/contains=] |attribute|:
                 1. [=list/Remove=] |attribute| from
                     |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"].
             1. If |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]
-               [=map/with default=] &laquo; &raquo; [=list/contains=] |attribute|:
+               [=map/with default=] &#171; &#187; [=list/contains=] |attribute|:
                 1. [=list/Remove=] |attribute| from
                     |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"].
     1. [=list/Append=] |attribute| to |configuration|["{{SanitizerConfig/removeAttributes}}"]
@@ -1207,7 +1207,7 @@ Note: While this algorithm is called [=remove unsafe=], we use
 
 1. [=Assert=]: The [=map/get the keys|key set=] of [=built-in safe baseline configuration=]
    [=set/equals=]
-   &laquo;[ "{{SanitizerConfig/removeElements}}", "{{SanitizerConfig/removeAttributes}}" ] &raquo;.
+   &#171;[ "{{SanitizerConfig/removeElements}}", "{{SanitizerConfig/removeAttributes}}" ] &#187;.
 1. [=Assert=]: |configuration| is [=SanitizerConfig/valid=].
 1. Let |result| be false.
 1. [=list/For each=] |element| in
@@ -1258,51 +1258,51 @@ value to a {{SanitizerConfig}}.
 
 1. If neither |configuration|["{{SanitizerConfig/elements}}"] nor
     |configuration|["{{SanitizerConfig/removeElements}}"] [=map/exist=], then [=map/set=]
-    |configuration|["{{SanitizerConfig/removeElements}}"] to &laquo; &raquo;.
+    |configuration|["{{SanitizerConfig/removeElements}}"] to &#171; &#187;.
 1. If neither |configuration|["{{SanitizerConfig/processingInstructions}}"] nor
     |configuration|["{{SanitizerConfig/removeProcessingInstructions}}"] [=map/exist=]:
-    1. If |allowCommentsPIsAndDataAttributes| is true, then [=map/set=] |configuration|["{{SanitizerConfig/removeProcessingInstructions}}"] to &laquo; &raquo;.
-    1. Otherwise, [=map/set=] |configuration|["{{SanitizerConfig/processingInstructions}}"] to &laquo; &raquo;.
+    1. If |allowCommentsPIsAndDataAttributes| is true, then [=map/set=] |configuration|["{{SanitizerConfig/removeProcessingInstructions}}"] to &#171; &#187;.
+    1. Otherwise, [=map/set=] |configuration|["{{SanitizerConfig/processingInstructions}}"] to &#171; &#187;.
 1. If neither |configuration|["{{SanitizerConfig/attributes}}"] nor
     |configuration|["{{SanitizerConfig/removeAttributes}}"] [=map/exist=], then [=map/set=]
-    |configuration|["{{SanitizerConfig/removeAttributes}}"] to &laquo; &raquo;.
+    |configuration|["{{SanitizerConfig/removeAttributes}}"] to &#171; &#187;.
 1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=]:
-   1. Let |elements| be &laquo; &raquo;.
+   1. Let |elements| be &#171; &#187;.
    1. [=list/iterate|For each=] |element| of |configuration|["{{SanitizerConfig/elements}}"] do:
       1. [=list/Append=] the result of [=canonicalize a sanitizer element with attributes=]
           |element| to |elements|.
    1. Set |configuration|["{{SanitizerConfig/elements}}"] to |elements|.
 1. If |configuration|["{{SanitizerConfig/removeElements}}"] [=map/exists=]:
-   1. Let |elements| be &laquo; &raquo;.
+   1. Let |elements| be &#171; &#187;.
    1. [=list/iterate|For each=] |element| of |configuration|["{{SanitizerConfig/removeElements}}"] do:
       1. [=list/Append=] the result of [=canonicalize a sanitizer element=] |element| to
           |elements|.
    1. Set |configuration|["{{SanitizerConfig/removeElements}}"] to |elements|.
 1. If |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"] [=map/exists=]:
-   1. Let |elements| be &laquo; &raquo;.
+   1. Let |elements| be &#171; &#187;.
    1. [=list/iterate|For each=] |element| of |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"] do:
       1. [=list/Append=] the result of [=canonicalize a sanitizer element=] |element| to |elements|.
    1. Set |configuration|["{{SanitizerConfig/replaceWithChildrenElements}}"] to |elements|.
 1. If |configuration|["{{SanitizerConfig/processingInstructions}}"] [=map/exists=]:
-   1. Let |processingInstructions| be &laquo; &raquo;.
+   1. Let |processingInstructions| be &#171; &#187;.
    1. [=list/iterate|For each=] |pi| of |configuration|["{{SanitizerConfig/processingInstructions}}"]:
       1. [=list/Append=] the result of [=canonicalize a sanitizer processing instruction=]
           |pi| to |processingInstructions|.
    1. Set |configuration|["{{SanitizerConfig/processingInstructions}}"] to |processingInstructions|.
 1. If |configuration|["{{SanitizerConfig/removeProcessingInstructions}}"] [=map/exists=]:
-   1. Let |processingInstructions| be &laquo; &raquo;.
+   1. Let |processingInstructions| be &#171; &#187;.
    1. [=list/iterate|For each=] |pi| of |configuration|["{{SanitizerConfig/removeProcessingInstructions}}"]:
       1. [=list/Append=] the result of [=canonicalize a sanitizer processing instruction=] |pi| to
           |processingInstructions|.
    1. Set |configuration|["{{SanitizerConfig/removeProcessingInstructions}}"] to |processingInstructions|.
 1. If |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
-   1. Let |attributes| be &laquo; &raquo;.
+   1. Let |attributes| be &#171; &#187;.
    1. [=list/iterate|For each=] |attribute| of |configuration|["{{SanitizerConfig/attributes}}"] do:
       1. [=list/Append=] the result of [=canonicalize a sanitizer attribute=] |attribute| to
           |attributes|.
    1. Set |configuration|["{{SanitizerConfig/attributes}}"] to |attributes|.
 1. If |configuration|["{{SanitizerConfig/removeAttributes}}"] [=map/exists=]:
-   1. Let |attributes| be &laquo; &raquo;.
+   1. Let |attributes| be &#171; &#187;.
    1. [=list/iterate|For each=] |attribute| of |configuration|["{{SanitizerConfig/removeAttributes}}"] do:
       1. [=list/Append=] the result of [=canonicalize a sanitizer attribute=] |attribute| to
           |attributes|.
@@ -1322,18 +1322,18 @@ To <dfn>canonicalize a sanitizer element with attributes</dfn> a {{SanitizerElem
 1. Let |result| be the result of [=canonicalize a sanitizer element=] with |element|.
 1. If |element| is a [=dictionary=]:
   1. If |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/exists=]:
-    1. Let |attributes| be &laquo; &raquo;.
+    1. Let |attributes| be &#171; &#187;.
     1. [=list/iterate|For each=] |attribute| of |element|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]:
       1. [=list/Append=] the result of [=canonicalize a sanitizer attribute=] with |attribute| to |attributes|.
     1. [=map/Set=] |result|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] to |attributes|.
   1. If |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/exists=]:
-    1. Let |attributes| be &laquo; &raquo;.
+    1. Let |attributes| be &#171; &#187;.
     1. [=list/iterate|For each=] |attribute| of |element|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"]:
       1. [=list/Append=] the result of [=canonicalize a sanitizer attribute=] with |attribute| to |attributes|.
     1. [=map/Set=] |result|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to |attributes|.
 1. If neither |result|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] nor
    |result|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/exist=]:
-  1. [=map/Set=] |result|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to &laquo; &raquo;.
+  1. [=map/Set=] |result|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] to &#171; &#187;.
 1. Return |result|.
 
 </div>
@@ -1348,9 +1348,9 @@ return the result of [=canonicalize a sanitizer name=] with |element| and the [=
 In order to <dfn>canonicalize a sanitizer processing instruction</dfn> |pi|, run the following steps:
 
 1. [=Assert=]: |pi| is either a {{DOMString}} or a [=dictionary=].
-1. If |pi| is a {{DOMString}}, then return &laquo;[ "`target`" &rightarrow; |pi| ]&raquo;.
+1. If |pi| is a {{DOMString}}, then return &#171;[ "`target`" &rightarrow; |pi| ]&#187;.
 1. [=Assert=]: |pi| is a [=dictionary=] and |pi|["target"] [=map/exists=].
-1. Return &laquo;[ "`target`" &rightarrow; |pi|["target"] ]&raquo;.
+1. Return &#171;[ "`target`" &rightarrow; |pi|["target"] ]&#187;.
 
 </div>
 
@@ -1366,13 +1366,13 @@ In order to <dfn>canonicalize a sanitizer name</dfn> |name|, with a default
 namespace |defaultNamespace|, run the following steps:
 
 1. [=Assert=]: |name| is either a {{DOMString}} or a [=dictionary=].
-1. If |name| is a {{DOMString}}, then return &laquo;[ "`name`" &rightarrow; |name|, "`namespace`" &rightarrow; |defaultNamespace|]&raquo;.
+1. If |name| is a {{DOMString}}, then return &#171;[ "`name`" &rightarrow; |name|, "`namespace`" &rightarrow; |defaultNamespace|]&#187;.
 1. [=Assert=]: |name| is a [=dictionary=] and both |name|["name"] and |name|["namespace"] [=map/exist=].
 1. If |name|["namespace"] is the empty string, then set it to null.
-1. Return &laquo;[ <br>
+1. Return &#171;[ <br>
   "`name`" &rightarrow; |name|["name"], <br>
   "`namespace`" &rightarrow; |name|["namespace"] <br>
-  ]&raquo;.
+  ]&#187;.
 
 </div>
 
@@ -1465,7 +1465,7 @@ there is more than one |entry| in |list| where
 <div algorithm>
 To <dfn for=SanitizerConfig>remove duplicates</dfn> from a [=/list=] |list|,
 
-1. Let |result| be &laquo; &raquo;.
+1. Let |result| be &#171; &#187;.
 1. [=list/iterate|For each=] |entry| of |list|, [=SanitizerConfig/add=] |entry| to |result|.
 1. Return |result|.
 
@@ -1476,8 +1476,8 @@ The <dfn for=SanitizerConfig>intersection</dfn> of two [=/lists=] |A| and |B|
 containing {{SanitizerElement}} is the same as [=set/intersection|set intersection=],
 but with the [=/set=] entries previously [=canonicalize a sanitizer name|canonicalized=]:
 
-1. Let |set A| be &laquo; [] &raquo;
-1. Let |set B| be &laquo; [] &raquo;
+1. Let |set A| be &#171; [] &#187;
+1. Let |set B| be &#171; [] &#187;
 1. [=list/iterate|For each=] |entry| of |A|, [=set/append=] the result of
     [=canonicalize a sanitizer name=] |entry| to |set A|.
 1. [=list/iterate|For each=] |entry| of |B|, [=set/append=] the result of
@@ -1545,7 +1545,7 @@ highlight: json
 The <dfn>built-in navigating URL attributes list</dfn>, for which "`javascript:`"
 navigations are "unsafe", are as follows:
 
-&laquo;[
+&#171;[
   <br>
   [
     { "`name`" &rightarrow; "`a`", "`namespace`" &rightarrow; [=HTML namespace=] },
@@ -1587,14 +1587,14 @@ navigations are "unsafe", are as follows:
     { "`name`" &rightarrow; "`href`", "`namespace`" &rightarrow; [=XLink namespace=] }
   ],
   <br>
-]&raquo;
+]&#187;
 </div>
 
 The <dfn>built-in animating URL attributes list</dfn>, which can be used in
 [[SVG11]] to declaratively modify navigation elements to use "`javascript:`"
 URLs, is as follows:
 
-&laquo;[
+&#171;[
   <br>
   [
     { "`name`" &rightarrow; "`animate`", "`namespace`" &rightarrow; [=SVG namespace=] },
@@ -1611,12 +1611,12 @@ URLs, is as follows:
     { "`name`" &rightarrow; "`attributeName`", "`namespace`" &rightarrow; `null` }
   ],
   <br>
-]&raquo;
+]&#187;
 
 The <dfn>built-in non-replaceable elements list</dfn> contains elements that must not be
 replaced with their children, as doing so can lead to re-parsing issues or an invalid node tree.
 
-&laquo;[
+&#171;[
   <br>
   { "`name`" &rightarrow; "`html`", "`namespace`" &rightarrow; [=HTML namespace=] },
   <br>
@@ -1624,7 +1624,7 @@ replaced with their children, as doing so can lead to re-parsing issues or an in
   <br>
   { "`name`" &rightarrow; "`math`", "`namespace`" &rightarrow; [=MathML Namespace=] },
   <br>
-]&raquo;
+]&#187;
 
 <div class=note><span class=marker>Note:</span>
 

--- a/index.bs
+++ b/index.bs
@@ -1207,7 +1207,7 @@ Note: While this algorithm is called [=remove unsafe=], we use
 
 1. [=Assert=]: The [=map/get the keys|key set=] of [=built-in safe baseline configuration=]
    [=set/equals=]
-   «[ "{{SanitizerConfig/removeElements}}", "{{SanitizerConfig/removeAttributes}}" ] ».
+   « [ "{{SanitizerConfig/removeElements}}", "{{SanitizerConfig/removeAttributes}}" ] ».
 1. [=Assert=]: |configuration| is [=SanitizerConfig/valid=].
 1. Let |result| be false.
 1. [=list/For each=] |element| in


### PR DESCRIPTION
To @annevk's request


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evilpie/sanitizer-api/pull/395.html" title="Last updated on Apr 16, 2026, 3:02 PM UTC (d7244e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/395/80d1a2e...evilpie:d7244e3.html" title="Last updated on Apr 16, 2026, 3:02 PM UTC (d7244e3)">Diff</a>