### PR TITLE
Remove custom element state when is attribute is blocked

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -938,6 +938,13 @@ beginning with |node|. It consistes of these steps:
         |elementName|:
        1. Set |elementWithLocalAttributes| to
            |configuration|["{{SanitizerConfig/elements}}"][|elementName|].
+    1. If |child|'s [=is value=] is not `null`:
+        1. Set |isAttribute| to  &laquo;[ "`name`" &rightarrow; "`is`", "`namespace`" &rightarrow; null ]&raquo;.
+        1. If [=is attribute allowed=] for |isAttribute| given |configuration|,
+            |child| is [=/blocked=]:
+            1. Set |child|'s [=custom element state=] to "undefined".
+            1. Set |child|'s [=custom element definition=] to `null`.
+            1. Set |child|'s [=is value=] to `null`.
     1. [=list/iterate|For each=] |attribute| in |child|'s [=Element/attribute list=]:
       1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
          [=Attr/local name=] and [=Attr/namespace=].

--- a/index.bs
+++ b/index.bs
@@ -1094,6 +1094,9 @@ and an {{SanitizerElementNamespace}} |elementName|:
     1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
         [=map/exists=] and |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] does not [=SanitizerConfig/contain=] |attrName|:
         1. Return [=/blocked=].
+    1. Otherwise, if |configuration|["{{SanitizerConfig/removeAttributes}}"]
+       [=SanitizerConfig/contains=] |attrName|:
+        1. Return [=/blocked=].
 1. Return [=/allowed=].
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1033,13 +1033,12 @@ beginning with |node|. It consistes of these steps:
        then call [=sanitize core=] on |child|'s [=Element/shadow root=] with
        |configuration| and |handleJavascriptNavigationUrls|.
     1. [=list/iterate|For each=] |attribute| in |child|'s [=Element/attribute list=]:
-      1. If [=is attribute allowed=] for |attribute| given |configuration|,
-         and |child| is [=/blocked=],
+      1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
+         [=Attr/local name=] and [=Attr/namespace=].
+      1. If [=is attribute allowed=] for |attrName| given |configuration|,
+         and |elementName| is [=/blocked=],
          then [=/remove an attribute|remove=] |attribute|.
-
       1. If |handleJavascriptNavigationUrls|:
-        1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
-           [=Attr/local name=] and [=Attr/namespace=].
         1. If &laquo;[|elementName|, |attrName|]&raquo; matches an entry in
            the [=built-in navigating URL attributes list=], and if |attribute|
            [=contains a javascript: URL=], then [=/remove an attribute|remove=]
@@ -1059,13 +1058,11 @@ beginning with |node|. It consistes of these steps:
 </div>
 
 <div algorithm>
-To determine <dfn>is attribute allowed</dfn> for an |attribute|,
-given a {{SanitizerConfig}} |configuration|, an {{Element}} |current element|:
+To determine <dfn>is attribute allowed</dfn> for a
+{{SanitizerAttributeNamespace}} |attrName|,
+given a {{SanitizerConfig}} |configuration|,
+and an {{SanitizerElementNamespace}} |elementName|:
 
-1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
-    [=Attr/local name=] and [=Attr/namespace=].
-1. Let |elementName| be a {{SanitizerElementNamespace}} with |current element|'s
-    [=Element/local name=] and [=Element/namespace=].
 1. Let |elementWithLocalAttributes| be an empty [=ordered map=].
 1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=] and
     |configuration|["{{SanitizerConfig/elements}}"] [=SanitizerConfig/contains=]
@@ -1087,8 +1084,9 @@ given a {{SanitizerConfig}} |configuration|, an {{Element}} |current element|:
         |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/with default=] &laquo; &raquo;
         [=SanitizerConfig/contains=] |attrName|.
     1. Let the [=boolean=] |isDataAttributeAllowed| be whether both,
-        "data-" is a [=code unit prefix=] of |attribute|'s
-        [=Attr/local name=] and [=Attr/namespace=] is `null`, and
+        "data-" is a [=code unit prefix=] of
+        |attrName|[{{SanitizerAttributeNamespace/name}}] and
+        |attrName|[{{SanitizerAttributeNamespace/namespace}}] is `null`, and
         |configuration|["{{SanitizerConfig/dataAttributes}}"] is true.
     1. If neither |globallyAllowed| nor |locallyAllowed| nor
         |isDataAttributeAllowed|, return [=/blocked=].

--- a/index.bs
+++ b/index.bs
@@ -1032,53 +1032,74 @@ beginning with |node|. It consistes of these steps:
     1. If |child| is a [=shadow host=],
        then call [=sanitize core=] on |child|'s [=Element/shadow root=] with
        |configuration| and |handleJavascriptNavigationUrls|.
-    1. Let |elementWithLocalAttributes| be « [] ».
-    1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=] and
-        |configuration|["{{SanitizerConfig/elements}}"] [=SanitizerConfig/contains=]
-        |elementName|:
-       1. Set |elementWithLocalAttributes| to
-           |configuration|["{{SanitizerConfig/elements}}"][|elementName|].
     1. [=list/iterate|For each=] |attribute| in |child|'s [=Element/attribute list=]:
-      1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
-         [=Attr/local name=] and [=Attr/namespace=].
-
-      1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/with default=] « »
-        [=SanitizerConfig/contains=] |attrName|:
-          1. [=/remove an attribute|Remove=] |attribute|.
-      1. Otherwise, if |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
-          1. If |configuration|["{{SanitizerConfig/attributes}}"] does not
-              [=SanitizerConfig/contain=] |attrName| and
-              |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/with default=] « »
-              does not [=SanitizerConfig/contain=] |attrName|, and if
-              "data-" is not a [=code unit prefix=] of |attribute|'s [=Attr/local name=] and
-              [=Attr/namespace=] is not `null` or
-              |configuration|["{{SanitizerConfig/dataAttributes}}"] is not true:
-              1. [=/remove an attribute|Remove=] |attribute|.
-      1. Otherwise:
-        1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
-          [=map/exists=] and |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] does not [=SanitizerConfig/contain=] |attrName|:
-          1. [=/remove an attribute|Remove=] |attribute|.
-
-        1. Otherwise, if |configuration|["{{SanitizerConfig/removeAttributes}}"] [=SanitizerConfig/contains=] |attrName|:
-              1. [=/remove an attribute|Remove=] |attribute|.
+      1. If [=is attribute allowed=] for |attribute| given |configuration|,
+         and |child| is [=/blocked=],
+         then [=/remove an attribute|remove=] |attribute|.
 
       1. If |handleJavascriptNavigationUrls|:
-         1. If «[|elementName|, |attrName|]» matches an entry in
-            the [=built-in navigating URL attributes list=], and if |attribute|
-            [=contains a javascript: URL=], then [=/remove an attribute|remove=] |attribute|.
-         1. If |child|'s [=Element/namespace=] [=string/is=] the
-            [=MathML Namespace=] and |attr|'s [=Attr/local name=] [=string/is=]
-            "`href`" and  |attr|'s [=Attr/namespace=] is `null` or the
-            [=XLink namespace=] and |attr| [=contains a javascript: URL=],
-            then [=/remove an attribute|remove=] |attribute|.
-         1. If the [=built-in animating URL attributes list=]
-            [=SanitizerConfig/contains=]
-            «[|elementName|, |attrName|]» and |attr|'s
-            [=get an attribute value|value=] [=string/is=] "`href`" or
-            "`xlink:href`", then [=/remove an attribute|remove=] |attribute|.
+        1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
+           [=Attr/local name=] and [=Attr/namespace=].
+        1. If &laquo;[|elementName|, |attrName|]&raquo; matches an entry in
+           the [=built-in navigating URL attributes list=], and if |attribute|
+           [=contains a javascript: URL=], then [=/remove an attribute|remove=]
+           |attribute|.
+        1. If |child|'s [=Element/namespace=] [=string/is=] the
+           [=MathML Namespace=] and |attr|'s [=Attr/local name=] [=string/is=]
+           "`href`" and  |attr|'s [=Attr/namespace=] is `null` or the
+           [=XLink namespace=] and |attr| [=contains a javascript: URL=],
+           then [=/remove an attribute|remove=] |attribute|.
+        1. If the [=built-in animating URL attributes list=]
+           [=SanitizerConfig/contains=]
+           &laquo;[|elementName|, |attrName|]&raquo; and |attr|'s
+           [=get an attribute value|value=] [=string/is=] "`href`" or
+           "`xlink:href`", then [=/remove an attribute|remove=] |attribute|.
     1. Call [=sanitize core=] on |child| with |configuration| and |handleJavascriptNavigationUrls|.
 
 </div>
+
+<div algorithm>
+To determine <dfn>is attribute allowed</dfn> for an |attribute|,
+given a {{SanitizerConfig}} |configuration|, an {{Element}} |current element|:
+
+1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
+    [=Attr/local name=] and [=Attr/namespace=].
+1. Let |elementName| be a {{SanitizerElementNamespace}} with |current element|'s
+    [=Element/local name=] and [=Element/namespace=].
+1. Let |elementWithLocalAttributes| be an empty [=ordered map=].
+1. If |configuration|["{{SanitizerConfig/elements}}"] [=map/exists=] and
+    |configuration|["{{SanitizerConfig/elements}}"] [=SanitizerConfig/contains=]
+    |elementName|:
+   1. Set |elementWithLocalAttributes| to the |item| in
+       |configuration|["{{SanitizerConfig/elements}}"] where
+       |elementName|["{{SanitizerElementNamespace/name}}"] [=string/is=]
+       |item|["{{SanitizerElementNamespace/name}}"] and
+       |elementName|["{{SanitizerElementNamespace/namespace}}"] [=string/is=]
+       |item|["{{SanitizerElementNamespace/namespace}}"].
+1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/removeAttributes}}"] [=map/with default=] &laquo; &raquo;
+    [=SanitizerConfig/contains=] |attrName|:
+    1. Return [=/blocked=].
+1. If |configuration|["{{SanitizerConfig/attributes}}"] [=map/exists=]:
+    1. Let the [=boolean=] |globallyAllowed| be whether
+        |configuration|["{{SanitizerConfig/attributes}}"]
+        [=SanitizerConfig/contains=] |attrName|.
+    1. Let the [=boolean=] |locallyAllowed| be whether
+        |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] [=map/with default=] &laquo; &raquo;
+        [=SanitizerConfig/contains=] |attrName|.
+    1. Let the [=boolean=] |isDataAttributeAllowed| be whether both,
+        "data-" is a [=code unit prefix=] of |attribute|'s
+        [=Attr/local name=] and [=Attr/namespace=] is `null`, and
+        |configuration|["{{SanitizerConfig/dataAttributes}}"] is true.
+    1. If neither |globallyAllowed| nor |locallyAllowed| nor
+        |isDataAttributeAllowed|, return [=/blocked=].
+1. Otherwise:
+    1. If |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"]
+        [=map/exists=] and |elementWithLocalAttributes|["{{SanitizerElementNamespaceWithAttributes/attributes}}"] does not [=SanitizerConfig/contain=] |attrName|:
+        1. Return [=/blocked=].
+1. Return [=/allowed=].
+
+</div>
+
 
 <div class=note>
 <span class=marker>Note:</span> Current browsers support `javascript:` URLs

--- a/index.bs
+++ b/index.bs
@@ -1032,6 +1032,13 @@ beginning with |node|. It consistes of these steps:
     1. If |child| is a [=shadow host=],
        then call [=sanitize core=] on |child|'s [=Element/shadow root=] with
        |configuration| and |handleJavascriptNavigationUrls|.
+    1. If |child|'s [=is value=] is not `null`:
+        1. Let |isAttrName| be  &laquo;[ "`name`" &rightarrow; "`is`", "`namespace`" &rightarrow; null ]&raquo;.
+        1. If [=is attribute allowed=] for |isAttrName| given |configuration|,
+           and |elementName| is [=/blocked=]:
+            1. Set |child|'s [=custom element state=] to "undefined".
+            1. Set |child|'s [=custom element definition=] to `null`.
+            1. Set |child|'s [=is value=] to `null`.
     1. [=list/iterate|For each=] |attribute| in |child|'s [=Element/attribute list=]:
       1. Let |attrName| be a {{SanitizerAttributeNamespace}} with |attribute|'s
          [=Attr/local name=] and [=Attr/namespace=].


### PR DESCRIPTION
This depends on changes in whatwg/sanitizer-api#385  that haven't happened yet.

I am not really certain if there isn't some other data structure that we need to patch for this. Presumably this would be easier to specify when we do streaming parsing.

Fixes whatwg/html#12533.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evilpie/sanitizer-api/pull/396.html" title="Last updated on May 18, 2026, 11:29 AM UTC (9d82a36)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/sanitizer-api/396/8b4bdb0...evilpie:9d82a36.html" title="Last updated on May 18, 2026, 11:29 AM UTC (9d82a36)">Diff</a>